### PR TITLE
NextJS expects env variables to be fetched statically

### DIFF
--- a/src/config/serverConfig.ts
+++ b/src/config/serverConfig.ts
@@ -7,13 +7,9 @@ interface ServerConfig {
   daamUrl: string;
 }
 
-function getEnvVariable(key: string, defaultValue: string): string {
-  return process.env[key] || defaultValue;
-}
-
 const serverConfig: ServerConfig = {
-  ckanUrl: getEnvVariable('NEXT_PUBLIC_CKAN_URL', 'https://ckan-test.healthdata.nl'),
-  daamUrl: getEnvVariable('DAAM_URL', 'http://localhost:8080'),
+  ckanUrl: process.env.NEXT_PUBLIC_CKAN_URL || 'https://ckan-test.healthdata.nl',
+  daamUrl: process.env.DAAM_URL || 'http://localhost:8080',
 };
 
 export default serverConfig;


### PR DESCRIPTION
NextJS was not able to replace NEXT_PUBLIC_CKAN_URL into actual value specified in .env.local because during build process it looks for exact string `process.env.NEXT_PUBLIC_CKAN_URL` whereas we were dynamically generating it