### PR TITLE
feat: Application icon in header

### DIFF
--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -4,7 +4,7 @@
 
 import Disclaimer from "@/components/disclaimer";
 import Footer from "@/components/footer";
-import Header from "@/components/header";
+import Header from "@/components/Header";
 import SessionProviderWrapper from "@/components/utils/sessionProviderWrapper";
 import { DatasetBasketProvider } from "@/providers/DatasetBasketProvider";
 import { config } from "@fortawesome/fontawesome-svg-core";

--- a/src/components/Header/ApplicationIcon.tsx
+++ b/src/components/Header/ApplicationIcon.tsx
@@ -1,0 +1,20 @@
+// SPDX-FileCopyrightText: 2024 PNED G.I.E.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+import Link from "next/link";
+import { faFileText } from "@fortawesome/free-solid-svg-icons";
+import { FontAwesomeIcon } from "@fortawesome/react-fontawesome";
+
+function ApplicationIcon() {
+  return (
+    <Link
+      href="/applications"
+      className="flex items-center text-info hover:text-primary"
+    >
+      <FontAwesomeIcon icon={faFileText} size="xl" />
+    </Link>
+  );
+}
+
+export default ApplicationIcon;

--- a/src/components/Header/Avatar.tsx
+++ b/src/components/Header/Avatar.tsx
@@ -13,7 +13,7 @@ import { User } from "@/types/user.types";
 import { keycloackSessionLogOut } from "@/utils/auth";
 import {
   faDatabase,
-  faFolder,
+  faFileText,
   faGear,
   faSignOut,
 } from "@fortawesome/free-solid-svg-icons";
@@ -61,7 +61,7 @@ function Avatar({ user }: AvatarProps) {
             <span>Datasets</span>
           </DropdownMenuItem>
           <DropdownMenuItem className="cursor-pointer gap-x-3 transition-all duration-300 hover:bg-primary hover:text-white">
-            <FontAwesomeIcon icon={faFolder} className="text-sm" />
+            <FontAwesomeIcon icon={faFileText} className="text-sm" />
             <Link href="/applications">Applications</Link>
           </DropdownMenuItem>
           <DropdownMenuItem className="cursor-pointer gap-x-3 transition-all duration-300 hover:bg-primary hover:text-white">

--- a/src/components/Header/index.tsx
+++ b/src/components/Header/index.tsx
@@ -23,10 +23,10 @@ import Image from "next/image";
 import Link from "next/link";
 import { usePathname } from "next/navigation";
 import { useEffect, useState } from "react";
-import logo from "../public/egdi-logo-horizontal-full-color-rgb.svg";
-import Avatar from "./avatar";
-import Button from "./button";
-import Notification from "./notification";
+import logo from "@/public/egdi-logo-horizontal-full-color-rgb.svg";
+import Avatar from "./Avatar";
+import Button from "../button";
+import ApplicationIcon from "./ApplicationIcon";
 
 function Header() {
   const { data: session, status } = useSession();
@@ -62,7 +62,7 @@ function Header() {
   if (status !== "loading") {
     loginBtn = session ? (
       <>
-        <Notification />
+        <ApplicationIcon />
         <Avatar user={session.user as User} />
       </>
     ) : (


### PR DESCRIPTION
I believe Application Icon should also be a primary header icon after login

User should not have to first click Avatar and then click on Application

<img width="1511" alt="Screenshot 2024-04-04 at 09 18 10" src="https://github.com/GenomicDataInfrastructure/gdi-userportal-frontend/assets/1210046/0826f327-4697-4d10-89e8-bf477118595e">
