### PR TITLE
feat: remove image from organization page

### DIFF
--- a/src/components/PublisherList.tsx
+++ b/src/components/PublisherList.tsx
@@ -5,7 +5,6 @@ import Link from "next/link";
 import { RetrievedPublisher } from "@/services/discovery/types/dataset.types";
 import { FontAwesomeIcon } from "@fortawesome/react-fontawesome";
 import { faArrowRight, faDatabase } from "@fortawesome/free-solid-svg-icons";
-import buildingImg from "../public/building.svg";
 
 interface PublisherListProps {
   publishers: RetrievedPublisher[];
@@ -24,18 +23,6 @@ const PublisherList: React.FC<PublisherListProps> = ({ publishers }) => {
               className="bg-white py-4 flex flex-col items-start justify-start rounded-lg shadow-lg border-b-4 border-b-[#B5BFC4] hover:border-b-secondary transition hover:bg-gray-50 text-left"
               style={{ maxWidth: "260px" }}
             >
-              <div className="w-full h-24 mb-3 flex justify-center items-center">
-                {/* {org.imageUrl ? (
-                  <img src={org.imageUrl} alt={org.name} className="w-full h-full object-cover rounded-t-lg" />
-                ) : (
-                  <img src={buildingImg.src} alt={org.name} className="w-24 h-24 object-cover" />
-                )} */}
-                <img
-                  src={buildingImg.src}
-                  alt={org.name}
-                  className="w-20 h-20 text-primary"
-                />
-              </div>
               <div className="p-4 h-full flex flex-col">
                 <h3 className="text-lg truncate-lines-1 font-medium mb-1">
                   {org.title}


### PR DESCRIPTION
<img width="1633" alt="Screenshot 2024-08-23 at 09 45 55" src="https://github.com/user-attachments/assets/7814f7f3-8630-4601-8446-943f7794a1ab">


a bit dull but cant do anything about that! 