### PR TITLE
fix the data fetching issue for theme and tags

### DIFF
--- a/src/app/services/ckan.service.ts
+++ b/src/app/services/ckan.service.ts
@@ -40,11 +40,9 @@ export class CkanService {
           modified: item.metadata_modified,
           organization: item.organization.title,
           publisher_name: item.publisher_name,
-          tags: item.tags.map((tag: { name: string }) => tag.name),
-          theme: item.theme?.[0]
-            ? JSON.parse(item.theme[0]).map((theme: string) => `"${theme}"`)
-            : null,
-          format: item.resources?.[0]?.format,
+          tags: item.tags?.map((tag: { name: string }) => tag.name),
+          theme: item.theme?.map((theme: string) => `"${theme}"`),
+          format: item.resources?.format,
         }));
 
         return {


### PR DESCRIPTION
A fix for fetching theme and tags (keywords). 

The data format from ckan-test was different from the one used locally.