### PR TITLE
Remove identifiers links and show record count

### DIFF
--- a/.env.local.example
+++ b/.env.local.example
@@ -11,7 +11,7 @@ KEYCLOAK_ISSUER_URL=https://id.portal.dev.gdi.lu/realms/gdi
 END_SESSION_URL=https://id.portal.dev.gdi.lu/realms/gdi/protocol/openid-connect/logout
 REFRESH_TOKEN_URL=https://id.portal.dev.gdi.lu/realms/gdi/protocol/openid-connect/token
 CSP_HEADER=`
-    default-src 'self' https://api.portal.dev.gdi.lu https://dataset-discovery-service-test.azurewebsites.net http://localhost:3000;
+    default-src 'self' https://api.portal.dev.gdi.lu;
     script-src 'self' 'unsafe-eval' 'unsafe-inline';
     style-src 'self' 'unsafe-inline';
     img-src 'self' blob: data:;

--- a/src/app/applications/ApplicationItem.tsx
+++ b/src/app/applications/ApplicationItem.tsx
@@ -103,11 +103,7 @@ export default function ApplicationItem({
           <div className="md:flex-1">
             <h3 className="mb-4 text-lg font-bold text-primary">Datasets</h3>
             {application.datasets.map((dataset) => (
-              <a
-                href={`/datasets/${dataset.externalId}`}
-                key={dataset.id}
-                className="mb-2 block items-baseline gap-2 hover:underline"
-              >
+              <span className="mb-2 flex items-center gap-2">
                 <FontAwesomeIcon
                   icon={faDatabase}
                   className="text-md text-info"
@@ -115,7 +111,7 @@ export default function ApplicationItem({
                 <h3 className="sm:text-md text-base font-bold text-info lg:text-lg">
                   {getLabelName(dataset.title)}
                 </h3>
-              </a>
+              </span>
             ))}
           </div>
         </div>

--- a/src/app/applications/ApplicationItem.tsx
+++ b/src/app/applications/ApplicationItem.tsx
@@ -102,8 +102,11 @@ export default function ApplicationItem({
           </div>
           <div className="md:flex-1">
             <h3 className="mb-4 text-lg font-bold text-primary">Datasets</h3>
-            {application.datasets.map((dataset) => (
-              <span className="mb-2 flex items-center gap-2">
+            {application.datasets.map((dataset, index) => (
+              <span
+                className="mb-2 flex items-center gap-2"
+                key={`${dataset.id}-${index}`}
+              >
                 <FontAwesomeIcon
                   icon={faDatabase}
                   className="text-md text-info"

--- a/src/app/datasets/[id]/sidebarItems.ts
+++ b/src/app/datasets/[id]/sidebarItems.ts
@@ -38,11 +38,8 @@ function createDatasetSidebarItems(dataset: RetrievedDataset): SidebarItem[] {
     },
     {
       label: 'Identifier',
-      value: {
-        label: dataset.identifier,
-        url: dataset.identifier,
-      },
-      isLink: true,
+      value: dataset.identifier,
+      isLink: false,
     },
     {
       label: 'Spatial URI',

--- a/src/app/datasets/datasetItem.tsx
+++ b/src/app/datasets/datasetItem.tsx
@@ -48,7 +48,18 @@ function DatasetItem({ dataset }: DatasetItemProps) {
         <p className="mb-4 text-xs md:text-sm">{truncatedDesc}</p>
       )}
       <Chips chips={dataset.themes?.map((x) => x.label) || []} />
-      <div className="mt-4 flex w-full justify-end">
+      <div
+        className={
+          "mt-4 flex w-full " +
+          (!!dataset.recordsCount ? "justify-between" : "justify-end")
+        }
+      >
+        {!!dataset.recordsCount && (
+          <span className="mt-4 flex rounded bg-info px-2 py-1 text-xs font-bold text-white">
+            {dataset.recordsCount} record{dataset.recordsCount > 1 ? "s" : ""}{" "}
+            found
+          </span>
+        )}
         {!isLoading && (
           <Button
             text={isInBasket ? "Remove from basket" : "Add to basket"}


### PR DESCRIPTION
In this PR, as it's not clear at this point how we will use `dct:identifier` for internal identification, we are removing links from identifier strings.

Another small fix, we need to present records count in the UI. We will revise the layout on the 24 April.

<img width="1536" alt="Screenshot 2024-04-19 at 09 41 56" src="https://github.com/GenomicDataInfrastructure/gdi-userportal-frontend/assets/4491850/53ef5ade-de3f-426e-a571-e4edefb8daef">
