### PR TITLE
fix filter list close icon location

### DIFF
--- a/src/app/datasets/FilterList/FilterItem.tsx
+++ b/src/app/datasets/FilterList/FilterItem.tsx
@@ -2,16 +2,9 @@
 //
 // SPDX-License-Identifier: Apache-2.0
 
-import { type IconDefinition } from "@fortawesome/fontawesome-svg-core";
 import { FontAwesomeIcon } from "@fortawesome/react-fontawesome";
-import MultipleSelector, { type Option } from "./ui/multipleSelector";
-
-export type FilterItemProps = {
-  field: string;
-  label: string;
-  data: Option[];
-  icon: IconDefinition;
-};
+import { FilterItemProps } from "@/utils/convertDataToFilterItemProps";
+import MultipleSelector from "@/components/ui/multipleSelector";
 
 function FilterItem({ field, label, data, icon }: FilterItemProps) {
   return (

--- a/src/app/datasets/FilterList/index.tsx
+++ b/src/app/datasets/FilterList/index.tsx
@@ -3,7 +3,10 @@
 // SPDX-License-Identifier: Apache-2.0
 
 import { type Facet } from "@/services/ckan/types/packageSearch.types";
-import { convertDataToFilterItemProps } from "@/utils/dto";
+import {
+  convertDataToFilterItemProps,
+  FilterItemProps,
+} from "@/utils/convertDataToFilterItemProps";
 import {
   faBook,
   faFilter,
@@ -13,12 +16,13 @@ import {
   faFile,
   faKey,
   faLocation,
+  faX,
   type IconDefinition,
 } from "@fortawesome/free-solid-svg-icons";
 import { FontAwesomeIcon } from "@fortawesome/react-fontawesome";
 import Link from "next/link";
-import Button from "./button";
-import FilterItem, { FilterItemProps } from "./filterItem";
+import Button from "@/components/button";
+import FilterItem from "./FilterItem";
 
 const fieldToIconMap: Record<string, IconDefinition> = {
   publisher_name: faUser,
@@ -32,15 +36,13 @@ const fieldToIconMap: Record<string, IconDefinition> = {
 
 type FilterListProps = {
   facets: Facet[];
-  displayContinueButton?: boolean;
-  setIsFilterOpen: React.Dispatch<React.SetStateAction<boolean>>;
+  toggleFullScreenFilter?: React.Dispatch<React.SetStateAction<boolean>>;
   queryParams: Record<string, string | string[] | undefined>;
 };
 
 function FilterList({
   facets,
-  displayContinueButton = false,
-  setIsFilterOpen,
+  toggleFullScreenFilter,
   queryParams,
 }: FilterListProps) {
   const filterItemProps: FilterItemProps[] = convertDataToFilterItemProps(
@@ -57,12 +59,22 @@ function FilterList({
 
   return (
     <div className="flex flex-col gap-y-10 rounded-lg bg-white-smoke px-6 py-8">
-      <h1 className="text-xl">
-        <span className="mr-2">
-          <FontAwesomeIcon icon={faFilter} />
-        </span>
-        Filters
-      </h1>
+      <div className="flex items-center justify-between">
+        <h1 className="text-xl">
+          <span className="mr-2">
+            <FontAwesomeIcon icon={faFilter} />
+          </span>
+          Filters
+        </h1>
+        {toggleFullScreenFilter && (
+          <button
+            className="hover:text-secondary"
+            onClick={() => toggleFullScreenFilter(false)}
+          >
+            <FontAwesomeIcon icon={faX} />
+          </button>
+        )}
+      </div>
       {filterItemProps.map((props) => (
         <li key={props.field} className="list-none">
           <FilterItem
@@ -85,12 +97,12 @@ function FilterList({
             />
           </Link>
         )}
-        {displayContinueButton && (
+        {toggleFullScreenFilter && (
           <Button
             text="Continue"
             type="info"
             className="w-fit text-xs"
-            onClick={() => setIsFilterOpen(false)}
+            onClick={() => toggleFullScreenFilter(false)}
           ></Button>
         )}
       </div>

--- a/src/app/datasets/clientWrapper.tsx
+++ b/src/app/datasets/clientWrapper.tsx
@@ -4,9 +4,8 @@
 
 "use client";
 
-import Button from "@/components/button";
 import DatasetList from "@/components/datasetList";
-import FilterList from "@/components/filterList";
+import FilterList from "./FilterList";
 import PaginationContainer from "@/components/paginationContainer";
 import SearchBar from "@/components/SearchBar";
 import PageContainer from "@/components/PageContainer";
@@ -15,7 +14,7 @@ import { Facet } from "@/services/ckan/types/packageSearch.types";
 import { PackageSearchResult } from "@/services/ckan/types/packageSearch.types";
 import { SCREEN_SIZE, pixelWidthToScreenSize } from "@/utils/windowSize";
 import { FontAwesomeIcon } from "@fortawesome/react-fontawesome";
-import { faFilter, faX } from "@fortawesome/free-solid-svg-icons";
+import { faFilter } from "@fortawesome/free-solid-svg-icons";
 import { useEffect, useState } from "react";
 
 type ClientWrapperProps = {
@@ -31,30 +30,23 @@ export default function ClientWrapper({
   queryParams,
   facets,
 }: ClientWrapperProps) {
-  const [isFilterOpen, setIsFilterOpen] = useState(false);
+  const [isFullScreenFilterOpen, toggleFullScreenFilter] = useState(false);
   const { width } = useWindowSize();
   const screenSize = pixelWidthToScreenSize(width);
 
   useEffect(() => {
-    if (screenSize === SCREEN_SIZE.XL) setIsFilterOpen(false);
+    if (screenSize === SCREEN_SIZE.XL) toggleFullScreenFilter(false);
   }, [screenSize]);
 
   return (
     <PageContainer>
       <div className="grid grid-cols-12">
-        {isFilterOpen ? (
-          <div className="col-start-0 relative col-span-12 rounded-lg border bg-white-smoke">
+        {isFullScreenFilterOpen ? (
+          <div className="col-start-0 col-span-12 rounded-lg border bg-white-smoke">
             <FilterList
               facets={facets}
-              displayContinueButton={true}
-              setIsFilterOpen={setIsFilterOpen}
+              toggleFullScreenFilter={toggleFullScreenFilter}
               queryParams={queryParams}
-            />
-            <Button
-              icon={faX}
-              className="absolute right-0 top-0 w-fit hover:bg-primary hover:text-white"
-              text=""
-              onClick={() => setIsFilterOpen(false)}
             />
           </div>
         ) : (
@@ -63,7 +55,7 @@ export default function ClientWrapper({
               <SearchBar queryParams={queryParams} />
               <button
                 className="ml-4 h-11 rounded-lg bg-info px-4 text-xs text-white hover:bg-secondary md:text-xs xl:hidden"
-                onClick={() => setIsFilterOpen(!isFilterOpen)}
+                onClick={() => toggleFullScreenFilter(!isFullScreenFilterOpen)}
               >
                 <FontAwesomeIcon icon={faFilter} />
               </button>
@@ -72,11 +64,7 @@ export default function ClientWrapper({
               {`${datasets.count} ${datasets.count > 1 ? "datasets" : "dataset"} found`}
             </p>
             <div className="border-1 col-start-0 col-span-4 mr-6 hidden rounded-lg border bg-white-smoke xl:block">
-              <FilterList
-                facets={facets}
-                setIsFilterOpen={setIsFilterOpen}
-                queryParams={queryParams}
-              />
+              <FilterList facets={facets} queryParams={queryParams} />
             </div>
             <div className="col-start-0 col-span-12 xl:col-span-8 xl:col-start-5">
               <DatasetList datasets={datasets.datasets} />

--- a/src/utils/__tests__/convertDataToFilterItemProps.test.ts
+++ b/src/utils/__tests__/convertDataToFilterItemProps.test.ts
@@ -3,7 +3,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 import { faBook, faUser } from '@fortawesome/free-solid-svg-icons';
-import { convertDataToFilterItemProps } from '../dto';
+import { convertDataToFilterItemProps } from '../convertDataToFilterItemProps';
 
 describe('Map field details objects to filter item props', () => {
   it('should map field details to filter item props', () => {

--- a/src/utils/convertDataToFilterItemProps.ts
+++ b/src/utils/convertDataToFilterItemProps.ts
@@ -2,9 +2,16 @@
 //
 // SPDX-License-Identifier: Apache-2.0
 
-import { FilterItemProps } from '@/components/filterItem';
+import { type Option } from '@/components/ui/multipleSelector';
 import { Facet } from '@/services/ckan/types/packageSearch.types';
 import { IconDefinition } from '@fortawesome/free-solid-svg-icons';
+
+export type FilterItemProps = {
+  field: string;
+  label: string;
+  data: Option[];
+  icon: IconDefinition;
+};
 
 function convertDataToFilterItemProps(facets: Facet[], fieldToIconMap: Record<string, IconDefinition>): FilterItemProps[] {
   return facets.map((facet: Facet) => {


### PR DESCRIPTION
1. Move FilterList and FilterItem out of components and inside datasets page because they are not re-usable
2. Move close button inside FilterList component
3. Remove displayContinueButton prop as it is rebundant
4. Use flex to align close button instead of absolute