### PR TITLE
fix: #125 Fix Lucene query

### DIFF
--- a/_http/catalogue.http
+++ b/_http/catalogue.http
@@ -2,4 +2,10 @@
 #
 # SPDX-License-Identifier: Apache-2.0
 
-GET http://localhost:4200/api/3/action/package_search?start=0&rows=5
+GET https://ckan-test.healthdata.nl/api/3/action/package_search?start=0&rows=12&fq=tags%3ACancer+registry
+
+###
+GET https://ckan-test.healthdata.nl/api/3/action/package_search?start=0&rows=12&fq=extras_theme%3A(%22http%3A%2F%2Fpurl.obolibrary.org%2Fobo%2Fomit_0010062%22)%20AND%20extras_publisher_name%3A(%22afdeling%20nkr-analyse%22)%20AND%20tags%3A(%22Cancer%20registry%22)
+
+###
+GET https://ckan-test.healthdata.nl/api/3/action/tag_list

--- a/src/app/datasets/page.tsx
+++ b/src/app/datasets/page.tsx
@@ -20,19 +20,18 @@ async function DatasetPage({ searchParams }: DatasetPageProps) {
   const DATASET_PER_PAGE = 12;
 
   const options: PackageSearchOptions = {
-    tags: searchParams.keywords
+    keywords: searchParams.keywords
       ? parseFilterValuesSingleQueryString(searchParams.keywords as string)
       : undefined,
-    orgs: searchParams.catalogues
+    catalogues: searchParams.catalogues
       ? parseFilterValuesSingleQueryString(searchParams.catalogues as string)
       : undefined,
-    groups: searchParams.themes
+    themes: searchParams.themes
       ? parseFilterValuesSingleQueryString(searchParams.themes as string)
       : undefined,
     publishers: searchParams.publishers
       ? parseFilterValuesSingleQueryString(searchParams.publishers as string)
       : undefined,
-    resFormat: [],
     offset: searchParams.page ? Number(searchParams.page) - 1 : 0,
     limit: DATASET_PER_PAGE,
     query: searchParams?.q as string | undefined,

--- a/src/components/filterItem.tsx
+++ b/src/components/filterItem.tsx
@@ -12,6 +12,10 @@ export type FilterItemProps = {
   icon: IconDefinition;
 };
 
+function capitalizeFirstLetter(text: string) {
+  return text.charAt(0).toUpperCase() + text.slice(1);
+}
+
 function FilterItem({ label, data, icon }: FilterItemProps) {
   return (
     <div>
@@ -20,7 +24,7 @@ function FilterItem({ label, data, icon }: FilterItemProps) {
           icon={icon}
           className="text-xs font-extrabold text-info"
         />
-        <p className="text-bold text-info">{label}</p>
+        <p className="text-bold text-info">{capitalizeFirstLetter(label)}</p>
       </div>
       <MultipleSelector
         label={label}

--- a/src/components/ui/multipleSelector.tsx
+++ b/src/components/ui/multipleSelector.tsx
@@ -223,16 +223,13 @@ const MultipleSelector = React.forwardRef<
     const handleUnselect = React.useCallback(
       (option: Option) => {
         const newOptions = convertQueryStringToOptions(
-          params.get(label.toLowerCase()) as string,
+          params.get(label) as string,
         ).filter((o) => o.value !== option.value);
 
         if (newOptions.length === 0) {
-          params.delete(label.toLowerCase());
+          params.delete(label);
         } else {
-          params.set(
-            label.toLowerCase(),
-            convertOptionsToQueryString(newOptions),
-          );
+          params.set(label, convertOptionsToQueryString(newOptions));
         }
         router.push(`${pathname}?${params}`);
 
@@ -261,20 +258,18 @@ const MultipleSelector = React.forwardRef<
 
     useEffect(() => {
       if (value) {
-        params.set(label.toLowerCase(), convertOptionsToQueryString(value));
+        params.set(label, convertOptionsToQueryString(value));
         router.push(`${pathname}?${params}`);
       }
     }, [value, label, params, router, pathname]);
 
     useEffect(() => {
-      if (!params.has(label.toLowerCase())) {
+      if (!params.has(label)) {
         setSelected([]);
         return;
       }
 
-      const values = convertQueryStringToOptions(
-        params.get(label.toLowerCase()) as string,
-      );
+      const values = convertQueryStringToOptions(params.get(label) as string);
 
       const existingValues = values.filter((v: Option) =>
         arrayDefaultOptions.find((option: Option) => option.value === v.value),
@@ -323,7 +318,7 @@ const MultipleSelector = React.forwardRef<
         .split(",")
         .map((v: string) => ({
           value: v,
-          label: v.charAt(0).toUpperCase() + v.slice(1),
+          label: v,
         }));
     };
 
@@ -348,10 +343,7 @@ const MultipleSelector = React.forwardRef<
               return;
             }
             setInputValue("");
-            const newOptions = [
-              ...selected,
-              { value, label: value.charAt(0).toUpperCase() + value.slice(1) },
-            ];
+            const newOptions = [...selected, { value, label: value }];
             setSelected(newOptions);
             onChange?.(newOptions);
           }}
@@ -399,7 +391,7 @@ const MultipleSelector = React.forwardRef<
 
       if (creatable) {
         return (value: string, search: string) => {
-          return value.toLowerCase().includes(search.toLowerCase()) ? 1 : -1;
+          return value.includes(search) ? 1 : -1;
         };
       }
       // Using default filter in `cmdk`. We don't have to provide it.
@@ -546,7 +538,7 @@ const MultipleSelector = React.forwardRef<
                                 setInputValue("");
                                 const newOptions = [...selected, option];
                                 params.set(
-                                  label.toLowerCase(),
+                                  label,
                                   convertOptionsToQueryString(newOptions),
                                 );
                                 router.push(`${pathname}?${params}`);

--- a/src/services/ckan/__tests__/datasetList.test.ts
+++ b/src/services/ckan/__tests__/datasetList.test.ts
@@ -99,44 +99,46 @@ describe('datasetList', () => {
   test('applies tag filters correctly', async () => {
     const datasetList = makeDatasetList('https://mock-ckan-instance.com');
     const searchOptions = {
-      tags: ['education', 'science'],
+      keywords: ['education', 'science'],
       limit: 1,
     };
 
     await datasetList(searchOptions);
 
-    expect(mockedAxios.get).toHaveBeenCalledWith(expect.stringContaining('tags:(education OR science)'));
+    expect(mockedAxios.get).toHaveBeenCalledWith(expect.stringContaining('tags%3A(%22education%22%20AND%20%22science%22)'));
   });
 
   test('applies organization filters correctly', async () => {
     const datasetList = makeDatasetList('https://mock-ckan-instance.com');
     const searchOptions = {
-      orgs: ['org1', 'org2'],
+      catalogues: ['org1', 'org2'],
       limit: 1,
     };
 
     await datasetList(searchOptions);
 
-    expect(mockedAxios.get).toHaveBeenCalledWith(expect.stringContaining('organization:(org1 OR org2)'));
+    expect(mockedAxios.get).toHaveBeenCalledWith(expect.stringContaining('organization%3A(%22org1%22%20AND%20%22org2%22)'));
   });
 
   test('combines multiple filters correctly', async () => {
     const datasetList = makeDatasetList('https://mock-ckan-instance.com');
     const searchOptions = {
-      tags: ['technology', 'http://example.com/other-tag'],
+      keywords: ['technology', 'http://example.com/other-tag'],
       publishers: ['A random publisher'],
-      orgs: ['org1'],
-      groups: ['group1'],
-      resFormat: ['PDF', 'CSV'],
+      catalogues: ['org1'],
+      themes: ['group1'],
       limit: 1,
     };
 
     await datasetList(searchOptions);
 
-    expect(mockedAxios.get).toHaveBeenCalledWith(expect.stringContaining('tags:(technology OR "http://example.com/other-tag")'));
-    expect(mockedAxios.get).toHaveBeenCalledWith(expect.stringContaining('publisher:("A random publisher")'));
-    expect(mockedAxios.get).toHaveBeenCalledWith(expect.stringContaining('organization:(org1)'));
-    expect(mockedAxios.get).toHaveBeenCalledWith(expect.stringContaining('groups:(group1)'));
-    expect(mockedAxios.get).toHaveBeenCalledWith(expect.stringContaining('res_format:(PDF OR CSV)'));
+    expect(mockedAxios.get).toHaveBeenCalledWith(
+      expect.stringContaining('tags%3A(%22technology%22%20AND%20%22http%3A%2F%2Fexample.com%2Fother-tag%22)'),
+    );
+    expect(mockedAxios.get).toHaveBeenCalledWith(
+      expect.stringContaining('extras_publisher_name%3A(%22A%20random%20publisher%22)'),
+    );
+    expect(mockedAxios.get).toHaveBeenCalledWith(expect.stringContaining('organization%3A(%22org1%22)'));
+    expect(mockedAxios.get).toHaveBeenCalledWith(expect.stringContaining('extras_theme%3A(%22group1%22)'));
   });
 });

--- a/src/services/ckan/datasetList.ts
+++ b/src/services/ckan/datasetList.ts
@@ -24,33 +24,26 @@ export const makeDatasetList = (DMS: string) => {
 };
 
 const buildFilterQueryPart = (filters: string[]): string => {
-  return filters.length > 0
-    ? `(${filters
-        .map((filter: string) => (filter.startsWith('http') ? `"${filter}"` : filter))
-        .map((value: string) => (value.includes(' ') ? `"${value}"` : value))
-        .join(' OR ')})`
-    : '';
+  return filters.map((filter: string) => `"${filter}"`).join(' AND ');
 };
 
 const constructQueryParams = (options: PackageSearchOptions): string => {
-  const groupFilter = buildFilterQueryPart(options.groups || []);
-  const orgFilter = buildFilterQueryPart(options.orgs || []);
-  const tagFilter = buildFilterQueryPart(options.tags || []);
+  const catalogueFilter = buildFilterQueryPart(options.catalogues || []);
+  const themeFilter = buildFilterQueryPart(options.themes || []);
   const publisherFilter = buildFilterQueryPart(options.publishers || []);
-  const resFormatFilter = buildFilterQueryPart(options.resFormat || []);
+  const keywordFilter = buildFilterQueryPart(options.keywords || []);
 
   const filters = [
-    groupFilter && `groups:${groupFilter}`,
-    orgFilter && `organization:${orgFilter}`,
-    tagFilter && `tags:${tagFilter}`,
-    publisherFilter && `publisher:${publisherFilter}`,
-    resFormatFilter && `res_format:${resFormatFilter}`,
+    catalogueFilter && `organization:(${catalogueFilter})`,
+    themeFilter && `extras_theme:(${themeFilter})`,
+    publisherFilter && `extras_publisher_name:(${publisherFilter})`,
+    keywordFilter && `tags:(${keywordFilter})`,
   ]
     .filter(Boolean)
-    .join('+');
+    .join(' AND ');
 
   let queryParams = `start=${options.offset || 0}&rows=${options.limit || 10}`;
-  queryParams += filters ? `&fq=${filters}` : '';
+  queryParams += filters ? `&fq=${encodeURIComponent(filters)}` : '';
   queryParams += options.query ? `&q=${options.query}` : '';
   queryParams += options.sort ? `&sort=${options.sort}` : '';
   queryParams += options.include_private ? `&include_private=${options.include_private}` : '';

--- a/src/services/ckan/types/packageSearch.types.ts
+++ b/src/services/ckan/types/packageSearch.types.ts
@@ -4,11 +4,10 @@
 import { Dataset } from './../../../types/dataset.types';
 
 export interface PackageSearchOptions {
-  tags?: string[];
-  orgs?: string[];
-  groups?: string[];
+  keywords?: string[];
+  catalogues?: string[];
+  themes?: string[];
   publishers?: string[];
-  resFormat?: string[];
   offset?: number;
   limit?: number;
   query?: string;

--- a/src/utils/__tests__/dto.test.ts
+++ b/src/utils/__tests__/dto.test.ts
@@ -28,10 +28,10 @@ describe('Map field details objects to filter item props', () => {
 
     const expected = [
       {
-        label: 'Publishers',
+        label: 'publishers',
         data: [
           {
-            label: 'Adeling NKR-analyse',
+            label: 'adeling NKR-analyse',
             value: 'adeling NKR-analyse',
           },
           {
@@ -39,21 +39,21 @@ describe('Map field details objects to filter item props', () => {
             value: 'Centro Nacional de Epidemiología',
           },
           {
-            label: 'Sciensano Network of General Practitioners team',
+            label: 'sciensano Network of General Practitioners team',
             value: 'sciensano Network of General Practitioners team',
           },
         ],
         icon: faUser,
       },
       {
-        label: 'Catalogues',
+        label: 'catalogues',
         data: [
           {
             label: 'EU',
             value: 'EU',
           },
           {
-            label: 'Lumc',
+            label: 'lumc',
             value: 'lumc',
           },
           {
@@ -84,7 +84,7 @@ describe('Map field details objects to filter item props', () => {
 
     const expected = [
       {
-        label: 'Publishers',
+        label: 'publishers',
         data: [],
         icon: faUser,
       },
@@ -110,7 +110,7 @@ describe('Map field details objects to filter item props', () => {
 
     const expected = [
       {
-        label: 'Publishers',
+        label: 'publishers',
         data: [],
         icon: undefined,
       },

--- a/src/utils/__tests__/textProcessing.test.ts
+++ b/src/utils/__tests__/textProcessing.test.ts
@@ -66,7 +66,7 @@ describe('Parse filter values from a single query string', () => {
 
   it('should parse filter values with uppercase letters', () => {
     const filterValues = '(Afdeling NKR-analyse,DI Dr. Gerhard Fülöp,Helena Jericek Klanscek)';
-    const expected = ['afdeling nkr-analyse', 'di dr. gerhard fülöp', 'helena jericek klanscek'];
+    const expected = ['Afdeling NKR-analyse', 'DI Dr. Gerhard Fülöp', 'Helena Jericek Klanscek'];
 
     const parsedValues = parseFilterValuesSingleQueryString(filterValues);
 

--- a/src/utils/dto.ts
+++ b/src/utils/dto.ts
@@ -9,10 +9,10 @@ import { IconDefinition } from '@fortawesome/free-solid-svg-icons';
 function convertDataToFilterItemProps(data: FieldDetails[], fieldToIconMap: Record<string, IconDefinition>): FilterItemProps[] {
   return data.map((fieldDetails: FieldDetails) => {
     return {
-      label: fieldDetails.field.charAt(0).toUpperCase() + fieldDetails.field.slice(1) + 's',
+      label: fieldDetails.field + 's',
       data: fieldDetails.values.map((v: string) => {
         return {
-          label: v.charAt(0).toUpperCase() + v.slice(1),
+          label: v,
           value: v,
         };
       }),

--- a/src/utils/textProcessing.ts
+++ b/src/utils/textProcessing.ts
@@ -31,10 +31,7 @@ function removeEndingPunctuation(text: string): string {
 }
 
 function parseFilterValuesSingleQueryString(filterValues: string): string[] {
-  return filterValues
-    .slice(1, -1)
-    .split(',')
-    .map((value) => value.toLowerCase());
+  return filterValues.slice(1, -1).split(',');
 }
 
 export { parseFilterValuesSingleQueryString, truncateDescription };


### PR DESCRIPTION
I removed some unnecessary case transformation.
All terms should be unique, thus we should always in this case quote text on lucene queries.