### PR TITLE
fix: keywords showing Dataset Card

### DIFF
--- a/src/components/DatasetCard.tsx
+++ b/src/components/DatasetCard.tsx
@@ -109,7 +109,7 @@ function DatasetCard({ dataset }: Readonly<DatasetCardProps>) {
         </div>
       </div>
       <div className="mt-6 flex justify-between items-center pr-2">
-        <Chips chips={dataset.themes?.map((x) => x.label) || []} />
+        <Chips chips={dataset.keywords?.map((x) => x.label) || []} />
         <Button
           text={isInBasket ? "Remove from basket" : "Add to basket"}
           icon={isInBasket ? faMinusCircle : faPlusCircle}

--- a/src/services/discovery/types/dataset.types.ts
+++ b/src/services/discovery/types/dataset.types.ts
@@ -33,6 +33,7 @@ export type SearchedDataset = {
   title: string;
   description?: string;
   themes?: ValueLabel[];
+  keywords: ValueLabel[];
   organization: RetrievedPublisher;
   modifiedAt: string;
   createdAt: string;


### PR DESCRIPTION
Blocked by: https://github.com/GenomicDataInfrastructure/gdi-userportal-dataset-discovery-service/pull/114

Before:
<img width="1070" alt="Screenshot 2024-09-11 at 12 30 09" src="https://github.com/user-attachments/assets/8860cc9e-78a6-4977-9490-b0470d4a51ab">


After:
<img width="1110" alt="Screenshot 2024-09-11 at 12 29 57" src="https://github.com/user-attachments/assets/6e54220f-1f4b-4bd7-a0d1-28a871784f99">

<!-- Generated by sourcery-ai[bot]: start summary -->

## Summary by Sourcery

Fix the Dataset Card component to display keywords instead of themes by updating the data mapping and type definition.

Bug Fixes:
- Fix the display of keywords instead of themes in the Dataset Card component.

<!-- Generated by sourcery-ai[bot]: end summary -->