### PR TITLE
feat: #363 display contact points

### DIFF
--- a/src/app/datasets/[id]/sidebarItems.tsx
+++ b/src/app/datasets/[id]/sidebarItems.tsx
@@ -85,21 +85,40 @@ function createDatasetSidebarItems(dataset: RetrievedDataset): SidebarItem[] {
           <h1 className="font-bold">Contact Point(s)</h1>
           <div className="flex items-center text-[14px]">
             <div className="flex flex-col gap-1">
-              {dataset.contacts.map((contact, index) => (
+              {dataset.contacts.length === 0 ? (
                 <>
-                  <div key={index} className="flex gap-8 items-center">
+                  <div className="flex gap-8 items-center">
                     <FontAwesomeIcon icon={faUser} className="text-primary" />
-                    <p>{contact.name || "No contact provided."}</p>
+                    <p>No contact provided.</p>
                   </div>
                   <div className="flex gap-8 items-center">
                     <FontAwesomeIcon
                       icon={faEnvelope}
                       className="text-primary"
                     />
-                    <p>{contact.email || "No e-mail provided."}</p>
+                    <p>No e-mail provided.</p>
                   </div>
                 </>
-              ))}
+              ) : (
+                dataset.contacts.map((contact, index) => (
+                  <>
+                    <div key={index} className="flex gap-8 items-center">
+                      <FontAwesomeIcon icon={faUser} className="text-primary" />
+                      <p>{contact.name || "No contact provided."}</p>
+                    </div>
+                    <div
+                      key={`${index}-email`}
+                      className="flex gap-8 items-center"
+                    >
+                      <FontAwesomeIcon
+                        icon={faEnvelope}
+                        className="text-primary"
+                      />
+                      <p>{contact.email || "No e-mail provided."}</p>
+                    </div>
+                  </>
+                ))
+              )}
             </div>
           </div>
         </div>

--- a/src/app/datasets/[id]/sidebarItems.tsx
+++ b/src/app/datasets/[id]/sidebarItems.tsx
@@ -84,18 +84,22 @@ function createDatasetSidebarItems(dataset: RetrievedDataset): SidebarItem[] {
         >
           <h1 className="font-bold">Contact Point(s)</h1>
           <div className="flex items-center text-[14px]">
-            <div className="h-20 w-20 flex justify-left items-center">
-              {dataset.catalogue /* Optionally add organization logo here */}
-            </div>
             <div className="flex flex-col gap-1">
-              <div className="flex gap-2 items-center">
-                <FontAwesomeIcon icon={faUser} className="text-primary" />
-                <p>{dataset.contact?.label || "No contact provided."}</p>
-              </div>
-              <div className="flex gap-2 items-center">
-                <FontAwesomeIcon icon={faEnvelope} className="text-primary" />
-                <p>{dataset.contact?.value || "No e-mail provided."}</p>
-              </div>
+              {dataset.contacts.map((contact, index) => (
+                <>
+                  <div key={index} className="flex gap-8 items-center">
+                    <FontAwesomeIcon icon={faUser} className="text-primary" />
+                    <p>{contact.name || "No contact provided."}</p>
+                  </div>
+                  <div className="flex gap-8 items-center">
+                    <FontAwesomeIcon
+                      icon={faEnvelope}
+                      className="text-primary"
+                    />
+                    <p>{contact.email || "No e-mail provided."}</p>
+                  </div>
+                </>
+              ))}
             </div>
           </div>
         </div>

--- a/src/services/discovery/types/dataset.types.ts
+++ b/src/services/discovery/types/dataset.types.ts
@@ -15,7 +15,7 @@ export interface RetrievedDataset {
   modifiedAt: string;
   url: string;
   languages: ValueLabel[];
-  contact: ValueLabel;
+  contacts: ContactPoint[];
   hasVersions: ValueLabel[];
   accessRights: ValueLabel;
   conformsTo: ValueLabel[];
@@ -66,4 +66,9 @@ export interface DatasetDictionaryEntry {
   field_name: string;
   data_type: string;
   description: string;
+}
+
+export interface ContactPoint {
+  name: string;
+  email: string;
 }


### PR DESCRIPTION
<img width="1307" alt="Screenshot 2024-08-06 at 14 24 19" src="https://github.com/user-attachments/assets/303e8d7b-2f5c-4031-8e52-df63af1fb847">
<img width="1317" alt="Screenshot 2024-08-06 at 14 25 36" src="https://github.com/user-attachments/assets/6c3e8e16-9b47-40ea-9933-489d80b0dfc7">

<!-- Generated by sourcery-ai[bot]: start summary -->

## Summary by Sourcery

Add support for displaying multiple contact points in the dataset sidebar and update the dataset type definition to include multiple contact points.

New Features:
- Display multiple contact points for datasets in the sidebar.

Enhancements:
- Refactor dataset contact information to support multiple contact points.

<!-- Generated by sourcery-ai[bot]: end summary -->