### PR TITLE
Fix: Prepend NEXT_PUBLIC_ before env variables to make it available in both client and backend

### DIFF
--- a/.env.local.example
+++ b/.env.local.example
@@ -1,7 +1,7 @@
 # SPDX-FileCopyrightText: 2024 PNED G.I.E.
 #
 # SPDX-License-Identifier: Apache-2.0
-CKAN_URL=https://ckan-test.healthdata.nl
+NEXT_PUBLIC_CKAN_URL=https://ckan-test.healthdata.nl
 NEXTAUTH_URL=http://localhost:3000
 NEXTAUTH_SECRET=your-secret
 KEYCLOAK_CLIENT_ID=ckan

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -9,7 +9,7 @@ services:
       context: .
     restart: unless-stopped
     environment:
-      - CKAN_URL=https://ckan-test.healthdata.nl
+      - NEXT_PUBLIC_CKAN_URL=https://ckan-test.healthdata.nl
       - NEXTAUTH_URL=http://localhost:3000
       - NEXTAUTH_SECRET=your-secret
       - KEYCLOAK_CLIENT_ID=ckan

--- a/src/app/datasets/[id]/page.tsx
+++ b/src/app/datasets/[id]/page.tsx
@@ -6,7 +6,7 @@ import Error from "@/app/error";
 import Chips from "@/components/Chips";
 import PageHeading from "@/components/PageHeading";
 import PageSubHeading from "@/components/PageSubHeading";
-import { datasetGet } from "@/services/ckan/index.server";
+import { datasetGet } from "@/services/ckan";
 import DistributionAccordion from "./DistributionAccordion";
 import Sidebar from "./Sidebar";
 import AddToBasketBtn from "./AddToBasketBtn";

--- a/src/app/datasets/page.tsx
+++ b/src/app/datasets/page.tsx
@@ -3,7 +3,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 import ClientWrapper from "@/app/datasets/clientWrapper";
-import { datasetList, fieldDetailsGet } from "@/services/ckan/index.server";
+import { datasetList, fieldDetailsGet } from "@/services/ckan";
 import { Field } from "@/services/ckan/types/fieldDetails.types";
 import { PackageSearchOptions } from "@/services/ckan/types/packageSearch.types";
 import { parseFilterValuesSingleQueryString } from "@/utils/textProcessing";

--- a/src/components/DatasetCounter.tsx
+++ b/src/components/DatasetCounter.tsx
@@ -3,7 +3,7 @@
 // SPDX-License-Identifier: Apache-2.0
 "use client";
 import React, { useEffect, useState } from "react";
-import { datasetCount } from "@/services/ckan/index.server";
+import { datasetCount } from "@/services/ckan";
 
 export function DatasetCounter() {
   const [count, setCount] = useState<number | null>(null);

--- a/src/components/PortalStatistics.tsx
+++ b/src/components/PortalStatistics.tsx
@@ -3,7 +3,7 @@
 // SPDX-License-Identifier: Apache-2.0
 "use client";
 import React, { useEffect, useState } from "react";
-import { portalStatistics } from "@/services/ckan/index.server";
+import { portalStatistics } from "@/services/ckan";
 import { PortalStatistics as IPortalStatistics } from "@/services/ckan/types/portalStatistics.types";
 
 export function PortalStatistics() {

--- a/src/config/serverConfig.ts
+++ b/src/config/serverConfig.ts
@@ -12,7 +12,7 @@ function getEnvVariable(key: string, defaultValue: string): string {
 }
 
 const serverConfig: ServerConfig = {
-  ckanUrl: getEnvVariable('CKAN_URL', 'https://ckan-test.healthdata.nl'),
+  ckanUrl: getEnvVariable('NEXT_PUBLIC_CKAN_URL', 'https://ckan-test.healthdata.nl'),
   daamUrl: getEnvVariable('DAAM_URL', 'http://localhost:8080'),
 };
 

--- a/src/services/ckan/index.ts
+++ b/src/services/ckan/index.ts
@@ -11,6 +11,7 @@ import { makeDatasetList } from './datasetList';
 import { makeFieldDetailsGet } from './fieldDetailsGet';
 
 const DMS_URL = serverConfig.ckanUrl;
+
 const datasetList = makeDatasetList(DMS_URL);
 const datasetGet = makeDatasetGet(DMS_URL);
 const datasetCount = makeDatasetCount(DMS_URL);

--- a/src/services/daam/index.server.ts
+++ b/src/services/daam/index.server.ts
@@ -1,6 +1,11 @@
 // SPDX-FileCopyrightText: 2024 PNED G.I.E.
 //
 // SPDX-License-Identifier: Apache-2.0
+
+if (typeof window !== 'undefined') {
+  throw new Error('This module is intended for server-side use only and should not be included in client-side components.');
+}
+
 import { makeCreateApplication } from './backend/createApplication';
 import serverConfig from '../../config/serverConfig';
 


### PR DESCRIPTION
[bundling-environment-variables-for-the-browser](https://nextjs.org/docs/pages/building-your-application/configuring/environment-variables#bundling-environment-variables-for-the-browser)

I made the index file generic for ckan to keep it simple because it is used in both client as well as server components