### PR TITLE
fix: ignore rejectUnauthorized in if explicitly stated in env

### DIFF
--- a/src/services/discovery/datasetList.ts
+++ b/src/services/discovery/datasetList.ts
@@ -4,12 +4,25 @@
 
 import { ExtendedSession } from "@/app/api/auth/auth.types";
 import axios, { AxiosResponse } from "axios";
+import https from "https";
 import {
   DatasetSearchOptions,
   DatasetSearchQuery,
   DatasetsSearchResponse,
 } from "./types/datasetSearch.types";
 import { createHeaders } from "./utils";
+
+const axiosInstance = axios.create({
+  baseURL: process.env.API_URL || "",
+});
+
+if (process.env.NODE_IGNORE_SSL) {
+  const httpsAgent = new https.Agent({
+    rejectUnauthorized: false,
+  });
+  axiosInstance.defaults.httpsAgent = httpsAgent;
+  console.log("Development mode: RejectUnauthorized is disabled.");
+}
 
 export const makeDatasetList = (discoveryUrl: string) => {
   return async (
@@ -25,12 +38,23 @@ export const makeDatasetList = (discoveryUrl: string) => {
       operator: options.operator,
     } as DatasetSearchQuery;
 
-    return await axios.post<DatasetsSearchResponse>(
-      `${discoveryUrl}/api/v1/datasets/search`,
-      datasetSearchQuery,
-      {
-        headers: await createHeaders(session),
+    try {
+      return await axiosInstance.post<DatasetsSearchResponse>(
+        `${discoveryUrl}/api/v1/datasets/search`,
+        datasetSearchQuery,
+        {
+          headers: await createHeaders(session),
+        }
+      );
+    } catch (exception) {
+      if (axios.isAxiosError(exception)) {
+        console.log("Error Status:", exception.response?.status);
+        console.log("Error Headers:", exception.response?.headers);
+        console.log("Error Data:", exception.response?.data);
+      } else {
+        console.log("Non-Axios Error:", exception);
       }
-    );
+      throw exception;
+    }
   };
 };


### PR DESCRIPTION
in datasetlist:

ignore rejectUnauthorized in if explicitly stated in env
improve exception handing

<!-- Generated by sourcery-ai[bot]: start summary -->

## Summary by Sourcery

Modify the dataset list service to conditionally disable SSL certificate validation based on an environment variable and enhance error handling with detailed logging for Axios errors.

Bug Fixes:
- Ignore the 'rejectUnauthorized' setting in HTTPS requests if explicitly stated in the environment variable 'NODE_IGNORE_SSL'.

Enhancements:
- Improve exception handling in the dataset list service by adding detailed logging for Axios errors, including status, headers, and data.

<!-- Generated by sourcery-ai[bot]: end summary -->