### PR TITLE
feat: Handling Errors

### DIFF
--- a/src/app/error.tsx
+++ b/src/app/error.tsx
@@ -1,0 +1,47 @@
+// SPDX-FileCopyrightText: 2024 PNED G.I.E.
+//
+// SPDX-License-Identifier: Apache-2.0
+"use client";
+
+import { useEffect } from "react";
+import Button from "@/components/Button";
+import { faHouse } from "@fortawesome/free-solid-svg-icons";
+
+export default function Error({
+  error,
+}: {
+  error: Error & { digest?: string };
+}) {
+  useEffect(() => {
+    console.error(error);
+  }, [error]);
+
+  return (
+    <section>
+      <div className="container mx-auto w-full max-w-3xl p-4 md:p-8">
+        <div>
+          {process.env.NODE_ENV !== "development" && (
+            <div className="bg-primary p-4 text-warning">
+              <p className="font-medium">{error.message}</p>
+              {error.stack && (
+                <pre className="mt-4 overflow-x-auto">{error.stack}</pre>
+              )}
+            </div>
+          )}
+          <h1 className="mt-3 text-2xl font-semibold text-primary md:text-3xl">
+            Internal Server Error
+          </h1>
+          <p className="mt-4 text-secondary">
+            Our apologies, but our server has encountered an internal error that
+            prevents it from fulfilling your request. This is a temporary issue,
+            and we&apos;re on the case to get it fixed. Please try again in a
+            little while
+          </p>
+          <div className="mt-6">
+            <Button href="/" text="Take me home" icon={faHouse} />
+          </div>
+        </div>
+      </div>
+    </section>
+  );
+}

--- a/src/app/error.tsx
+++ b/src/app/error.tsx
@@ -7,20 +7,33 @@ import { useEffect } from "react";
 import Button from "@/components/Button";
 import { faHouse } from "@fortawesome/free-solid-svg-icons";
 
-export default function Error({
-  error,
-}: {
+interface ErrorProps {
   error: Error & { digest?: string };
-}) {
+  statusCode?: number;
+}
+
+export default function Error({ error, statusCode }: ErrorProps) {
   useEffect(() => {
     console.error(error);
   }, [error]);
+
+  let heading = "Something Went Wrong";
+  let message =
+    "Our apologies, but our server has encountered an internal error that prevents it from fulfilling your request. This is a temporary issue, and we're on the case to get it fixed. Please try again in a little while.";
+
+  switch (statusCode) {
+    case 404:
+      heading = "Page Not Found";
+      message =
+        "The page you're looking for doesn't seem to exist. It might have been moved or deleted.";
+      break;
+  }
 
   return (
     <section>
       <div className="container mx-auto w-full max-w-3xl p-4 md:p-8">
         <div>
-          {process.env.NODE_ENV !== "development" && (
+          {process.env.NODE_ENV !== "development" && error && (
             <div className="bg-primary p-4 text-warning">
               <p className="font-medium">{error.message}</p>
               {error.stack && (
@@ -29,14 +42,9 @@ export default function Error({
             </div>
           )}
           <h1 className="mt-3 text-2xl font-semibold text-primary md:text-3xl">
-            Internal Server Error
+            {heading}
           </h1>
-          <p className="mt-4 text-secondary">
-            Our apologies, but our server has encountered an internal error that
-            prevents it from fulfilling your request. This is a temporary issue,
-            and we&apos;re on the case to get it fixed. Please try again in a
-            little while
-          </p>
+          <p className="mt-4 text-secondary">{message}</p>
           <div className="mt-6">
             <Button href="/" text="Take me home" icon={faHouse} />
           </div>

--- a/src/app/error.tsx
+++ b/src/app/error.tsx
@@ -7,12 +7,15 @@ import { useEffect } from "react";
 import Button from "@/components/Button";
 import { faHouse } from "@fortawesome/free-solid-svg-icons";
 
-interface ErrorProps {
+interface ErrorBoundaryProps {
   error: Error & { digest?: string };
   statusCode?: number;
 }
 
-export default function Error({ error, statusCode }: ErrorProps) {
+export default function ErrorBoundary({
+  error,
+  statusCode,
+}: ErrorBoundaryProps) {
   useEffect(() => {
     console.error(error);
   }, [error]);

--- a/src/app/error.tsx
+++ b/src/app/error.tsx
@@ -27,6 +27,11 @@ export default function Error({ error, statusCode }: ErrorProps) {
       message =
         "The page you're looking for doesn't seem to exist. It might have been moved or deleted.";
       break;
+    case 401:
+      heading = "Unauthorized";
+      message =
+        "You're not authorized to access this page. Please log in and try again.";
+      break;
   }
 
   return (

--- a/src/app/not-found.tsx
+++ b/src/app/not-found.tsx
@@ -1,3 +1,6 @@
+// SPDX-FileCopyrightText: 2024 PNED G.I.E.
+//
+// SPDX-License-Identifier: Apache-2.0
 import Error from "./error";
 
 export default function NotFound() {

--- a/src/app/not-found.tsx
+++ b/src/app/not-found.tsx
@@ -1,0 +1,5 @@
+import Error from "./error";
+
+export default function NotFound() {
+  return <Error statusCode={404} />;
+}

--- a/src/components/Button.tsx
+++ b/src/components/Button.tsx
@@ -1,0 +1,45 @@
+// SPDX-FileCopyrightText: 2024 PNED G.I.E.
+//
+// SPDX-License-Identifier: Apache-2.0
+"use client";
+import React from "react";
+import { FontAwesomeIcon } from "@fortawesome/react-fontawesome";
+import { IconDefinition } from "@fortawesome/fontawesome-svg-core";
+
+interface ButtonProps {
+  icon: IconDefinition;
+  text: string;
+  onClick?: () => void;
+  href?: string;
+  className?: string;
+}
+
+const Button: React.FC<ButtonProps> = ({
+  icon,
+  text,
+  onClick,
+  href,
+  className,
+}) => {
+  const classes = `rounded-lg px-4 py-2 text-sm font-bold w-1/2 bg-primary text-white hover:bg-secondary transition-colors duration-200 tracking-wide sm:w-auto ${className}`;
+
+  if (href) {
+    return (
+      <a
+        href={href}
+        className={classes}
+        onClick={onClick} // Optionally include onClick for <a>
+      >
+        <FontAwesomeIcon icon={icon} /> {text}
+      </a>
+    );
+  } else {
+    return (
+      <button className={classes} onClick={onClick}>
+        <FontAwesomeIcon icon={icon} /> {text}
+      </button>
+    );
+  }
+};
+
+export default Button;

--- a/src/components/header.tsx
+++ b/src/components/header.tsx
@@ -14,6 +14,7 @@ import Link from "next/link";
 import { usePathname } from "next/navigation";
 import { useState } from "react";
 import logo from "../public/egdi-logo-horizontal-full-color-rgb.svg";
+import Button from "@/components/Button";
 
 function Header() {
   const [isMenuOpen, setIsMenuOpen] = useState(false);
@@ -58,12 +59,7 @@ function Header() {
         {isAuthenticated && <FontAwesomeIcon icon={faUser} />}
         {isAuthenticated && <span>{username()}</span>}
         {!isAuthenticated && (
-          <button
-            className="rounded border-2 bg-secondary px-4 py-2 text-sm font-bold text-white hover:border-2 hover:border-secondary hover:bg-transparent hover:text-secondary"
-            onClick={login}
-          >
-            <FontAwesomeIcon icon={faRightToBracket} /> Sign In
-          </button>
+          <Button icon={faRightToBracket} onClick={login} text="Sign In" />
         )}
         {isAuthenticated && (
           <button onClick={logout}>

--- a/src/components/header.tsx
+++ b/src/components/header.tsx
@@ -37,7 +37,7 @@ function Header() {
           height="69"
         />
       </Link>
-      <div className="items-center text-lg text-primary sm:flex">
+      <div className="items-center text-lg text-primary hidden md:flex">
         <Link
           href="/"
           className={`mr-10 hover:text-info ${activeTab === "/" ? "text-secondary" : ""}`}

--- a/src/components/header.tsx
+++ b/src/components/header.tsx
@@ -37,7 +37,7 @@ function Header() {
           height="69"
         />
       </Link>
-      <div className="items-center text-lg text-primary hidden md:flex">
+      <div className="hidden items-center text-lg text-primary md:flex">
         <Link
           href="/"
           className={`mr-10 hover:text-info ${activeTab === "/" ? "text-secondary" : ""}`}


### PR DESCRIPTION
With this change:

On local env, If application crashes, it shows following page (with stacktrace)

<img width="956" alt="Screenshot 2024-02-13 at 14 57 42" src="https://github.com/GenomicDataInfrastructure/gdi-userportal-frontend/assets/1210046/c7961ff6-e7a6-4a81-b478-613fde9d96d8">




On prod, if application. crashes, it shows following page
<img width="1912" alt="Screenshot 2024-02-13 at 14 57 54" src="https://github.com/GenomicDataInfrastructure/gdi-userportal-frontend/assets/1210046/de722560-e342-4178-afe2-3230556617a2">



For 404 page
<img width="950" alt="Screenshot 2024-02-13 at 14 57 36" src="https://github.com/GenomicDataInfrastructure/gdi-userportal-frontend/assets/1210046/503e5d97-873c-4dc2-b66e-89ea36ee6ee3">
