### PR TITLE
Fix for removing logic duplication for handling application submission errors

### DIFF
--- a/src/app/applications/[id]/page.tsx
+++ b/src/app/applications/[id]/page.tsx
@@ -30,6 +30,7 @@ export default function ApplicationDetailsPage() {
   const { application, error, submitApplication, clearError } =
     useApplicationDetails();
   const handleSubmission = () => {
+    onCloseAlert();
     clearError();
     submitApplication();
   };

--- a/src/providers/application/ApplicationProvider.tsx
+++ b/src/providers/application/ApplicationProvider.tsx
@@ -247,33 +247,24 @@ function ApplicationProvider({ children }: ApplicationProviderProps) {
   async function submitApplication() {
     dispatch({ type: ApplicationActionType.LOADING });
 
-    try {
-      const response = await fetch(
-        `/api/applications/${application!.id}/submit`,
-        { method: "POST" },
-      );
+    const response = await fetch(
+      `/api/applications/${application!.id}/submit`,
+      { method: "POST" },
+    );
 
-      if (response.ok) {
-        dispatch({ type: ApplicationActionType.CLEAR_ERROR });
-        fetchApplication();
-      } else {
-        const errorResponse = await response.json();
-        const errorMessage =
-          errorResponse.error || "An unexpected error occurred.";
-        dispatch({
-          type: ApplicationActionType.REJECTED,
-          payload: errorMessage,
-        });
-      }
-    } catch (error) {
+    if (response.ok) {
+      dispatch({ type: ApplicationActionType.CLEAR_ERROR });
+      fetchApplication();
+    } else {
+      const errorResponse = await response.json();
+      const errorMessage =
+        errorResponse.error || "An unexpected error occurred.";
       dispatch({
         type: ApplicationActionType.REJECTED,
-        payload:
-          "Failed to submit application due to a network or server issue.",
+        payload: errorMessage,
       });
     }
   }
-
   return (
     <ApplicationContext.Provider
       value={{


### PR DESCRIPTION
A small fix for removing the try & catch logic. The error is already being handled in the if else condition.
* Fetch doesn't throw exceptions