### PR TITLE
fix: spacing

### DIFF
--- a/src/app/about/page.tsx
+++ b/src/app/about/page.tsx
@@ -10,56 +10,62 @@ import React from "react";
 const AboutPage: React.FC = () => {
   return (
     <PageContainer>
-      <PageHeading className="mb-4">
-        About Genomic Data Infrastructure (GDI)
-      </PageHeading>
       <p>
-        The Genomic Data Infrastructure (GDI) project aims to enable access to
-        genomic and related phenotypic and clinical data to improve research,
-        policymaking and healthcare across Europe. The GDI project aims to
-        unlock a data network of over one million genome sequences for research
-        and clinical reference. This will create unprecedented opportunities for
-        transnational and multi-stakeholder actions in personalised medicine for
-        cancer, common, rare and infectious diseases as well as access to a
-        reference genome collection representing the European population (Genome
-        of Europe).
+        <PageHeading className="mb-4">
+          About Genomic Data Infrastructure (GDI)
+        </PageHeading>
+        <p>
+          The Genomic Data Infrastructure (GDI) project aims to enable access to
+          genomic and related phenotypic and clinical data to improve research,
+          policymaking and healthcare across Europe. The GDI project aims to
+          unlock a data network of over one million genome sequences for
+          research and clinical reference. This will create unprecedented
+          opportunities for transnational and multi-stakeholder actions in
+          personalised medicine for cancer, common, rare and infectious diseases
+          as well as access to a reference genome collection representing the
+          European population (Genome of Europe).
+        </p>
       </p>
 
-      <PageSubHeading className="my-4">User Portal</PageSubHeading>
       <p>
-        The User Portal, developed by the Genomic Data Infrastructure (GDI)
-        project, is the central entry point for accessing genomic data. As part
-        of the Genomic Data Infrastructure (GDI) project, it unlocks a vast
-        repository of over one million genome sequences, this platform is
-        currently under development and will serve as the main European-level
-        hub for data access, providing a user-friendly interface for researchers
-        and healthcare professionals.{" "}
+        <PageSubHeading className="my-4">User Portal</PageSubHeading>
+        <p>
+          The User Portal, developed by the Genomic Data Infrastructure (GDI)
+          project, is the central entry point for accessing genomic data. As
+          part of the Genomic Data Infrastructure (GDI) project, it unlocks a
+          vast repository of over one million genome sequences, this platform is
+          currently under development and will serve as the main European-level
+          hub for data access, providing a user-friendly interface for
+          researchers and healthcare professionals.{" "}
+        </p>
       </p>
 
-      <PageSubHeading className="my-4">Key Objectives</PageSubHeading>
-      <ul className="list-inside list-disc">
-        <li>
-          To link and to provide cross-border access to genomic and related
-          phenotypic datasets across Europe
-        </li>
-        <li>
-          To advance understanding of genomics for more precise and faster
-          clinical decision making, diagnostics, treatments systems, and to
-          benefit the overall economy
-        </li>
-        <li>
-          To align with the development under the European Health Data Space
-          (EHDS)
-        </li>
-        <li>
-          To Facilitate research, policy-making, and healthcare improvements
-        </li>
-        <li>
-          To maintain awareness, acceptance and trust in the main groups of
-          stakeholders, notably European citizens, data holders, healthcare
-          professionals, researchers and public health authorities
-        </li>
-      </ul>
+      <p>
+        <PageSubHeading className="my-4">Key Objectives</PageSubHeading>
+        <ul className="list-inside list-disc">
+          <li>
+            To link and to provide cross-border access to genomic and related
+            phenotypic datasets across Europe
+          </li>
+          <li>
+            To advance understanding of genomics for more precise and faster
+            clinical decision making, diagnostics, treatments systems, and to
+            benefit the overall economy
+          </li>
+          <li>
+            To align with the development under the European Health Data Space
+            (EHDS)
+          </li>
+          <li>
+            To Facilitate research, policy-making, and healthcare improvements
+          </li>
+          <li>
+            To maintain awareness, acceptance and trust in the main groups of
+            stakeholders, notably European citizens, data holders, healthcare
+            professionals, researchers and public health authorities
+          </li>
+        </ul>
+      </p>
 
       <p className="mt-20">
         For more detailed information, please visit the{" "}

--- a/src/components/PageContainer.tsx
+++ b/src/components/PageContainer.tsx
@@ -13,7 +13,7 @@ interface PageContainerProps {
 
 function PageContainer({ children, className }: PageContainerProps) {
   return (
-    <div className={`container mx-auto space-y-20 px-4 pt-20 ${className}`}>
+    <div className={`container mx-auto space-y-10 px-4 pt-20 ${className}`}>
       {children}
     </div>
   );


### PR DESCRIPTION
With this [PR](https://github.com/GenomicDataInfrastructure/gdi-userportal-frontend/pull/164), the spacing for about us page is broken
 

This PR is a fix towards that

Before
<img width="1605" alt="Screenshot 2024-04-10 at 14 10 22" src="https://github.com/GenomicDataInfrastructure/gdi-userportal-frontend/assets/1210046/869ae8c1-35fb-42ce-a2a0-1abfe6807c6f">


After
<img width="1535" alt="Screenshot 2024-04-10 at 14 10 10" src="https://github.com/GenomicDataInfrastructure/gdi-userportal-frontend/assets/1210046/a31f7e4a-1945-4a2c-b48d-17fd1d97c054">
