### PR TITLE
fix not needed underline in md files

### DIFF
--- a/src/components/MarkdownRenderer.tsx
+++ b/src/components/MarkdownRenderer.tsx
@@ -23,7 +23,7 @@ const MarkdownRenderer: React.FC<MarkdownRendererProps> = ({ content }) => {
       components={{
         h1: ({ ...props }) => (
           <h1
-            className="text-left font-medium text-2xl sm:text-3xl mb-6 underline decoration-primary underline-offset-8"
+            className="text-left font-medium text-2xl sm:text-3xl mb-6 decoration-primary"
             {...props}
           />
         ),


### PR DESCRIPTION
<!-- Generated by sourcery-ai[bot]: start summary -->

## Summary by Sourcery

Fix the issue of unnecessary underline in h1 elements within the MarkdownRenderer component by removing the underline class.

Bug Fixes:
- Remove unnecessary underline from h1 elements in MarkdownRenderer component.

<!-- Generated by sourcery-ai[bot]: end summary -->