### PR TITLE
feat: #261 made support fields uneditable

### DIFF
--- a/src/app/applications/[id]/DateField.tsx
+++ b/src/app/applications/[id]/DateField.tsx
@@ -29,7 +29,7 @@ function DateField({ formId, field, title, editable }: DateFieldProps) {
       if (newValue !== field.value) {
         updateInputFields(formId, field.id, newValue);
       }
-    }, 2000);
+    }, 500);
 
     return () => clearTimeout(timeoutId);
   }, [inputValue, formId, field.id, field.value, updateInputFields]);

--- a/src/app/applications/[id]/DateField.tsx
+++ b/src/app/applications/[id]/DateField.tsx
@@ -14,9 +14,10 @@ type DateFieldProps = {
   field: FormField;
   formId: number;
   title: string;
+  editable: boolean;
 };
 
-function DateField({ formId, field, title }: DateFieldProps) {
+function DateField({ formId, field, title, editable }: DateFieldProps) {
   const { updateInputFields } = useApplicationDetails();
   const [inputValue, setInputValue] = useState<Date | null>(
     field.value ? new Date(field.value) : null
@@ -37,6 +38,8 @@ function DateField({ formId, field, title }: DateFieldProps) {
     setInputValue(date);
   };
 
+  const isDisabled = !editable;
+
   return (
     <div className="rounded border p-4">
       <div className="flex flex-col justify-between">
@@ -48,12 +51,13 @@ function DateField({ formId, field, title }: DateFieldProps) {
         <DatePicker
           selected={inputValue}
           onChange={handleDateChange}
-          className="mt-4 h-12 w-full rounded-lg border-2 border-primary px-4 py-[9px] text-base shadow-sm transition-all duration-200 ease-in-out hover:shadow-md focus:border-transparent focus:outline-none focus:ring-2 focus:ring-primary"
+          className={`mt-4 h-12 w-full rounded-lg border-2 border-primary px-4 py-[9px] text-base shadow-sm transition-all duration-200 ease-in-out ${isDisabled ? "border-info bg-background ring-offset-background placeholder:text-muted-foreground focus-visible:ring-ring flex text-sm file:border-0 file:bg-transparent file:font-medium file:text-sm focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-offset-2 disabled:cursor-not-allowed disabled:opacity-50" : "bg-white hover:shadow-md focus:border-transparent focus:outline-none focus:ring-2 focus:ring-primary"}`}
           placeholderText="dd/mm/yyyy"
           dateFormat="dd/MM/yyyy"
           calendarClassName="rounded-lg shadow-lg p-2"
           dayClassName={() => "p-2 rounded-full hover:bg-blue-200"}
           popperPlacement="bottom-start"
+          disabled={isDisabled}
         />
       </div>
     </div>

--- a/src/app/applications/[id]/EmailField.tsx
+++ b/src/app/applications/[id]/EmailField.tsx
@@ -11,9 +11,10 @@ type EmailFieldProps = {
   field: FormField;
   formId: number;
   title: string;
+  editable: boolean;
 };
 
-function EmailField({ field, formId, title }: EmailFieldProps) {
+function EmailField({ field, formId, title, editable }: EmailFieldProps) {
   return (
     <GenericInputField
       field={field}
@@ -21,6 +22,7 @@ function EmailField({ field, formId, title }: EmailFieldProps) {
       type="email"
       placeholder="Enter your email address"
       title={title}
+      editable={editable}
     />
   );
 }

--- a/src/app/applications/[id]/FieldContainer.tsx
+++ b/src/app/applications/[id]/FieldContainer.tsx
@@ -15,9 +15,10 @@ import PhoneField from "./PhoneField";
 type FieldContainerProps = {
   formId: number;
   field: FormField;
+  editable: boolean;
 };
 
-function FieldContainer({ formId, field }: FieldContainerProps) {
+function FieldContainer({ formId, field, editable }: FieldContainerProps) {
   const fieldTitle =
     field.title.find((label) => label.language === "en")?.name ||
     field.title[0].name;
@@ -26,22 +27,58 @@ function FieldContainer({ formId, field }: FieldContainerProps) {
     switch (field.type) {
       case FieldType.ATTACHMENT:
         return (
-          <FileUploadField field={field} formId={formId} title={fieldTitle} />
+          <FileUploadField
+            field={field}
+            formId={formId}
+            title={fieldTitle}
+            editable={editable}
+          />
         );
       case FieldType.TEXT:
         return (
-          <InputFormField field={field} formId={formId} title={fieldTitle} />
+          <InputFormField
+            field={field}
+            formId={formId}
+            title={fieldTitle}
+            editable={editable}
+          />
         );
       case FieldType.TEXT_AREA:
         return (
-          <TextAreaFormField field={field} formId={formId} title={fieldTitle} />
+          <TextAreaFormField
+            field={field}
+            formId={formId}
+            title={fieldTitle}
+            editable={editable}
+          />
         );
       case FieldType.PHONE:
-        return <PhoneField field={field} formId={formId} title={fieldTitle} />;
+        return (
+          <PhoneField
+            field={field}
+            formId={formId}
+            title={fieldTitle}
+            editable={editable}
+          />
+        );
       case FieldType.DATE:
-        return <DateField field={field} formId={formId} title={fieldTitle} />;
+        return (
+          <DateField
+            field={field}
+            formId={formId}
+            title={fieldTitle}
+            editable={editable}
+          />
+        );
       case FieldType.EMAIL:
-        return <EmailField field={field} formId={formId} title={fieldTitle} />;
+        return (
+          <EmailField
+            field={field}
+            formId={formId}
+            title={fieldTitle}
+            editable={editable}
+          />
+        );
     }
   }
 

--- a/src/app/applications/[id]/FileUploadFormField.tsx
+++ b/src/app/applications/[id]/FileUploadFormField.tsx
@@ -12,9 +12,15 @@ type FileUploadFieldProps = {
   field: FormField;
   formId: number;
   title: string;
+  editable: boolean;
 };
 
-function FileUploadFormField({ field, formId, title }: FileUploadFieldProps) {
+function FileUploadFormField({
+  field,
+  formId,
+  title,
+  editable,
+}: FileUploadFieldProps) {
   const { application, isLoading, addAttachment } = useApplicationDetails();
 
   function onFileUpload(e: React.ChangeEvent<HTMLInputElement>) {
@@ -37,14 +43,14 @@ function FileUploadFormField({ field, formId, title }: FileUploadFieldProps) {
           <input
             type="file"
             id={`input-file-${field.id}`}
-            disabled={isLoading}
+            disabled={isLoading || !editable}
             onChange={onFileUpload}
             className="hidden"
           />
           <label
             htmlFor={`input-file-${field.id}`}
             className={`cursor-pointer rounded-lg bg-info p-2 py-2 text-[9px] font-bold tracking-wide text-white transition-colors duration-200 hover:opacity-80 sm:w-auto sm:px-4 sm:text-xs ${
-              isLoading ? "cursor-not-allowed opacity-10" : ""
+              isLoading || !editable ? "cursor-not-allowed opacity-50" : ""
             }`}
           >
             <FontAwesomeIcon icon={faPlusCircle} className="mr-2" />

--- a/src/app/applications/[id]/FormContainer.tsx
+++ b/src/app/applications/[id]/FormContainer.tsx
@@ -7,9 +7,10 @@ import FieldContainer from "./FieldContainer";
 
 type FormContainerProps = {
   form: Form;
+  editable: boolean;
 };
 
-function FormContainer({ form }: FormContainerProps) {
+function FormContainer({ form, editable }: FormContainerProps) {
   const formTitle =
     form.externalTitle.find((label) => label.language === "en")?.name ||
     form.externalTitle?.[0]?.name;
@@ -22,7 +23,11 @@ function FormContainer({ form }: FormContainerProps) {
           (field) =>
             field && (
               <li key={field.id}>
-                <FieldContainer formId={form.id} field={field} />
+                <FieldContainer
+                  formId={form.id}
+                  field={field}
+                  editable={editable}
+                />
               </li>
             )
         )}

--- a/src/app/applications/[id]/GenericInputField.tsx
+++ b/src/app/applications/[id]/GenericInputField.tsx
@@ -13,6 +13,7 @@ type GenericInputFieldProps = {
   type: string;
   placeholder: string;
   title: string;
+  editable: boolean;
   onChange?: (value: string) => void;
   children?: React.ReactNode;
 };
@@ -23,6 +24,7 @@ function GenericInputField({
   type,
   placeholder,
   title,
+  editable,
   onChange,
   children,
 }: GenericInputFieldProps) {
@@ -46,6 +48,8 @@ function GenericInputField({
     }
   };
 
+  const isDisabled = !editable || isLoading;
+
   return (
     <div className="rounded border p-4">
       <div className="flex flex-col justify-between">
@@ -62,9 +66,9 @@ function GenericInputField({
             name={field.id.toString()}
             value={inputValue}
             onChange={handleInputChange}
-            className="h-12 w-full rounded-lg border-2 border-primary px-4 py-[9px] shadow-sm transition-all duration-200 ease-in-out hover:shadow-md focus:border-transparent focus:outline-none focus:ring-2 focus:ring-primary"
+            className={`h-12 w-full rounded-lg border-2 border-primary px-4 py-[9px] shadow-sm transition-all duration-200 ease-in-out hover:shadow-md focus:border-transparent focus:outline-none focus:ring-2 focus:ring-primary ${isDisabled ? "border-info bg-background ring-offset-background placeholder:text-muted-foreground focus-visible:ring-ring flex text-sm file:border-0 file:bg-transparent file:font-medium file:text-sm focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-offset-2 disabled:cursor-not-allowed disabled:opacity-50" : "bg-white hover:shadow-md focus:border-transparent focus:outline-none focus:ring-2 focus:ring-primary"}`}
             placeholder={placeholder}
-            disabled={isLoading}
+            disabled={!editable || isLoading}
           />
         </div>
       </div>

--- a/src/app/applications/[id]/GenericInputField.tsx
+++ b/src/app/applications/[id]/GenericInputField.tsx
@@ -36,7 +36,7 @@ function GenericInputField({
       if (inputValue !== field.value) {
         updateInputFields(formId, field.id, inputValue);
       }
-    }, 2000);
+    }, 500);
 
     return () => clearTimeout(timeoutId);
   }, [inputValue, formId, field, updateInputFields]);

--- a/src/app/applications/[id]/InputFormField.tsx
+++ b/src/app/applications/[id]/InputFormField.tsx
@@ -11,9 +11,15 @@ type InputFormFieldProps = {
   field: FormField;
   formId: number;
   title: string;
+  editable: boolean;
 };
 
-function InputFormField({ formId, field, title }: InputFormFieldProps) {
+function InputFormField({
+  formId,
+  field,
+  title,
+  editable,
+}: InputFormFieldProps) {
   return (
     <GenericInputField
       field={field}
@@ -21,6 +27,7 @@ function InputFormField({ formId, field, title }: InputFormFieldProps) {
       type="text"
       placeholder={title}
       title={title}
+      editable={editable}
     />
   );
 }

--- a/src/app/applications/[id]/PhoneField.tsx
+++ b/src/app/applications/[id]/PhoneField.tsx
@@ -25,7 +25,7 @@ function PhoneField({ formId, field, title, editable }: PhoneFieldProps) {
       if (inputValue !== field.value) {
         updateInputFields(formId, field.id, inputValue);
       }
-    }, 2000);
+    }, 500);
 
     return () => clearTimeout(timeoutId);
   }, [inputValue, formId, field, updateInputFields]);

--- a/src/app/applications/[id]/PhoneField.tsx
+++ b/src/app/applications/[id]/PhoneField.tsx
@@ -13,9 +13,10 @@ type PhoneFieldProps = {
   field: FormField;
   formId: number;
   title: string;
+  editable: boolean;
 };
 
-function PhoneField({ formId, field, title }: PhoneFieldProps) {
+function PhoneField({ formId, field, title, editable }: PhoneFieldProps) {
   const { updateInputFields } = useApplicationDetails();
   const [inputValue, setInputValue] = useState(field.value);
 
@@ -62,6 +63,7 @@ function PhoneField({ formId, field, title }: PhoneFieldProps) {
             onChange={handlePhoneChange}
             onBlur={handlePhoneBlur}
             className="flex w-full"
+            disabled={!editable}
           />
         </div>
       </div>

--- a/src/app/applications/[id]/TextAreaFormField.tsx
+++ b/src/app/applications/[id]/TextAreaFormField.tsx
@@ -29,7 +29,7 @@ function TextAreaFormField({
       if (inputValue !== field.value) {
         updateInputFields(formId, field.id, inputValue);
       }
-    }, 2000);
+    }, 500);
 
     return () => clearTimeout(timeoutId);
   }, [inputValue, formId, field, updateInputFields]);

--- a/src/app/applications/[id]/TextAreaFormField.tsx
+++ b/src/app/applications/[id]/TextAreaFormField.tsx
@@ -12,9 +12,15 @@ type TextAreaFormFieldProps = {
   field: FormField;
   formId: number;
   title: string;
+  editable: boolean;
 };
 
-function TextAreaFormField({ formId, field, title }: TextAreaFormFieldProps) {
+function TextAreaFormField({
+  formId,
+  field,
+  title,
+  editable,
+}: TextAreaFormFieldProps) {
   const { isLoading, updateInputFields } = useApplicationDetails();
   const [inputValue, setInputValue] = useState(field.value);
 
@@ -32,6 +38,8 @@ function TextAreaFormField({ formId, field, title }: TextAreaFormFieldProps) {
     setInputValue(event.target.value);
   };
 
+  const isDisabled = !editable || isLoading;
+
   return (
     <div className="rounded border p-4">
       <div className="flex flex-col justify-between">
@@ -44,9 +52,9 @@ function TextAreaFormField({ formId, field, title }: TextAreaFormFieldProps) {
           placeholder={title}
           rows={5}
           value={inputValue}
-          className="mt-4 w-full rounded-lg border-2 border-primary px-4 py-[9px] shadow-sm transition-all duration-200 ease-in-out hover:shadow-md focus:border-transparent focus:outline-none focus:ring-2 focus:ring-primary"
+          className={`mt-4 w-full rounded-lg border-2 border-primary px-4 py-[9px] shadow-sm transition-all duration-200 ease-in-out ${isDisabled ? "border-info bg-background ring-offset-background placeholder:text-muted-foreground focus-visible:ring-ring flex text-sm file:border-0 file:bg-transparent file:font-medium file:text-sm focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-offset-2 disabled:cursor-not-allowed disabled:opacity-50" : "bg-white hover:shadow-md focus:border-transparent focus:outline-none focus:ring-2 focus:ring-primary"}`}
           onChange={handleInputChange}
-          disabled={isLoading}
+          disabled={isDisabled}
         />
       </div>
     </div>

--- a/src/app/applications/[id]/page.tsx
+++ b/src/app/applications/[id]/page.tsx
@@ -71,6 +71,7 @@ export default function ApplicationDetailsPage() {
   const events = application.events;
   const lastEvent = events[0];
   const sidebarItems = createApplicationSidebarItems(application);
+  const editable = isApplicationEditable(application);
 
   return (
     <PageContainer>
@@ -95,7 +96,7 @@ export default function ApplicationDetailsPage() {
               )}
             </div>
             <div className="mt-4 flex gap-x-3 sm:mt-0">
-              {isApplicationEditable(application) && (
+              {editable && (
                 <Button
                   type="primary"
                   text="Submit"
@@ -121,7 +122,7 @@ export default function ApplicationDetailsPage() {
                 (form) =>
                   form && (
                     <li key={form.id}>
-                      <FormContainer form={form} />
+                      <FormContainer form={form} editable={editable} />
                     </li>
                   )
               )}

--- a/src/components/PhoneInput.tsx
+++ b/src/components/PhoneInput.tsx
@@ -46,19 +46,24 @@ const PhoneInput = forwardRef<
 ));
 PhoneInput.displayName = "PhoneInput";
 
-const InputComponent = forwardRef<HTMLInputElement, InputProps>(
-  ({ className, ...props }, ref) => (
-    <Input
-      className={cn(
-        "h-12 w-full rounded-md border-2 border-primary px-4 py-[9px] shadow-sm transition-all duration-200 ease-in-out hover:shadow-md focus:border-transparent focus:outline-none focus:ring-2 focus:ring-primary",
-        className,
-        "ml-2"
-      )}
-      ref={ref}
-      {...props}
-    />
-  )
-);
+const InputComponent = forwardRef<
+  HTMLInputElement,
+  InputProps & { disabled?: boolean }
+>(({ className, disabled, ...props }, ref) => (
+  <Input
+    className={cn(
+      "h-12 w-full rounded-md border-2 px-4 py-[9px] shadow-sm transition-all duration-200 ease-in-out focus:border-transparent focus:outline-none focus:ring-2",
+      disabled
+        ? "border-info bg-background text-muted-foreground cursor-not-allowed opacity-50"
+        : "border-primary bg-white hover:shadow-md focus:ring-primary",
+      className,
+      "ml-2"
+    )}
+    ref={ref}
+    {...props}
+    disabled={disabled}
+  />
+));
 InputComponent.displayName = "InputComponent";
 
 type CountrySelectOption = { label: string; value: RPNInput.Country };
@@ -97,7 +102,8 @@ const CountrySelect = forwardRef<HTMLDivElement, CountrySelectProps>(
             type="button"
             variant="outline"
             className={cn(
-              "flex h-12 items-center gap-1 rounded-l-md border-2 border-primary px-3"
+              "flex h-12 items-center gap-1 rounded-l-md border-2 px-3",
+              disabled ? "border-info" : "border-primary"
             )}
             disabled={disabled}
           >

--- a/src/components/shadcn/command.tsx
+++ b/src/components/shadcn/command.tsx
@@ -20,7 +20,7 @@ const Command = React.forwardRef<
   <CommandPrimitive
     ref={ref}
     className={cn(
-      "bg-popover text-popover-foreground flex h-full w-full flex-col overflow-hidden rounded-md",
+      "bg-white flex h-full w-full flex-col overflow-hidden rounded-md",
       className
     )}
     {...props}
@@ -57,7 +57,7 @@ const CommandInput = React.forwardRef<
     <CommandPrimitive.Input
       ref={ref}
       className={cn(
-        "placeholder:text-muted-foreground flex h-11 w-full rounded-md bg-transparent py-3 text-sm outline-none disabled:cursor-not-allowed disabled:opacity-50",
+        "placeholder:text-gray-500 flex h-11 w-full rounded-md bg-transparent py-3 text-sm outline-none disabled:cursor-not-allowed disabled:opacity-50 text-black",
         className
       )}
       {...props}
@@ -74,7 +74,7 @@ const CommandList = React.forwardRef<
   <CommandPrimitive.List
     ref={ref}
     className={cn(
-      "max-h-[300px] overflow-y-auto overflow-x-hidden border border-gray-300 bg-white text-info",
+      "max-h-[300px] overflow-y-auto overflow-x-hidden bg-white border border-gray-300 text-info",
       className
     )}
     {...props}
@@ -103,7 +103,7 @@ const CommandGroup = React.forwardRef<
   <CommandPrimitive.Group
     ref={ref}
     className={cn(
-      "text-foreground [&_[cmdk-group-heading]]:text-muted-foreground overflow-hidden p-1 [&_[cmdk-group-heading]]:px-2 [&_[cmdk-group-heading]]:py-1.5 [&_[cmdk-group-heading]]:font-medium [&_[cmdk-group-heading]]:text-xs",
+      "text-info [&_[cmdk-group-heading]]:text-gray-500 overflow-hidden p-1 [&_[cmdk-group-heading]]:px-2 [&_[cmdk-group-heading]]:py-1.5 [&_[cmdk-group-heading]]:font-medium [&_[cmdk-group-heading]]:text-xs bg-white border-b border-gray-300",
       className
     )}
     {...props}
@@ -118,7 +118,7 @@ const CommandSeparator = React.forwardRef<
 >(({ className, ...props }, ref) => (
   <CommandPrimitive.Separator
     ref={ref}
-    className={cn("-mx-1 h-px bg-gray-300", className)}
+    className={cn("bg-gray-300 -mx-1 h-px", className)}
     {...props}
   />
 ));
@@ -131,7 +131,7 @@ const CommandItem = React.forwardRef<
   <CommandPrimitive.Item
     ref={ref}
     className={cn(
-      "aria-selected:bg-accent aria-selected:text-accent-foreground relative flex cursor-default select-none items-center rounded-sm px-2 py-1.5 text-sm outline-none data-[disabled]:pointer-events-none data-[disabled]:opacity-50",
+      "aria-selected:bg-gray-100 aria-selected:text-black relative flex cursor-default select-none items-center rounded-sm px-2 py-1.5 text-sm outline-none text-info hover:text-black hover:bg-gray-100",
       className
     )}
     {...props}
@@ -146,10 +146,7 @@ const CommandShortcut = ({
 }: React.HTMLAttributes<HTMLSpanElement>) => {
   return (
     <span
-      className={cn(
-        "text-muted-foreground ml-auto text-xs tracking-widest",
-        className
-      )}
+      className={cn("text-gray-500 ml-auto text-xs tracking-widest", className)}
       {...props}
     />
   );


### PR DESCRIPTION
<img width="1441" alt="Screenshot 2024-07-25 at 18 07 39" src="https://github.com/user-attachments/assets/f09143cd-3ba5-4db4-ab3c-59e1dd3df9c2">

fixed filter's side bar not working
add support fields are now visually looking uneditable

<!-- Generated by sourcery-ai[bot]: start summary -->

## Summary by Sourcery

This pull request addresses a bug with the filter's sidebar and enhances the form fields by making support fields uneditable. The changes include adding an 'editable' prop to various form field components and updating their styles to reflect the uneditable state.

- **Bug Fixes**:
    - Fixed the issue with the filter's sidebar not working.
- **Enhancements**:
    - Made support fields visually uneditable by introducing an 'editable' prop to various form field components and updating their styles accordingly.

<!-- Generated by sourcery-ai[bot]: end summary -->