### PR TITLE
60/user profile

### DIFF
--- a/src/components/Header/Avatar.tsx
+++ b/src/components/Header/Avatar.tsx
@@ -9,20 +9,29 @@ import {
   DropdownMenuItem,
   DropdownMenuTrigger,
 } from "@/components/shadcn/dropdown-menu";
+import { useWindowSize } from "@/hooks";
 import { User } from "@/types/user.types";
 import { keycloackSessionLogOut } from "@/utils/auth";
+import { pixelWidthToScreenSize } from "@/utils/windowSize";
 import {
+  faAngleDown,
   faDatabase,
-  faGear,
+  faFile,
   faSignOut,
+  faUser,
 } from "@fortawesome/free-solid-svg-icons";
 import { FontAwesomeIcon } from "@fortawesome/react-fontawesome";
 import { signOut } from "next-auth/react";
 import Image from "next/image";
+import Link from "next/link";
 
 type AvatarProps = {
   user: User;
 };
+
+function handleSignOut() {
+  keycloackSessionLogOut().then(() => signOut({ callbackUrl: "/" }));
+}
 
 function getInitials(name?: string) {
   if (!name) return null;
@@ -34,44 +43,57 @@ function getInitials(name?: string) {
     .toUpperCase();
 }
 
-function handleSignOut() {
-  keycloackSessionLogOut().then(() => signOut({ callbackUrl: "/" }));
-}
-
 function Avatar({ user }: AvatarProps) {
+  const { width } = useWindowSize();
+  const screenSize = pixelWidthToScreenSize(width);
+
+  const username =
+    screenSize === "SM" || screenSize === "MD"
+      ? getInitials(user?.name)
+      : user?.name;
+
   return (
-    <DropdownMenu>
-      <DropdownMenuTrigger asChild>
-        <div className="flex h-8 w-8 cursor-pointer items-center justify-center rounded-full bg-info p-[8px] text-xs text-white shadow-sm transition-all duration-300 hover:opacity-90 md:h-9 md:w-9 md:p-[10px] md:text-[13px]">
+    <div className="flex gap-x-2">
+      <div className="flex h-8 w-8 cursor-pointer items-center justify-center rounded-full bg-info p-[8px] text-xs text-white shadow-sm transition-colors duration-300 hover:bg-primary md:h-9 md:w-9 md:p-[10px] md:text-[13px]">
+        <Link href="/profile">
           {user?.image ? (
             <Image src={user.image} alt="avatar" className="rounded-full" />
           ) : (
-            <p className="flex items-center justify-center">
-              {getInitials(user?.name)}
-            </p>
+            <FontAwesomeIcon icon={faUser} />
           )}
-        </div>
-      </DropdownMenuTrigger>
-      <DropdownMenuContent className="bg-white">
-        <DropdownMenuGroup>
-          <DropdownMenuItem className="cursor-pointer gap-x-3 transition-all duration-300 hover:bg-primary hover:text-white">
-            <FontAwesomeIcon icon={faDatabase} className="text-sm" />
-            <span>Datasets</span>
-          </DropdownMenuItem>
-          <DropdownMenuItem className="cursor-pointer gap-x-3 transition-all duration-300 hover:bg-primary hover:text-white">
-            <FontAwesomeIcon icon={faGear} className="text-sm" />
-            <span>Settings</span>
-          </DropdownMenuItem>
-          <DropdownMenuItem
-            className="cursor-pointer gap-x-3 transition-all duration-300 hover:bg-primary hover:text-white"
-            onClick={handleSignOut}
-          >
-            <FontAwesomeIcon icon={faSignOut} className="text-sm" />
-            <span>Log out</span>
-          </DropdownMenuItem>
-        </DropdownMenuGroup>
-      </DropdownMenuContent>
-    </DropdownMenu>
+        </Link>
+      </div>
+      <DropdownMenu>
+        <DropdownMenuTrigger asChild>
+          <div className="flex items-center gap-x-1 md:gap-x-2">
+            <p className="text-[10px] font-bold md:text-xs">{username}</p>
+            <FontAwesomeIcon
+              icon={faAngleDown}
+              className="text-sm text-gray-500"
+            />
+          </div>
+        </DropdownMenuTrigger>
+        <DropdownMenuContent className="bg-white">
+          <DropdownMenuGroup>
+            <DropdownMenuItem className="cursor-pointer gap-x-3 transition-all duration-300 hover:bg-primary hover:text-white">
+              <FontAwesomeIcon icon={faFile} className="text-sm" />
+              <span>Applications</span>
+            </DropdownMenuItem>
+            <DropdownMenuItem className="cursor-pointer gap-x-3 transition-all duration-300 hover:bg-primary hover:text-white">
+              <FontAwesomeIcon icon={faDatabase} className="text-sm" />
+              <span>My Datasets</span>
+            </DropdownMenuItem>
+            <DropdownMenuItem
+              className="cursor-pointer gap-x-3 transition-all duration-300 hover:bg-primary hover:text-white"
+              onClick={handleSignOut}
+            >
+              <FontAwesomeIcon icon={faSignOut} className="text-sm" />
+              <span>Log out</span>
+            </DropdownMenuItem>
+          </DropdownMenuGroup>
+        </DropdownMenuContent>
+      </DropdownMenu>
+    </div>
   );
 }
 

--- a/src/components/Header/index.tsx
+++ b/src/components/Header/index.tsx
@@ -26,7 +26,6 @@ import Link from "next/link";
 import { usePathname } from "next/navigation";
 import { useEffect, useState } from "react";
 import Button from "../Button";
-import ApplicationIcon from "./ApplicationIcon";
 import Avatar from "./Avatar";
 
 function Header() {
@@ -34,14 +33,6 @@ function Header() {
   const [isMenuOpen, setIsMenuOpen] = useState<boolean>(false);
   const activeTab = usePathname();
   const { basket, isLoading } = useDatasetBasket();
-
-  function handleSignOut() {
-    keycloackSessionLogOut().then(() => signOut({ callbackUrl: "/" }));
-  }
-
-  const closeMenu = () => {
-    setIsMenuOpen(false);
-  };
 
   useEffect(() => {
     const handleOutsideClick = (event: MouseEvent) => {
@@ -58,14 +49,19 @@ function Header() {
     };
   }, [isMenuOpen]);
 
+  function handleSignOut() {
+    keycloackSessionLogOut().then(() => signOut({ callbackUrl: "/" }));
+  }
+
+  const closeMenu = () => {
+    setIsMenuOpen(false);
+  };
+
   let loginBtn;
 
   if (status !== "loading") {
     loginBtn = session ? (
-      <>
-        <ApplicationIcon />
-        <Avatar user={session.user as User} />
-      </>
+      <Avatar user={session.user as User} />
     ) : (
       <Button
         icon={faUser}
@@ -115,7 +111,10 @@ function Header() {
             href="/basket"
             className="relative flex items-center text-info hover:text-primary"
           >
-            <FontAwesomeIcon icon={faShoppingCart} size="lg" />
+            <FontAwesomeIcon
+              icon={faShoppingCart}
+              className="text-lg md:text-xl "
+            />
             {basket.length > 0 && (
               <span className="absolute right-0 top-0 inline-flex -translate-y-1/2 translate-x-1/2 transform items-center justify-center rounded-full bg-primary px-2 py-1 text-xs font-bold leading-none text-red-100">
                 {basket.length}


### PR DESCRIPTION
Change avatar and remove application icon from header

My suggestion is that clicking on the avatar will lead us to the user profile page, where there will be 2 tabs: applications and my datasets. By default, the application tab will be active (and thus we can still see our applications with one single click)

<img width="1920" alt="Screenshot 2024-05-02 at 15 54 34" src="https://github.com/GenomicDataInfrastructure/gdi-userportal-frontend/assets/63497031/2d04f320-3c06-473e-bf01-a059da7a8a5e">
ick)
<img width="1920" alt="Screenshot 2024-05-02 at 15 54 46" src="https://github.com/GenomicDataInfrastructure/gdi-userportal-frontend/assets/63497031/f8a2e661-5f6a-4d39-bb36-12eb8553c6b7">
