### PR TITLE
fix: Phone number onChange event

### DIFF
--- a/src/app/applications/[id]/PhoneField.tsx
+++ b/src/app/applications/[id]/PhoneField.tsx
@@ -39,7 +39,6 @@ function PhoneField({
 
   const handlePhoneChange = (value: string) => {
     setInputValue(value);
-    field.value = value;
   };
 
   const handlePhoneBlur = () => {


### PR DESCRIPTION
This seems to be have been placed by mistake. Normally we never assign field value directly. It will be done through action creators of redux

<!-- Generated by sourcery-ai[bot]: start summary -->

## Summary by Sourcery

Fix the onChange event in the PhoneField component by removing the direct assignment of the field value, aligning with the Redux state management approach.

Bug Fixes:
- Remove direct assignment of field value in PhoneField component to ensure proper state management through Redux action creators.

<!-- Generated by sourcery-ai[bot]: end summary -->