### PR TITLE
fix: provide client secret while refreshing token

### DIFF
--- a/src/utils/auth.ts
+++ b/src/utils/auth.ts
@@ -88,6 +88,7 @@ export async function refreshAccessToken(token: JWT) {
     headers: { 'Content-Type': 'application/x-www-form-urlencoded' },
     body: new URLSearchParams({
       client_id: `${process.env.KEYCLOAK_CLIENT_ID}`,
+      client_secret: `${process.env.KEYCLOAK_CLIENT_SECRET}`,
       grant_type: 'refresh_token',
       refresh_token: token.refresh_token as string,
     }),


### PR DESCRIPTION
1) After few minutes, the token will expire and has to be refreshed
2) While refreshing it would fail because no client secret was passed.
3) Thos resulted in application to throw errors after a while