### PR TITLE
feat: add distributions to dataset card and fix error layout

### DIFF
--- a/src/app/datasets/DatasetListContainer.tsx
+++ b/src/app/datasets/DatasetListContainer.tsx
@@ -28,7 +28,11 @@ export default function DatasetListContainer() {
       </div>
     );
   } else if (errorCode) {
-    return <Error statusCode={errorCode} />;
+    return (
+      <div className="col-start-0 col-span-12 xl:col-span-8 xl:col-start-5">
+        <Error statusCode={errorCode} />
+      </div>
+    );
   }
 
   return (

--- a/src/app/datasets/[id]/DatasetMetadata.tsx
+++ b/src/app/datasets/[id]/DatasetMetadata.tsx
@@ -158,7 +158,9 @@ const DatasetMetadata = ({
                 className="align-middle text-primary "
               />
               <span className="align-middle">
-                {dataset.distributions.length} Distribution(s)
+                {dataset.distributions.length > 1
+                  ? `${dataset.distributions.length} Distributions`
+                  : `${dataset.distributions.length} Distribution`}
               </span>
               <Tooltip message="Number of distributions available for the dataset." />
             </span>

--- a/src/components/DatasetCard.tsx
+++ b/src/components/DatasetCard.tsx
@@ -16,6 +16,7 @@ import {
   faUser,
   faBookBookmark,
   faThLarge,
+  faFile,
 } from "@fortawesome/free-solid-svg-icons";
 import { FontAwesomeIcon } from "@fortawesome/react-fontawesome";
 import Link from "next/link";
@@ -90,6 +91,14 @@ function DatasetCard({ dataset }: Readonly<DatasetCardProps>) {
               </div>
               <span>Published by {dataset.organization.title}</span>
             </div>
+            {dataset.distributions?.length > 0 && (
+              <div className="flex gap-x-2.5 pl-2 sm:pl-2 sm:border-l-[2px] sm:border-l-info">
+                <div className="my-auto">
+                  <FontAwesomeIcon icon={faFile} className="text-primary" />
+                </div>
+                <span> {dataset.distributions.length} Distribution(s)</span>
+              </div>
+            )}
             {dataset.recordsCount && dataset.recordsCount > 0 && (
               <div className="flex gap-x-2.5 pl-2 sm:pl-2 sm:border-l-[2px] sm:border-l-info">
                 <div className="my-auto">

--- a/src/components/DatasetCard.tsx
+++ b/src/components/DatasetCard.tsx
@@ -96,7 +96,11 @@ function DatasetCard({ dataset }: Readonly<DatasetCardProps>) {
                 <div className="my-auto">
                   <FontAwesomeIcon icon={faFile} className="text-primary" />
                 </div>
-                <span> {dataset.distributions.length} Distribution(s)</span>
+                <span>
+                  {dataset.distributions.length > 1
+                    ? `${dataset.distributions.length} Distributions`
+                    : `${dataset.distributions.length} Distribution`}
+                </span>
               </div>
             )}
             {dataset.recordsCount && dataset.recordsCount > 0 && (

--- a/src/services/discovery/types/dataset.types.ts
+++ b/src/services/discovery/types/dataset.types.ts
@@ -34,6 +34,7 @@ export type SearchedDataset = {
   description?: string;
   themes?: ValueLabel[];
   keywords: ValueLabel[];
+  distributions: RetrievedDistribution[];
   organization: RetrievedPublisher;
   modifiedAt: string;
   createdAt: string;


### PR DESCRIPTION
<img width="1362" alt="image" src="https://github.com/user-attachments/assets/377b35bd-5b26-4ecd-8ac2-c9a7ef4d1a88"><img width="1739" alt="Screenshot 2024-09-12 at 10 28 33" src="https://github.com/user-attachments/assets/8f46069c-d824-4fc7-a484-b7971549d46e">

before it was like this the error:
<img width="765" alt="Screenshot 2024-09-12 at 08 40 53" src="https://github.com/user-attachments/assets/f579e859-f881-4723-98ca-5d09de1ee4ae">

<!-- Generated by sourcery-ai[bot]: start summary -->

## Summary by Sourcery

Introduce a feature to display distributions in the dataset card and correct the error message layout in the dataset list container.

New Features:
- Add a section to display the number of distributions in the dataset card if available.

Bug Fixes:
- Fix the layout of the error message in the dataset list container to ensure proper alignment.

<!-- Generated by sourcery-ai[bot]: end summary -->