### PR TITLE
fix: #364 error of missing timezone in console

### DIFF
--- a/src/app/datasets/[id]/DatasetMetadata.tsx
+++ b/src/app/datasets/[id]/DatasetMetadata.tsx
@@ -1,3 +1,7 @@
+// SPDX-FileCopyrightText: 2024 PNED G.I.E.
+//
+// SPDX-License-Identifier: Apache-2.0
+
 "use client";
 
 import { useEffect, useState } from "react";

--- a/src/app/datasets/[id]/DatasetMetadata.tsx
+++ b/src/app/datasets/[id]/DatasetMetadata.tsx
@@ -12,7 +12,7 @@ import {
   faLanguage,
   faIdBadge,
 } from "@fortawesome/free-solid-svg-icons";
-import { formatDate, formatDateTime } from "@/utils/formatDate";
+import { formatDate } from "@/utils/formatDate";
 import {
   RetrievedDataset,
   DatasetRelationship,

--- a/src/app/datasets/[id]/DatasetMetadata.tsx
+++ b/src/app/datasets/[id]/DatasetMetadata.tsx
@@ -1,9 +1,6 @@
-// SPDX-FileCopyrightText: 2024 PNED G.I.E.
-//
-// SPDX-License-Identifier: Apache-2.0
-
 "use client";
 
+import { useEffect, useState } from "react";
 import { FontAwesomeIcon } from "@fortawesome/react-fontawesome";
 import {
   faSyncAlt,
@@ -15,7 +12,7 @@ import {
   faLanguage,
   faIdBadge,
 } from "@fortawesome/free-solid-svg-icons";
-import { formatDate } from "@/utils/formatDate";
+import { formatDate, formatDateTime } from "@/utils/formatDate";
 import {
   RetrievedDataset,
   DatasetRelationship,
@@ -39,6 +36,21 @@ const DatasetMetadata = ({
   relationships: DatasetRelationship[];
   dictionary: DatasetDictionaryEntry[];
 }) => {
+  const [userTimezone, setUserTimezone] = useState<string | null>(null);
+
+  useEffect(() => {
+    try {
+      const timezone = Intl.DateTimeFormat().resolvedOptions().timeZone;
+      setUserTimezone(timezone);
+    } catch (error) {
+      console.error("Error fetching user timezone", error);
+    }
+  }, []);
+
+  if (userTimezone === null) {
+    return null;
+  }
+
   return (
     <>
       <div className="flex flex-col sm:flex-row sm:flex-wrap gap-3 font-[400] text-gray">

--- a/src/utils/__tests__/formatDate.test.ts
+++ b/src/utils/__tests__/formatDate.test.ts
@@ -51,16 +51,18 @@ describe("formatDate and formatDateTime", () => {
   });
 
   describe("Server-side behavior", () => {
-    it("returns the formatted date in UTC if formatDate is called server-side", () => {
+    it("throws an error if formatDate is called server-side", () => {
       const input = "2024-02-09T10:27:47.585Z";
-      const formattedDate = formatDate(input);
-      expect(formattedDate).toBe("9 February 2024");
+      expect(() => formatDate(input)).toThrow(
+        "getUserTimezone must be called on the client side"
+      );
     });
 
-    it("returns the formatted date and time in UTC if formatDateTime is called server-side", () => {
+    it("throws an error if formatDateTime is called server-side", () => {
       const input = "2024-02-09T10:27:47.585Z";
-      const formattedDateTime = formatDateTime(input);
-      expect(formattedDateTime).toBe("9 February 2024, 10.27 (UTC)");
+      expect(() => formatDateTime(input)).toThrow(
+        "getUserTimezone must be called on the client side"
+      );
     });
   });
 });

--- a/src/utils/formatDate.ts
+++ b/src/utils/formatDate.ts
@@ -19,7 +19,7 @@ export function formatDateTime(inputDate: string) {
 
 function getUserTimezone() {
   if (!isClient()) {
-    return "UTC";
+    throw new Error("getUserTimezone must be called on the client side");
   }
 
   return Intl.DateTimeFormat().resolvedOptions().timeZone;


### PR DESCRIPTION
<!-- Generated by sourcery-ai[bot]: start summary -->

## Summary by Sourcery

Fix the missing timezone error in the console by fetching and setting the user's timezone. Update the `getUserTimezone` function to throw an error if called server-side, and adjust related tests to ensure proper client-side usage.

Bug Fixes:
- Fix the error of missing timezone in the console by ensuring the user's timezone is fetched and set correctly.

Enhancements:
- Update the `getUserTimezone` function to throw an error if called server-side, ensuring it is only used on the client side.

Tests:
- Modify tests for `formatDate` and `formatDateTime` to check for errors when these functions are called server-side, ensuring proper client-side usage.

<!-- Generated by sourcery-ai[bot]: end summary -->