### PR TITLE
feat: #273 display Recents Datasets on homepage

### DIFF
--- a/src/app/Footer.tsx
+++ b/src/app/Footer.tsx
@@ -33,7 +33,7 @@ function Footer() {
 
   return (
     <>
-      <div className="bg-primary p-4 text-center">
+      <div className="bg-primary p-4 text-center mt-4">
         <a
           href={bannerLink ? `https://${bannerLink}` : "#"}
           target={bannerLink ? "_blank" : ""}

--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -62,3 +62,19 @@ h6 {
 .font-date {
   @apply font-medium;
 }
+
+.truncate-lines-1 {
+  overflow: hidden;
+  text-overflow: ellipsis;
+  display: -webkit-box;
+  -webkit-line-clamp: 2;
+  -webkit-box-orient: vertical;
+}
+
+.truncate-lines-3 {
+  overflow: hidden;
+  text-overflow: ellipsis;
+  display: -webkit-box;
+  -webkit-line-clamp: 3;
+  -webkit-box-orient: vertical;
+}

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -1,4 +1,4 @@
-// SPDX-License-Identifier: 2024 PNED G.I.E.
+// SPDX-FileCopyrightText: 2024 PNED G.I.E.
 // SPDX-License-Identifier: Apache-2.0
 
 "use client";

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -6,12 +6,33 @@
 import PageContainer from "@/components/PageContainer";
 import SearchBar from "@/components/Searchbar";
 import { useSearchParams } from "next/navigation";
+import { useEffect, useState } from "react";
+import { datasetList } from "@/services/discovery/index.public";
+import { SearchedDataset } from "@/services/discovery/types/dataset.types";
+import RecentDatasets from "@/components/RecentDatasets";
 import aboutBackground from "../public/homepage-about-background.png";
 import { FontAwesomeIcon } from "@fortawesome/react-fontawesome";
 import { faArrowUpRightFromSquare } from "@fortawesome/free-solid-svg-icons";
 
 const HomePage = () => {
   const queryParams = useSearchParams();
+  const [datasets, setDatasets] = useState<SearchedDataset[]>([]);
+
+  useEffect(() => {
+    async function fetchData() {
+      try {
+        const response = await datasetList({
+          limit: 200,
+          sort: "createdAt desc",
+        });
+        setDatasets(response.data.datasets);
+      } catch (error) {
+        console.error("Error fetching datasets", error);
+      }
+    }
+    fetchData();
+  }, []);
+
   const homepageTitle =
     process.env.NEXT_PUBLIC_HOMEPAGE_TITLE || "WELCOME TO GDI";
   const homepageSubtitle =
@@ -70,15 +91,8 @@ const HomePage = () => {
         </div>
       </div>
 
-      <div className="mb-20">
-        <div className="rounded-lg bg-white p-8 shadow-md transition-shadow duration-300 ease-in-out hover:shadow-lg text-left">
-          <h3 className="mb-4 text-2xl font-bold text-primary">
-            Most Recent Datasets
-          </h3>
-          <p className="text-lg">
-            Mock most recent datasets will be displayed here.
-          </p>
-        </div>
+      <div className="mb-4">
+        <RecentDatasets datasets={datasets} />
       </div>
     </PageContainer>
   );

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2024 PNED G.I.E.
+// SPDX-License-Identifier: 2024 PNED G.I.E.
 // SPDX-License-Identifier: Apache-2.0
 
 "use client";
@@ -13,25 +13,36 @@ import RecentDatasets from "@/components/RecentDatasets";
 import aboutBackground from "../public/homepage-about-background.png";
 import { FontAwesomeIcon } from "@fortawesome/react-fontawesome";
 import { faArrowUpRightFromSquare } from "@fortawesome/free-solid-svg-icons";
+import { useAlert } from "@/providers/AlertProvider";
+import { AxiosError } from "axios";
 
 const HomePage = () => {
   const queryParams = useSearchParams();
   const [datasets, setDatasets] = useState<SearchedDataset[]>([]);
+  const { setAlert } = useAlert();
 
   useEffect(() => {
     async function fetchData() {
       try {
         const response = await datasetList({
-          limit: 200,
+          limit: 4,
           sort: "createdAt desc",
         });
         setDatasets(response.data.datasets);
       } catch (error) {
-        console.error("Error fetching datasets", error);
+        if (error instanceof AxiosError) {
+          setAlert({
+            type: "error",
+            message:
+              error.response?.data?.title ||
+              `Failed to fetch datasets, status code: ${error.response?.status}`,
+            details: error.response?.data?.detail,
+          });
+        }
       }
     }
     fetchData();
-  }, []);
+  }, [setAlert]);
 
   const homepageTitle =
     process.env.NEXT_PUBLIC_HOMEPAGE_TITLE || "WELCOME TO GDI";

--- a/src/components/RecentDatasets.tsx
+++ b/src/components/RecentDatasets.tsx
@@ -5,6 +5,8 @@ import Link from "next/link";
 import { SearchedDataset } from "@/services/discovery/types/dataset.types";
 import { FontAwesomeIcon } from "@fortawesome/react-fontawesome";
 import { faArrowRight } from "@fortawesome/free-solid-svg-icons";
+import { formatDate } from "@/utils/formatDate";
+import { useMemo } from "react";
 
 type DatasetLinkProps = Pick<
   SearchedDataset,
@@ -12,12 +14,14 @@ type DatasetLinkProps = Pick<
 >;
 
 const RecentDatasets = ({ datasets }: { datasets: SearchedDataset[] }) => {
-  const sortedDatasets = [...datasets]
-    .sort(
-      (a, b) =>
-        new Date(b.createdAt).getTime() - new Date(a.createdAt).getTime()
-    )
-    .slice(0, 4);
+  const sortedDatasets = useMemo(() => {
+    return [...datasets]
+      .sort(
+        (a, b) =>
+          new Date(b.createdAt).getTime() - new Date(a.createdAt).getTime()
+      )
+      .slice(0, 4);
+  }, [datasets]);
 
   return (
     <div className="bg-white sm:p-4 rounded-lg pb-28 sm:pb-28 w-full">
@@ -33,7 +37,7 @@ const RecentDatasets = ({ datasets }: { datasets: SearchedDataset[] }) => {
               <Link
                 key={dataset.id}
                 href={`/datasets/${dataset.id}`}
-                className="block w-full sm:w-[350px] shadow hover:shadow-bb2 rounded-lg hover:scale-105 transition duration-500 text-left"
+                className="block w-full sm:w-full shadow hover:shadow-bb2 rounded-lg hover:scale-105 transition duration-500 text-left"
               >
                 <DatasetLink
                   title={dataset.title}
@@ -61,12 +65,8 @@ const RecentDatasets = ({ datasets }: { datasets: SearchedDataset[] }) => {
 function DatasetLink({ title, createdAt, description }: DatasetLinkProps) {
   return (
     <div className="p-5 h-full flex flex-col">
-      <span className="text-info flex items-center mb-2">
-        {new Intl.DateTimeFormat("en-GB", {
-          year: "numeric",
-          month: "short",
-          day: "numeric",
-        }).format(new Date(createdAt))}
+      <span className="text-info flex items-center mb-4">
+        {formatDate(createdAt)}
       </span>
       <h3 className="text-xl text-primary">{title}</h3>
       <div className="flex items-center gap-1 leading-6 tracking-tight pt-2 pb-2">

--- a/src/components/RecentDatasets.tsx
+++ b/src/components/RecentDatasets.tsx
@@ -1,0 +1,83 @@
+// SPDX-FileCopyrightText: 2024 PNED G.I.E.
+// SPDX-License-Identifier: Apache-2.0
+
+import Link from "next/link";
+import { SearchedDataset } from "@/services/discovery/types/dataset.types";
+import { FontAwesomeIcon } from "@fortawesome/react-fontawesome";
+import { faArrowRight } from "@fortawesome/free-solid-svg-icons";
+
+type DatasetLinkProps = Pick<
+  SearchedDataset,
+  "id" | "title" | "createdAt" | "description"
+>;
+
+const RecentDatasets = ({ datasets }: { datasets: SearchedDataset[] }) => {
+  const sortedDatasets = [...datasets]
+    .sort(
+      (a, b) =>
+        new Date(b.createdAt).getTime() - new Date(a.createdAt).getTime()
+    )
+    .slice(0, 4);
+
+  return (
+    <div className="bg-white sm:p-4 rounded-lg pb-28 sm:pb-28 w-full">
+      <div className="custom-container lg:px-3">
+        <div className="flex flex-col items-center w-full">
+          <div className="flex flex-col sm:flex-row w-full justify-between pb-8 sm:pb-2">
+            <h2 className="mb-4 text-2xl font-bold text-primary">
+              Most Recent Datasets
+            </h2>
+          </div>
+          <div className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 xl:grid-cols-4 gap-8 justify-center">
+            {sortedDatasets.map((dataset) => (
+              <Link
+                key={dataset.id}
+                href={`/datasets/${dataset.id}`}
+                className="block w-full sm:w-[350px] shadow hover:shadow-bb2 rounded-lg hover:scale-105 transition duration-500 text-left"
+              >
+                <DatasetLink
+                  id={dataset.id}
+                  title={dataset.title}
+                  createdAt={dataset.createdAt}
+                  description={dataset.description}
+                />
+              </Link>
+            ))}
+          </div>
+        </div>
+        <div className="flex justify-end mt-8">
+          <Link
+            href="/datasets"
+            className="flex items-center gap-1 transition hover:underline duration-1000 text-primary"
+          >
+            See all
+            <FontAwesomeIcon icon={faArrowRight} className="w-5 h-5" />
+          </Link>
+        </div>
+      </div>
+    </div>
+  );
+};
+
+function DatasetLink({ id, title, createdAt, description }: DatasetLinkProps) {
+  return (
+    <div className="p-5 h-full flex flex-col">
+      <span className="text-info flex items-center mb-2">
+        {new Intl.DateTimeFormat("en-GB", {
+          year: "numeric",
+          month: "short",
+          day: "numeric",
+        }).format(new Date(createdAt))}
+      </span>
+      <h3 className="text-xl text-primary">{title}</h3>
+      <div className="flex items-center gap-1 leading-6 tracking-tight pt-2 pb-2">
+        <p className="mb-4 text-xs md:text-base">{description}</p>
+      </div>
+      <div className="mt-auto text-primary flex items-center gap-1 transition hover:underline duration-1000">
+        Read More <FontAwesomeIcon icon={faArrowRight} className="w-5 h-5" />
+      </div>
+    </div>
+  );
+}
+
+export default RecentDatasets;

--- a/src/components/RecentDatasets.tsx
+++ b/src/components/RecentDatasets.tsx
@@ -8,7 +8,7 @@ import { faArrowRight } from "@fortawesome/free-solid-svg-icons";
 
 type DatasetLinkProps = Pick<
   SearchedDataset,
-  "id" | "title" | "createdAt" | "description"
+  "title" | "createdAt" | "description"
 >;
 
 const RecentDatasets = ({ datasets }: { datasets: SearchedDataset[] }) => {
@@ -36,7 +36,6 @@ const RecentDatasets = ({ datasets }: { datasets: SearchedDataset[] }) => {
                 className="block w-full sm:w-[350px] shadow hover:shadow-bb2 rounded-lg hover:scale-105 transition duration-500 text-left"
               >
                 <DatasetLink
-                  id={dataset.id}
                   title={dataset.title}
                   createdAt={dataset.createdAt}
                   description={dataset.description}
@@ -59,7 +58,7 @@ const RecentDatasets = ({ datasets }: { datasets: SearchedDataset[] }) => {
   );
 };
 
-function DatasetLink({ id, title, createdAt, description }: DatasetLinkProps) {
+function DatasetLink({ title, createdAt, description }: DatasetLinkProps) {
   return (
     <div className="p-5 h-full flex flex-col">
       <span className="text-info flex items-center mb-2">

--- a/src/components/RecentDatasets.tsx
+++ b/src/components/RecentDatasets.tsx
@@ -6,7 +6,6 @@ import { SearchedDataset } from "@/services/discovery/types/dataset.types";
 import { FontAwesomeIcon } from "@fortawesome/react-fontawesome";
 import { faArrowRight } from "@fortawesome/free-solid-svg-icons";
 import { formatDate } from "@/utils/formatDate";
-import { useMemo } from "react";
 
 type DatasetLinkProps = Pick<
   SearchedDataset,
@@ -14,30 +13,21 @@ type DatasetLinkProps = Pick<
 >;
 
 const RecentDatasets = ({ datasets }: { datasets: SearchedDataset[] }) => {
-  const sortedDatasets = useMemo(() => {
-    return [...datasets]
-      .sort(
-        (a, b) =>
-          new Date(b.createdAt).getTime() - new Date(a.createdAt).getTime()
-      )
-      .slice(0, 4);
-  }, [datasets]);
-
   return (
     <div className="bg-white sm:p-4 rounded-lg pb-28 sm:pb-28 w-full">
       <div className="custom-container lg:px-3">
         <div className="flex flex-col items-center w-full">
           <div className="flex flex-col sm:flex-row w-full justify-between pb-8 sm:pb-2">
-            <h2 className="mb-4 text-2xl font-bold text-primary">
+            <h2 className="mb-4 text-2xl font-bold text-primary text-center sm:text-left">
               Most Recent Datasets
             </h2>
           </div>
           <div className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 xl:grid-cols-4 gap-8 justify-center">
-            {sortedDatasets.map((dataset) => (
+            {datasets.map((dataset) => (
               <Link
                 key={dataset.id}
                 href={`/datasets/${dataset.id}`}
-                className="block w-full sm:w-full shadow hover:shadow-bb2 rounded-lg hover:scale-105 transition duration-500 text-left"
+                className="bg-white py-6 flex items-center justify-center rounded-lg shadow-lg border-b-4 border-b-[#B5BFC4] hover:border-b-secondary transition hover:bg-gray-50 text-left"
               >
                 <DatasetLink
                   title={dataset.title}
@@ -68,9 +58,11 @@ function DatasetLink({ title, createdAt, description }: DatasetLinkProps) {
       <span className="text-info flex items-center mb-4">
         {formatDate(createdAt)}
       </span>
-      <h3 className="text-xl text-primary">{title}</h3>
+      <h3 className="text-xl text-primary truncate-lines-1">{title}</h3>
       <div className="flex items-center gap-1 leading-6 tracking-tight pt-2 pb-2">
-        <p className="mb-4 text-xs md:text-base">{description}</p>
+        <p className="mb-4 text-xs md:text-base truncate-lines-3">
+          {description}
+        </p>
       </div>
       <div className="mt-auto text-primary flex items-center gap-1 transition hover:underline duration-1000">
         Read More <FontAwesomeIcon icon={faArrowRight} className="w-5 h-5" />


### PR DESCRIPTION
<img width="1674" alt="Screenshot 2024-07-16 at 16 23 44" src="https://github.com/user-attachments/assets/67a1adb8-dbb8-48e4-9ad2-0b147b788b61">
<!-- Generated by sourcery-ai[bot]: start summary -->

## Summary by Sourcery

This pull request introduces a new 'RecentDatasets' component to display the most recent datasets on the homepage. The homepage has been updated to integrate this new component, replacing the previous placeholder.

- **New Features**:
    - Added a new component 'RecentDatasets' to display the most recent datasets on the homepage.
- **Enhancements**:
    - Integrated the 'RecentDatasets' component into the homepage, replacing the placeholder for recent datasets.

<!-- Generated by sourcery-ai[bot]: end summary -->