### PR TITLE
Fix counter home view

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -10,7 +10,7 @@ trim_trailing_whitespace = true
 
 [*.ts]
 quote_type = single
-max_line_length = 100
+max_line_length = 130
 
 [*.md]
 max_line_length = off

--- a/src/app/components/filter/filter.component.ts
+++ b/src/app/components/filter/filter.component.ts
@@ -1,25 +1,47 @@
-import { Component, EventEmitter, Input, OnChanges, Output, SimpleChanges } from '@angular/core';
+import {
+  Component,
+  EventEmitter,
+  Input,
+  OnInit,
+  OnChanges,
+  SimpleChanges,
+  Output,
+} from '@angular/core';
 import { MatSelectChange } from '@angular/material/select';
 import { PartialDataset } from 'src/app/interfaces/dataset';
 import { Filter } from 'src/app/interfaces/filter';
+import { CkanService } from 'src/app/services/ckan.service';
 
 @Component({
   selector: 'app-filter',
   templateUrl: './filter.component.html',
   styleUrl: './filter.component.scss',
 })
-export class FilterComponent implements OnChanges {
+export class FilterComponent implements OnInit, OnChanges {
   @Input() label!: string;
-  @Input() data!: PartialDataset[];
+  @Input() ckanProp!: keyof PartialDataset;
   @Input() parentFilters!: Filter[];
-  @Input() prop!: keyof PartialDataset;
   @Output() filterEmitter: EventEmitter<Filter> = new EventEmitter<Filter>();
 
   filterValues: string[] = [];
   currentValues: string[] = [];
 
+  constructor(private ckanService: CkanService) {}
+
+  ngOnInit() {
+    const prop = this.label[0].toLowerCase() + this.label.slice(1, -1);
+    this.ckanService.getPropList(prop).subscribe((data: { count: number; values: string[] }) => {
+      this.filterValues = data.values
+        .sort(FilterComponent.sortData)
+        .map((value: string) =>
+          this.label === 'Catalogues'
+            ? value[0].toUpperCase() + value.slice(1).replaceAll('-', ' ')
+            : value
+        );
+    });
+  }
+
   ngOnChanges(changes: SimpleChanges): void {
-    this.filterValues = this.getUniqueFilterValues();
     if (changes['parentFilters'] && this.parentFilters.length === 0) {
       this.currentValues = [];
     }
@@ -37,19 +59,12 @@ export class FilterComponent implements OnChanges {
   private createFilter(): Filter {
     return {
       label: this.label,
-      values: this.currentValues,
-      ckanLabel: this.prop,
+      values:
+        this.label === 'Themes'
+          ? this.currentValues.map((value) => `"${value}"`)
+          : this.currentValues,
+      ckanProp: this.ckanProp,
     };
-  }
-
-  private getUniqueFilterValues(): string[] {
-    return [
-      ...new Set(
-        this.data
-          .filter((item: PartialDataset) => !!item[this.prop])
-          .flatMap((item: PartialDataset) => item[this.prop])
-      ),
-    ].sort(FilterComponent.sortData) as string[];
   }
 
   private static sortData(a: string | Date, b: string | Date): number {

--- a/src/app/components/footer/footer.component.ts
+++ b/src/app/components/footer/footer.component.ts
@@ -8,7 +8,7 @@ import { faExclamationCircle } from '@fortawesome/free-solid-svg-icons';
 @Component({
   selector: 'app-footer',
   templateUrl: './footer.component.html',
-  styleUrls: ['./footer.component.scss']
+  styleUrls: ['./footer.component.scss'],
 })
 export class FooterComponent {
   faLinkedin = faLinkedin;
@@ -16,11 +16,11 @@ export class FooterComponent {
   faXTwitter = faXTwitter;
   faGlobe = faGlobe;
   faExclamationCircle = faExclamationCircle;
-  
+
   constructor(private matIconRegistry: MatIconRegistry, private domSanitizer: DomSanitizer) {
     this.matIconRegistry.addSvgIcon(
       'linkedin',
       this.domSanitizer.bypassSecurityTrustResourceUrl('../../assets/linkedin.svg')
     );
-    }
+  }
 }

--- a/src/app/components/search-results/search-results.component.html
+++ b/src/app/components/search-results/search-results.component.html
@@ -20,34 +20,30 @@
 <div class="flex justify-center flex-col items-center lg:flex-row">
   <app-filter
     class="mx-3"
-    [data]="allResults"
-    [parentFilters]="currentFilters"
     label="Publishers"
-    prop="publisher_name"
+    ckanProp="publisher_name"
+    [parentFilters]="currentFilters"
     (filterEmitter)="onReceiveFilter($event)"
   ></app-filter>
   <app-filter
     class="mx-3"
-    [data]="allResults"
-    [parentFilters]="currentFilters"
     label="Catalogues"
-    prop="organization"
+    ckanProp="organization"
+    [parentFilters]="currentFilters"
     (filterEmitter)="onReceiveFilter($event)"
   ></app-filter>
   <app-filter
     class="mx-3"
-    [data]="allResults"
-    [parentFilters]="currentFilters"
     label="Themes"
-    prop="theme"
+    ckanProp="theme"
+    [parentFilters]="currentFilters"
     (filterEmitter)="onReceiveFilter($event)"
   ></app-filter>
   <app-filter
     class="mx-3"
-    [data]="allResults"
-    [parentFilters]="currentFilters"
     label="Keywords"
-    prop="tags"
+    ckanProp="tags"
+    [parentFilters]="currentFilters"
     (filterEmitter)="onReceiveFilter($event)"
   ></app-filter>
   <button

--- a/src/app/components/search-results/search-results.component.ts
+++ b/src/app/components/search-results/search-results.component.ts
@@ -1,9 +1,9 @@
 import { Component, OnInit } from '@angular/core';
-import { ActivatedRoute, Router } from '@angular/router';
 import { PageEvent } from '@angular/material/paginator';
-import { CkanService } from '../../services/ckan.service';
-import { Filter } from 'src/app/interfaces/filter';
+import { ActivatedRoute, Router } from '@angular/router';
 import { PartialDataset } from 'src/app/interfaces/dataset';
+import { Filter } from 'src/app/interfaces/filter';
+import { CkanService } from '../../services/ckan.service';
 
 @Component({
   selector: 'app-search-results',

--- a/src/app/components/search-results/search-results.component.ts
+++ b/src/app/components/search-results/search-results.component.ts
@@ -11,7 +11,6 @@ import { PartialDataset } from 'src/app/interfaces/dataset';
   styleUrls: ['./search-results.component.scss'],
 })
 export class SearchResultsComponent implements OnInit {
-  allResults: PartialDataset[] = [];
   results: PartialDataset[] = [];
   totalResults: number = 0;
 
@@ -31,19 +30,6 @@ export class SearchResultsComponent implements OnInit {
   ) {}
 
   ngOnInit(): void {
-    // Retrieve all values for filters (must go through all the pages)
-    this.ckanService
-      .searchDatasets(
-        this.currentSearchQuery,
-        this.currentFilterQuery,
-        this.currentSortingField,
-        0,
-        CkanService.MAX_RESULT_PAGES
-      )
-      .subscribe((data) => {
-        this.allResults = data.results;
-      });
-
     this.route.queryParams.subscribe((_) => {
       this.loadSearchResults(
         this.currentSearchQuery,
@@ -139,14 +125,14 @@ export class SearchResultsComponent implements OnInit {
   }
 
   private createQueryFromFilter(filter: Filter): string {
-    const { ckanLabel: label, values } = filter;
-    const separator = label === 'theme' || label === 'format' ? '' : ':';
+    const { ckanProp, values } = filter;
+    const separator = ckanProp === 'theme' || ckanProp === 'format' ? '' : ':';
     const correctedValues =
-      label === 'organization'
+      ckanProp === 'organization'
         ? values.map((value: string) => value.toLowerCase().replaceAll(' ', '-'))
         : values;
     return correctedValues.length === 0
       ? ''
-      : `${label}${separator}(${correctedValues.join(' OR ')})+`;
+      : `${ckanProp}${separator}(${correctedValues.join(' OR ')})+`;
   }
 }

--- a/src/app/interfaces/dataset-details.ts
+++ b/src/app/interfaces/dataset-details.ts
@@ -14,5 +14,12 @@ export interface DatasetDetails {
 }
 
 export interface Dataset {
-  result: DatasetDetails
+  result: DatasetDetails;
+}
+
+export interface Response {
+  result: {
+    count: number;
+    results: string[];
+  };
 }

--- a/src/app/interfaces/filter.ts
+++ b/src/app/interfaces/filter.ts
@@ -1,5 +1,5 @@
 export interface Filter {
-    label: string;
-    values: string[];
-    ckanLabel: string;
+  label: string;
+  values: string[];
+  ckanProp: string;
 }

--- a/src/app/services/ckan.service.ts
+++ b/src/app/services/ckan.service.ts
@@ -40,11 +40,9 @@ export class CkanService {
           modified: item.metadata_modified,
           organization: item.organization.title,
           publisher_name: item.publisher_name,
-          tags: item.tags.map((tag: { name: string }) => tag.name),
-          theme: item.theme?.[0]
-            ? JSON.parse(item.theme[0]).map((theme: string) => `"${theme}"`)
-            : null,
-          format: item.resources?.[0]?.format,
+          tags: item.tags?.map((tag: { name: string }) => tag.name),
+          theme: item.theme?.map((theme: string) => `"${theme}"`),
+          format: item.resources?.format,
         }));
 
         return {

--- a/src/main.ts
+++ b/src/main.ts
@@ -1,5 +1,5 @@
-import { platformBrowserDynamic } from '@angular/platform-browser-dynamic';
 import { enableProdMode } from '@angular/core';
+import { platformBrowserDynamic } from '@angular/platform-browser-dynamic';
 import { AppModule } from './app/app.module';
 import { environment } from './environment/environment';
 
@@ -7,5 +7,6 @@ if (environment.production) {
   enableProdMode();
 }
 
-platformBrowserDynamic().bootstrapModule(AppModule)
-  .catch(err => console.error(err));
+platformBrowserDynamic()
+  .bootstrapModule(AppModule)
+  .catch((err) => console.error(err));


### PR DESCRIPTION
Fix the home counters by querying new endpoints to fetch count and unique values of a dcat property.

Also retrieve filter values with these new endpoints to avoid getting values by requesting all the data at once (that will not scale). 