### PR TITLE
fix: #355 session always expires after 5 min

### DIFF
--- a/src/app/api/auth/config.ts
+++ b/src/app/api/auth/config.ts
@@ -21,7 +21,7 @@ export const authOptions: NextAuthOptions = {
   ],
   callbacks: {
     async jwt({ token, account }: JWTCallbackEntry) {
-      const currTimestamp = Math.floor(Date.now() / 1000);
+      const currTimestamp = Math.floor(Date.now() / 1000 - 60);
       const isTokenExpired = (token?.expires_at as number) < currTimestamp;
 
       if (account) {


### PR DESCRIPTION
the session was expiring at the same time as the refresh token happened so a buffer between them was needed, tested it works now

<!-- Generated by sourcery-ai[bot]: start summary -->

## Summary by Sourcery

This pull request addresses a bug where user sessions were expiring prematurely due to the session expiration coinciding with the refresh token expiration. A buffer has been added to the expiration timestamp to resolve this issue.

- **Bug Fixes**:
    - Fixed an issue where the session was expiring at the same time as the refresh token by adding a buffer to the expiration timestamp.

<!-- Generated by sourcery-ai[bot]: end summary -->