### PR TITLE
feat: #274 display themes on homepage

### DIFF
--- a/src/app/Footer.tsx
+++ b/src/app/Footer.tsx
@@ -36,8 +36,8 @@ function Footer() {
           <FontAwesomeIcon icon={faArrowRight} className="ml-2 text-warning" />
         </a>
       </div>
-      <footer className="flex flex-col items-center justify-between gap-y-4 border-t-primary bg-surface p-7 md:flex-row md:gap-x-12 md:gap-y-0 md:items-start">
-        <div className="flex flex-col gap-16 md:flex-row md:gap-24">
+      <footer className="flex flex-col items-center bg-surface justify-center gap-y-4 border-t-primary p-7 md:flex-row md:gap-x-12 md:gap-y-0">
+        <div className="container mx-auto flex flex-col gap-16 md:flex-row md:gap-24">
           {/* First column: About the project */}
           <div className="flex flex-col items-start gap-4">
             <Image src={footerLogo} alt="Footer logo" width={80} />

--- a/src/app/about/page.tsx
+++ b/src/app/about/page.tsx
@@ -77,7 +77,7 @@ const AboutPage: React.FC = () => {
         </a>
         .
       </p>
-      <p className="mt-4">
+      <p className="my-6">
         Please report any problems you find in{" "}
         <a
           href="https://github.com/GenomicDataInfrastructure/gdi-userportal-frontend/issues"

--- a/src/app/datasets/page.tsx
+++ b/src/app/datasets/page.tsx
@@ -180,7 +180,7 @@ export default function DatasetPage() {
             <div className="col-start-0 col-span-12 xl:col-span-8 xl:col-start-5">
               <DatasetList datasets={response.datasets!} />
             </div>
-            <div className="col-start-0 col-span-12 mt-10 xl:col-span-8 xl:col-start-5">
+            <div className="col-start-0 col-span-12 my-10 xl:col-span-8 xl:col-start-5">
               <PaginationContainer
                 datasetCount={response.datasetCount!}
                 datasetPerPage={DATASET_PER_PAGE}

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -56,22 +56,24 @@ const HomePage = () => {
           {serverConfig.homepageSubtitle}
         </h2>
       </div>
-      <div className="flex justify-center mb-24">
+      <div className="flex justify-center mb-8">
         <div className="w-full lg:w-4/5 xl:w-3/4">
           <SearchBar queryParams={queryParams} size="large" />
         </div>
       </div>
-
-      <ThemesSection maxThemes={12} />
-
-      <div className="mb-20 relative text-left flex items-center">
+      <div className="flex justify-center mb-12">
+        <div className="w-[305px] md:w-full">
+          <ThemesSection maxThemes={12} />
+        </div>
+      </div>
+      <div className="relative text-left flex items-center px-16">
         <div
           className="absolute inset-0 bg-cover bg-center"
           style={{
             backgroundImage: `url(${aboutBackground.src})`,
           }}
         ></div>
-        <div className="relative z-10 w-full md:w-3/4 lg:w-2/3 xl:w-3/5 bg-white bg-opacity-75 p-8 rounded-lg min-h-[300px]">
+        <div className="relative z-10 w-full md:w-3/4 lg:w-2/3 xl:w-3/5 bg-white bg-opacity-75 rounded-lg min-h-[300px]">
           <h3 className="mb-4 text-2xl font-bold text-primary">
             About the data portal
           </h3>
@@ -99,8 +101,13 @@ const HomePage = () => {
         </div>
       </div>
 
-      <div className="mb-4">
-        <RecentDatasets datasets={datasets} />
+      <div className="relative text-left flex items-center">
+        <div className="relative z-10 w-full my-8 px-16">
+          <h3 className="mb-4 text-2xl font-bold text-primary">
+            Most Recent Datasets
+          </h3>
+          <RecentDatasets datasets={datasets} />
+        </div>
       </div>
     </PageContainer>
   );

--- a/src/components/Header/index.tsx
+++ b/src/components/Header/index.tsx
@@ -80,149 +80,156 @@ function Header() {
   }
 
   return (
-    <div className="flex w-full items-center justify-between bg-surface px-4">
-      <div className="flex justify-between gap-x-8 md:gap-x-12 lg:gap-x-24">
-        <Link href="/">
-          <Image
-            src={logo}
-            alt="Logo"
-            className="mb-4 mt-4"
-            width={`${
-              screenSize === SCREEN_SIZE.SM || screenSize === SCREEN_SIZE.MD
-                ? "158"
-                : "190"
-            }`}
-            height={`${
-              screenSize === SCREEN_SIZE.SM || screenSize === SCREEN_SIZE.MD
-                ? "57"
-                : "69"
-            }`}
-          />
-        </Link>
-        <div className="hidden items-center gap-x-3 text-base font-semibold text-primary sm:flex lg:text-lg">
-          <Link
-            href="/"
-            className={`rounded-lg border-[1.5px] border-surface px-3 py-1 transition-colors duration-300 hover:border-hover-color lg:px-7 ${
-              activeTab === "/" ? "bg-primary text-white" : ""
-            }`}
-          >
-            Home
-          </Link>
-          <Link
-            href="/datasets"
-            className={`rounded-lg border-[1.5px] border-surface px-3 py-1 transition-colors duration-300 hover:border-hover-color lg:px-7 ${
-              activeTab.includes("datasets") ? "bg-primary text-white" : ""
-            }`}
-          >
-            Datasets
-          </Link>
-          <Link
-            href="/about"
-            className={`rounded-lg border-[1.5px] border-surface px-3 py-1 transition-colors duration-300 hover:border-hover-color lg:px-7 ${
-              activeTab === "/about" ? "bg-primary text-white" : ""
-            }`}
-          >
-            About
-          </Link>
-        </div>
-      </div>
-      <div className="mr-3 hidden items-center gap-x-5 sm:flex md:gap-x-8">
-        {!isLoading && (
-          <Link
-            href="/basket"
-            className={`relative flex items-center text-info hover:text-hover-color ${
-              activeTab.includes("basket") ? "text-primary" : ""
-            }`}
-          >
-            <FontAwesomeIcon
-              icon={faShoppingCart}
-              className="text-xl lg:text-2xl"
-            />
-            {basket.length > 0 && (
-              <span className="absolute right-0 top-0 inline-flex -translate-y-1/2 translate-x-1/2 transform items-center justify-center rounded-full bg-primary px-2 py-1 text-xs font-bold leading-none text-red-100">
-                {basket.length}
-              </span>
+    <div className="bg-surface">
+      <div className="container mx-auto ">
+        <div className="flex items-center justify-between px-4">
+          <div className="flex justify-between gap-x-5 md:gap-x-12 lg:gap-x-24">
+            <Link href="/">
+              <Image
+                src={logo}
+                alt="Logo"
+                className="mb-4 mt-4"
+                width={`${
+                  screenSize === SCREEN_SIZE.SM || screenSize === SCREEN_SIZE.MD
+                    ? "158"
+                    : "190"
+                }`}
+                height={`${
+                  screenSize === SCREEN_SIZE.SM || screenSize === SCREEN_SIZE.MD
+                    ? "57"
+                    : "69"
+                }`}
+              />
+            </Link>
+            <div className="hidden items-center gap-x-3 text-base font-semibold text-primary sm:flex lg:text-lg">
+              <Link
+                href="/"
+                className={`rounded-lg border-[1.5px] border-surface px-3 py-1 transition-colors duration-300 hover:border-hover-color lg:px-7 ${
+                  activeTab === "/" ? "bg-primary text-white" : ""
+                }`}
+              >
+                Home
+              </Link>
+              <Link
+                href="/datasets"
+                className={`rounded-lg border-[1.5px] border-surface px-3 py-1 transition-colors duration-300 hover:border-hover-color lg:px-7 ${
+                  activeTab.includes("datasets") ? "bg-primary text-white" : ""
+                }`}
+              >
+                Datasets
+              </Link>
+              <Link
+                href="/about"
+                className={`rounded-lg border-[1.5px] border-surface px-3 py-1 transition-colors duration-300 hover:border-hover-color lg:px-7 ${
+                  activeTab === "/about" ? "bg-primary text-white" : ""
+                }`}
+              >
+                About
+              </Link>
+            </div>
+          </div>
+          <div className="mr-3 hidden items-center gap-x-5 sm:flex md:gap-x-8">
+            {!isLoading && (
+              <Link
+                href="/basket"
+                className={`relative flex items-center text-info hover:text-hover-color ${
+                  activeTab.includes("basket") ? "text-primary" : ""
+                }`}
+              >
+                <FontAwesomeIcon
+                  icon={faShoppingCart}
+                  className="text-xl lg:text-2xl"
+                />
+                {basket.length > 0 && (
+                  <span className="absolute right-0 top-0 inline-flex -translate-y-1/2 translate-x-1/2 transform items-center justify-center rounded-full bg-primary px-2 py-1 text-xs font-bold leading-none text-red-100">
+                    {basket.length}
+                  </span>
+                )}
+              </Link>
             )}
-          </Link>
-        )}
-        {loginBtn}
-      </div>
+            {loginBtn}
+          </div>
 
-      <div className="menu-container relative sm:hidden">
-        <button
-          onClick={() => setIsMenuOpen(!isMenuOpen)}
-          className="text-primary focus:outline-none"
-        >
-          <FontAwesomeIcon icon={faBars} className="text-xl" />
-        </button>
-        {isMenuOpen && (
-          <div className="absolute right-0 z-10 mt-2 w-48 origin-top-right rounded-md bg-white shadow-lg">
-            {session && (
-              <div className="border-b-[1.5px] border-surface px-4 py-2">
-                <FontAwesomeIcon icon={faUser} className="mr-2" />
-                {session?.user?.name}
+          <div className="menu-container relative sm:hidden">
+            <button
+              onClick={() => setIsMenuOpen(!isMenuOpen)}
+              className="text-primary focus:outline-none"
+            >
+              <FontAwesomeIcon icon={faBars} className="text-xl" />
+            </button>
+            {isMenuOpen && (
+              <div className="absolute right-0 z-10 mt-2 w-48 origin-top-right rounded-md bg-white shadow-lg">
+                {session && (
+                  <div className="border-b-[1.5px] border-surface px-4 py-2">
+                    <FontAwesomeIcon icon={faUser} className="mr-2" />
+                    {session?.user?.name}
+                  </div>
+                )}
+                <Link
+                  href="/"
+                  className="block px-4 py-2 hover:bg-hover-color hover:text-white"
+                  onClick={closeMenu}
+                >
+                  <FontAwesomeIcon icon={faHome} className="mr-2" />
+                  Home
+                </Link>
+                <Link
+                  href="/datasets"
+                  className="block px-4 py-2 hover:bg-hover-color hover:text-white"
+                  onClick={closeMenu}
+                >
+                  <FontAwesomeIcon icon={faDatabase} className="mr-2" />
+                  Datasets
+                </Link>
+                <Link
+                  href="/about"
+                  className="block border-b-[2px] border-surface px-4 py-2 hover:bg-hover-color hover:text-white"
+                  onClick={closeMenu}
+                >
+                  <FontAwesomeIcon icon={faInfoCircle} className="mr-2" />
+                  About
+                </Link>
+                <Link
+                  href="/requests"
+                  className="block px-4 py-2 hover:bg-hover-color hover:text-white"
+                  onClick={closeMenu}
+                >
+                  <FontAwesomeIcon icon={faFolderOpen} className="mr-2" />
+                  Requests
+                </Link>
+                <Link
+                  href="/basket"
+                  className="block border-b-[2px] border-surface px-4 py-2 hover:bg-hover-color hover:text-white"
+                  onClick={closeMenu}
+                >
+                  <FontAwesomeIcon icon={faShoppingCart} className="mr-2" />
+                  {isLoading ? "Basket" : `Basket (${basket.length})`}
+                </Link>
+                {!session && (
+                  <button
+                    onClick={() => signIn("keycloak")}
+                    className="block w-full px-4 py-2 text-left hover:bg-hover-color hover:text-white"
+                  >
+                    <FontAwesomeIcon icon={faRightToBracket} className="mr-2" />
+                    Login
+                  </button>
+                )}
+                {session && (
+                  <button
+                    onClick={handleSignOut}
+                    className="block w-full px-4 py-2 text-left hover:bg-hover-color hover:text-white"
+                  >
+                    <FontAwesomeIcon
+                      icon={faRightFromBracket}
+                      className="mr-2"
+                    />
+                    Logout
+                  </button>
+                )}
               </div>
             )}
-            <Link
-              href="/"
-              className="block px-4 py-2 hover:bg-hover-color hover:text-white"
-              onClick={closeMenu}
-            >
-              <FontAwesomeIcon icon={faHome} className="mr-2" />
-              Home
-            </Link>
-            <Link
-              href="/datasets"
-              className="block px-4 py-2 hover:bg-hover-color hover:text-white"
-              onClick={closeMenu}
-            >
-              <FontAwesomeIcon icon={faDatabase} className="mr-2" />
-              Datasets
-            </Link>
-            <Link
-              href="/about"
-              className="block border-b-[2px] border-surface px-4 py-2 hover:bg-hover-color hover:text-white"
-              onClick={closeMenu}
-            >
-              <FontAwesomeIcon icon={faInfoCircle} className="mr-2" />
-              About
-            </Link>
-            <Link
-              href="/requests"
-              className="block px-4 py-2 hover:bg-hover-color hover:text-white"
-              onClick={closeMenu}
-            >
-              <FontAwesomeIcon icon={faFolderOpen} className="mr-2" />
-              Requests
-            </Link>
-            <Link
-              href="/basket"
-              className="block border-b-[2px] border-surface px-4 py-2 hover:bg-hover-color hover:text-white"
-              onClick={closeMenu}
-            >
-              <FontAwesomeIcon icon={faShoppingCart} className="mr-2" />
-              {isLoading ? "Basket" : `Basket (${basket.length})`}
-            </Link>
-            {!session && (
-              <button
-                onClick={() => signIn("keycloak")}
-                className="block w-full px-4 py-2 text-left hover:bg-hover-color hover:text-white"
-              >
-                <FontAwesomeIcon icon={faRightToBracket} className="mr-2" />
-                Login
-              </button>
-            )}
-            {session && (
-              <button
-                onClick={handleSignOut}
-                className="block w-full px-4 py-2 text-left hover:bg-hover-color hover:text-white"
-              >
-                <FontAwesomeIcon icon={faRightFromBracket} className="mr-2" />
-                Logout
-              </button>
-            )}
           </div>
-        )}
+        </div>
       </div>
     </div>
   );

--- a/src/components/RecentDatasets.tsx
+++ b/src/components/RecentDatasets.tsx
@@ -14,39 +14,32 @@ type DatasetLinkProps = Pick<
 
 const RecentDatasets = ({ datasets }: { datasets: SearchedDataset[] }) => {
   return (
-    <div className="bg-white sm:p-4 rounded-lg pb-28 sm:pb-28 w-full">
-      <div className="custom-container lg:px-3">
-        <div className="flex flex-col items-center w-full">
-          <div className="flex flex-col sm:flex-row w-full justify-between pb-8 sm:pb-2">
-            <h2 className="mb-4 text-2xl font-bold text-primary text-center sm:text-left">
-              Most Recent Datasets
-            </h2>
-          </div>
-          <div className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 xl:grid-cols-4 gap-8 justify-center">
-            {datasets.map((dataset) => (
-              <Link
-                key={dataset.id}
-                href={`/datasets/${dataset.id}`}
-                className="bg-white py-6 flex items-center justify-center rounded-lg shadow-lg border-b-4 border-b-[#B5BFC4] hover:border-b-secondary transition hover:bg-gray-50 text-left"
-              >
-                <DatasetLink
-                  title={dataset.title}
-                  createdAt={dataset.createdAt}
-                  description={dataset.description}
-                />
-              </Link>
-            ))}
-          </div>
+    <div className="bg-white">
+      <div className="flex flex-col items-center w-full">
+        <div className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 xl:grid-cols-4 gap-8 justify-center">
+          {datasets.map((dataset) => (
+            <Link
+              key={dataset.id}
+              href={`/datasets/${dataset.id}`}
+              className="bg-white py-6 flex items-center justify-center rounded-lg shadow-lg border-b-4 border-b-[#B5BFC4] hover:border-b-secondary transition hover:bg-gray-50 text-left"
+            >
+              <DatasetLink
+                title={dataset.title}
+                createdAt={dataset.createdAt}
+                description={dataset.description}
+              />
+            </Link>
+          ))}
         </div>
-        <div className="flex justify-end mt-8">
-          <Link
-            href="/datasets"
-            className="flex items-center gap-1 transition hover:underline duration-1000 text-primary"
-          >
-            See all
-            <FontAwesomeIcon icon={faArrowRight} className="w-5 h-5" />
-          </Link>
-        </div>
+      </div>
+      <div className="flex justify-end mt-12">
+        <Link
+          href="/datasets"
+          className="flex items-center gap-1 transition hover:underline duration-1000 text-primary"
+        >
+          See all
+          <FontAwesomeIcon icon={faArrowRight} className="w-5 h-5" />
+        </Link>
       </div>
     </div>
   );
@@ -60,9 +53,7 @@ function DatasetLink({ title, createdAt, description }: DatasetLinkProps) {
       </span>
       <h3 className="text-xl text-primary truncate-lines-1">{title}</h3>
       <div className="flex items-center gap-1 leading-6 tracking-tight pt-2 pb-2">
-        <p className="mb-4 text-xs md:text-base truncate-lines-3">
-          {description}
-        </p>
+        <p className="mb-4 md:text-base truncate-lines-3">{description}</p>
       </div>
       <div className="mt-auto text-primary flex items-center gap-1 transition hover:underline duration-1000">
         Read More <FontAwesomeIcon icon={faArrowRight} className="w-5 h-5" />

--- a/src/components/ThemesSection.tsx
+++ b/src/components/ThemesSection.tsx
@@ -4,7 +4,6 @@
 import { useRef, useState, useEffect } from "react";
 import { FontAwesomeIcon } from "@fortawesome/react-fontawesome";
 import { faArrowLeft, faArrowRight } from "@fortawesome/free-solid-svg-icons";
-import { useSearchParams } from "next/navigation";
 
 import agricultureImg from "../public/themes/agriculture.svg";
 import economyImg from "../public/themes/economy.svg";

--- a/src/components/ThemesSection.tsx
+++ b/src/components/ThemesSection.tsx
@@ -1,9 +1,12 @@
 // SPDX-FileCopyrightText: 2024 PNED G.I.E.
 // SPDX-License-Identifier: Apache-2.0
 
+import { useRef, useState, useEffect } from "react";
 import { FontAwesomeIcon } from "@fortawesome/react-fontawesome";
-import { faArrowRight } from "@fortawesome/free-solid-svg-icons";
+import { faArrowLeft, faArrowRight } from "@fortawesome/free-solid-svg-icons";
+import { useSearchParams } from "next/navigation";
 
+// Import all theme images
 import agricultureImg from "../public/themes/agriculture.svg";
 import economyImg from "../public/themes/economy.svg";
 import educationImg from "../public/themes/education.svg";
@@ -53,35 +56,70 @@ const allThemes = [
   { name: "Transport", img: transportImg },
 ];
 
-const getThemesFromEnv = () => {
-  const themesEnv = process.env.NEXT_PUBLIC_THEMES_LIST;
-  if (!themesEnv) {
-    return allThemes;
-  }
-
-  try {
-    const themesList = JSON.parse(themesEnv);
-    return allThemes.filter((theme) => themesList.includes(theme.name));
-  } catch (error) {
-    console.error("Error parsing NEXT_PUBLIC_THEMES_LIST:", error);
-    return allThemes;
-  }
-};
-
 const ThemesSection = ({ maxThemes }: { maxThemes?: number }) => {
-  const themes = getThemesFromEnv();
-  const displayedThemes = maxThemes ? themes.slice(0, maxThemes) : themes;
+  const themes = allThemes.slice(0, maxThemes);
+  const containerRef = useRef<HTMLDivElement>(null);
+  const [scrollPosition, setScrollPosition] = useState(0);
+  const [maxScroll, setMaxScroll] = useState(0);
+  const queryParams = useSearchParams();
+
+  const updateMaxScroll = () => {
+    if (containerRef.current) {
+      setMaxScroll(
+        containerRef.current.scrollWidth - containerRef.current.clientWidth
+      );
+    }
+  };
+
+  useEffect(() => {
+    updateMaxScroll();
+    window.addEventListener("resize", updateMaxScroll);
+    return () => {
+      window.removeEventListener("resize", updateMaxScroll);
+    };
+  }, []);
+
+  const handleScroll = (direction: "left" | "right") => {
+    const container = containerRef.current;
+    if (!container) return;
+
+    const scrollAmount = 202;
+
+    if (direction === "left") {
+      container.scrollTo({
+        left: scrollPosition - scrollAmount,
+        behavior: "smooth",
+      });
+      setScrollPosition((prev) => Math.max(prev - scrollAmount, 0));
+    } else {
+      container.scrollTo({
+        left: scrollPosition + scrollAmount,
+        behavior: "smooth",
+      });
+      setScrollPosition((prev) => Math.min(prev + scrollAmount, maxScroll));
+    }
+  };
 
   return (
-    <section className="mb-20">
-      <div className="grid grid-cols-2 sm:grid-cols-3 md:grid-cols-4 lg:grid-cols-5 xl:grid-cols-6 gap-4">
-        {displayedThemes.map((theme) => (
+    <section className="mx-12 my-4 flex flex-col items-center relative">
+      <button
+        className="absolute left-[-40px] z-10 p-2 bg-white border rounded-full shadow-md hover:border-b-secondary transition hover:bg-gray-50"
+        onClick={() => handleScroll("left")}
+        style={{ top: "50%", transform: "translateY(-50%)" }}
+        disabled={scrollPosition === 0}
+      >
+        <FontAwesomeIcon icon={faArrowLeft} />
+      </button>
+      <div
+        className="flex space-x-4 px-4 overflow-x-hidden"
+        ref={containerRef}
+        style={{ scrollBehavior: "smooth", maxWidth: "100%" }}
+      >
+        {themes.map((theme) => (
           <a
             key={theme.name}
-            className="bg-white py-6 flex items-center justify-center px-2 rounded-lg h-[166px] shadow-lg border-b-4 border-b-[#B5BFC4] hover:border-b-secondary transition hover:bg-gray-50"
-            href={`/datasets?group=${theme.name
-              .toLowerCase()
-              .replace(/\s+/g, "_")}`}
+            className="flex-none bg-white py-6 flex items-center justify-center px-2 rounded-lg w-[184px] h-[166px] shadow-lg border-b-4 border-b-[#B5BFC4] hover:border-b-secondary transition hover:bg-gray-50"
+            href={`/datasets?page=1&ckan-theme=${(theme.desc || theme.name).toLowerCase().replace(/[\s,]+/g, "-")}`}
           >
             <div className="flex flex-col justify-center items-center text-center">
               <img
@@ -91,20 +129,21 @@ const ThemesSection = ({ maxThemes }: { maxThemes?: number }) => {
                 height="48"
               />
               <h3 className="font-semibold text-lg sm:mt-1">{theme.name}</h3>
-              <div className="leading-4 max-w-[8.5rem]">{theme.desc}</div>
+              {theme.desc && (
+                <div className="leading-4 max-w-[8.5rem]">{theme.desc}</div>
+              )}
             </div>
           </a>
         ))}
       </div>
-      <div className="pt-4 px-8 sm:px-0 w-full flex">
-        <a
-          className="text-primary flex items-center gap-1 transition hover:underline duration-500 ml-auto"
-          href="/themes"
-        >
-          See all
-          <FontAwesomeIcon icon={faArrowRight} className="w-4 h-4" />
-        </a>
-      </div>
+      <button
+        className="absolute right-[-50px] z-10 p-2 bg-white border rounded-full shadow-md hover:border-b-secondary transition hover:bg-gray-50"
+        onClick={() => handleScroll("right")}
+        style={{ top: "50%", transform: "translateY(-50%)" }}
+        disabled={scrollPosition >= maxScroll}
+      >
+        <FontAwesomeIcon icon={faArrowRight} />
+      </button>
     </section>
   );
 };

--- a/src/components/ThemesSection.tsx
+++ b/src/components/ThemesSection.tsx
@@ -6,7 +6,6 @@ import { FontAwesomeIcon } from "@fortawesome/react-fontawesome";
 import { faArrowLeft, faArrowRight } from "@fortawesome/free-solid-svg-icons";
 import { useSearchParams } from "next/navigation";
 
-// Import all theme images
 import agricultureImg from "../public/themes/agriculture.svg";
 import economyImg from "../public/themes/economy.svg";
 import educationImg from "../public/themes/education.svg";
@@ -61,7 +60,6 @@ const ThemesSection = ({ maxThemes }: { maxThemes?: number }) => {
   const containerRef = useRef<HTMLDivElement>(null);
   const [scrollPosition, setScrollPosition] = useState(0);
   const [maxScroll, setMaxScroll] = useState(0);
-  const queryParams = useSearchParams();
 
   const updateMaxScroll = () => {
     if (containerRef.current) {


### PR DESCRIPTION
<img width="1122" alt="Screenshot 2024-07-22 at 08 31 39" src="https://github.com/user-attachments/assets/9218bcfb-53bc-41f3-a4a2-159590d93a92">

- fixed themes are now clickable
- made the themes scroll
- centred the footed and the header
- fixed the padding between the footer and the main page
- removed extra padding

<!-- Generated by sourcery-ai[bot]: start summary -->

## Summary by Sourcery

This pull request enhances the homepage by making the themes section clickable and scrollable, centering the footer and header, and adjusting padding for a cleaner layout.

- **New Features**:
    - Introduced clickable and scrollable themes section on the homepage.
- **Enhancements**:
    - Centered the footer and header for better alignment.
    - Adjusted padding between the footer and the main page for improved layout.
    - Removed extra padding to streamline the design.

<!-- Generated by sourcery-ai[bot]: end summary -->