### PR TITLE
feat: Make DatasetCounter and PortalStatistics components as client component to improve performance

### DIFF
--- a/src/components/DatasetCounter.tsx
+++ b/src/components/DatasetCounter.tsx
@@ -1,12 +1,26 @@
 // SPDX-FileCopyrightText: 2024 PNED G.I.E.
 //
 // SPDX-License-Identifier: Apache-2.0
-
-import React from "react";
+"use client";
+import React, { useEffect, useState } from "react";
 import { datasetCount } from "@/services/ckan/index.server";
 
-export async function DatasetCounter() {
-  const count = await datasetCount();
+export function DatasetCounter() {
+  const [count, setCount] = useState<number | null>(null);
+
+  useEffect(() => {
+    const fetchData = async () => {
+      const count = await datasetCount();
+      setCount(count);
+    };
+
+    fetchData();
+  }, []);
+
+  if (count === null) {
+    return <div className="text-xl font-bold text-primary">Loading...</div>;
+  }
+
   return (
     <div className="mb-4 mt-10 flex items-baseline text-primary">
       <p className="mr-3 text-4xl font-bold">{count.toLocaleString("en-GB")}</p>

--- a/src/components/PortalStatistics.tsx
+++ b/src/components/PortalStatistics.tsx
@@ -1,11 +1,28 @@
 // SPDX-FileCopyrightText: 2024 PNED G.I.E.
 //
 // SPDX-License-Identifier: Apache-2.0
-
+"use client";
+import React, { useEffect, useState } from "react";
 import { portalStatistics } from "@/services/ckan/index.server";
+import { PortalStatistics as IPortalStatistics } from "@/services/ckan/types/portalStatistics.types";
 
-export async function PortalStatistics() {
-  const propCounters = await portalStatistics();
+export function PortalStatistics() {
+  const [propCounters, setPropCounters] = useState<IPortalStatistics | null>(
+    null,
+  );
+
+  useEffect(() => {
+    const fetchData = async () => {
+      const data = await portalStatistics();
+      setPropCounters(data);
+    };
+
+    fetchData();
+  }, []);
+
+  if (propCounters === null) {
+    return <div>Loading...</div>;
+  }
 
   return (
     <div className="mt-4 px-4">

--- a/src/services/ckan/__tests__/portalStatistics.test.ts
+++ b/src/services/ckan/__tests__/portalStatistics.test.ts
@@ -32,9 +32,9 @@ describe('makePortalStatistics', () => {
     const portalStatistics = await getPortalStatistics();
 
     expect(portalStatistics).toEqual({
-      Themes: 379,
-      Catalogues: 5,
-      Keywords: 490,
+      themes: 379,
+      catalogues: 5,
+      keywords: 490,
     });
 
     expect(mockedAxios.get).toHaveBeenNthCalledWith(1, `${DMS_URL}/api/3/action/theme_list?`);

--- a/src/services/ckan/portalStatistics.ts
+++ b/src/services/ckan/portalStatistics.ts
@@ -4,10 +4,11 @@
 
 import axios from 'axios';
 import { constructCkanActionUrl } from './utils';
+import { PortalStatistics } from './types/portalStatistics.types';
 
 export const makePortalStatistics = (DMS: string) => {
-  return async (): Promise<{ [key: string]: number }> => {
-    const props = ['theme', 'catalogue', 'keyword'];
+  return async (): Promise<PortalStatistics> => {
+    const props: Array<'theme' | 'catalogue' | 'keyword'> = ['theme', 'catalogue', 'keyword'];
     const counts = await Promise.all(
       props.map(async (prop) => {
         const url = constructCkanActionUrl(DMS, `${prop}_list`);
@@ -16,11 +17,19 @@ export const makePortalStatistics = (DMS: string) => {
       }),
     );
 
-    const countsObject = props.reduce<{ [key: string]: number }>((acc, prop, index) => {
-      const propKey = `${prop.charAt(0).toUpperCase()}${prop.slice(1)}s`;
-      acc[propKey] = counts[index];
-      return acc;
-    }, {});
+    const countsObject = props.reduce<PortalStatistics>(
+      (acc, prop, index) => {
+        const propKey = (prop + 's') as keyof PortalStatistics;
+        acc[propKey] = counts[index];
+        return acc;
+      },
+      {
+        catalogues: 0,
+        keywords: 0,
+        themes: 0,
+      },
+    );
+
     return countsObject;
   };
 };

--- a/src/services/ckan/types/portalStatistics.types.ts
+++ b/src/services/ckan/types/portalStatistics.types.ts
@@ -1,3 +1,7 @@
+// SPDX-FileCopyrightText: 2024 PNED G.I.E.
+//
+// SPDX-License-Identifier: Apache-2.0
+
 export interface PortalStatistics {
   catalogues: number;
   keywords: number;

--- a/src/services/ckan/types/portalStatistics.types.ts
+++ b/src/services/ckan/types/portalStatistics.types.ts
@@ -1,0 +1,5 @@
+export interface PortalStatistics {
+  catalogues: number;
+  keywords: number;
+  themes: number;
+}


### PR DESCRIPTION
Before
<img width="373" alt="Screenshot 2024-03-06 at 12 46 55" src="https://github.com/GenomicDataInfrastructure/gdi-userportal-frontend/assets/1210046/3e1bc821-1a71-4af1-828c-9077791dd1f2">

After
<img width="344" alt="Screenshot 2024-03-06 at 12 14 00" src="https://github.com/GenomicDataInfrastructure/gdi-userportal-frontend/assets/1210046/014a932d-8bd7-44b5-96f1-cd2fec7d453f">
