### PR TITLE
Art 5378/send identifier to create application

### DIFF
--- a/src/app/basket/page.tsx
+++ b/src/app/basket/page.tsx
@@ -31,10 +31,12 @@ export default function Page() {
   }
 
   const requestNow = async () => {
+    const identifiers = basket
+      .map((dataset) => dataset.identifier)
+      .filter((identifier): identifier is string => identifier !== undefined);
+
     try {
-      const response = await createApplication(
-        basket.map((dataset) => dataset.id),
-      );
+      const response = await createApplication(identifiers);
       emptyBasket();
       window.location.href = `/applications/${response.applicationId}`;
     } catch (error) {

--- a/src/app/datasets/DatasetItem.tsx
+++ b/src/app/datasets/DatasetItem.tsx
@@ -32,6 +32,8 @@ function DatasetItem({ dataset }: DatasetItemProps) {
       addDatasetToBasket(dataset);
     }
   };
+  const hasIdentifier = !!dataset.identifier;
+  const buttonDisabled = isLoading || !hasIdentifier;
 
   return (
     <>
@@ -66,6 +68,7 @@ function DatasetItem({ dataset }: DatasetItemProps) {
             icon={isInBasket ? faMinusCircle : faPlusCircle}
             onClick={toggleDatasetInBasket}
             type={isInBasket ? "warning" : "primary"}
+            disabled={buttonDisabled}
           />
         )}
       </div>

--- a/src/app/datasets/[id]/AddToBasketBtn.tsx
+++ b/src/app/datasets/[id]/AddToBasketBtn.tsx
@@ -29,13 +29,13 @@ function AddToBasketBtn({ dataset }: AddToBasketBtnProps) {
 
   return (
     <div className="flex lg:w-1/3 lg:justify-end">
-        <Button
-          text={isInBasket ? "Remove from basket" : "Add to basket"}
-          icon={isInBasket ? faMinusCircle : faPlusCircle}
-          onClick={toggleDatasetInBasket}
-          type={isInBasket ? "warning" : "primary"}
-          disabled={buttonDisabled}
-        />
+      <Button
+        text={isInBasket ? "Remove from basket" : "Add to basket"}
+        icon={isInBasket ? faMinusCircle : faPlusCircle}
+        onClick={toggleDatasetInBasket}
+        type={isInBasket ? "warning" : "primary"}
+        disabled={buttonDisabled}
+      />
     </div>
   );
 }

--- a/src/app/datasets/[id]/AddToBasketBtn.tsx
+++ b/src/app/datasets/[id]/AddToBasketBtn.tsx
@@ -16,24 +16,26 @@ function AddToBasketBtn({ dataset }: AddToBasketBtnProps) {
   const { basket, addDatasetToBasket, removeDatasetFromBasket, isLoading } =
     useDatasetBasket();
   const isInBasket = basket.some((ds) => ds.id === dataset.id);
+  const hasIdentifier = dataset.identifier != null;
   const toggleDatasetInBasket = () => {
     if (isInBasket) {
       removeDatasetFromBasket(dataset);
-    } else {
+    } else if (hasIdentifier) {
       addDatasetToBasket(dataset);
     }
   };
 
+  const buttonDisabled = isLoading || !hasIdentifier;
+
   return (
     <div className="flex lg:w-1/3 lg:justify-end">
-      {!isLoading && (
         <Button
           text={isInBasket ? "Remove from basket" : "Add to basket"}
           icon={isInBasket ? faMinusCircle : faPlusCircle}
           onClick={toggleDatasetInBasket}
           type={isInBasket ? "warning" : "primary"}
+          disabled={buttonDisabled}
         />
-      )}
     </div>
   );
 }


### PR DESCRIPTION
In this pr:

- To create Applications identifier of datasets is being sent in the backend instead of the id
- The button for adding datasets to basket is disabled for the datasets that don't have an identifier