### PR TITLE
fix: loading btn turning into logged in user on page reload

### DIFF
--- a/src/components/header.tsx
+++ b/src/components/header.tsx
@@ -29,7 +29,7 @@ import Button from "./button";
 import Notification from "./notification";
 
 function Header() {
-  const { data: session } = useSession();
+  const { data: session, status } = useSession();
   const [isMenuOpen, setIsMenuOpen] = useState<boolean>(false);
   const activeTab = usePathname();
   const { basket, isLoading } = useDatasetBasket();
@@ -56,6 +56,24 @@ function Header() {
       window.removeEventListener("click", handleOutsideClick);
     };
   }, [isMenuOpen]);
+
+  let loginBtn;
+
+  if (status !== "loading") {
+    loginBtn = session ? (
+      <>
+        <Notification />
+        <Avatar user={session.user as User} />
+      </>
+    ) : (
+      <Button
+        icon={faUser}
+        text="Login"
+        type="primary"
+        onClick={() => signIn("keycloak")}
+      />
+    );
+  }
 
   return (
     <div className="flex w-full items-center justify-between bg-white-smoke px-4">
@@ -102,19 +120,7 @@ function Header() {
             </span>
           )}
         </Link>
-        {session ? (
-          <>
-            <Notification />
-            <Avatar user={session.user as User} />
-          </>
-        ) : (
-          <Button
-            icon={faUser}
-            text="Login"
-            type="primary"
-            onClick={() => signIn("keycloak")}
-          />
-        )}
+        {loginBtn}
       </div>
 
       <div className="menu-container relative sm:hidden">


### PR DESCRIPTION
I noticed that when you the app, you will see a login btn for a sec before it disappears and a logged in user initials appear. 

This happened because nextjs is still fetching the auth details on page load. I fixed it by using `status` variable