### PR TITLE
fix: the overflow of themes in dataset card and removing the icon

### DIFF
--- a/src/app/datasets/[id]/page.tsx
+++ b/src/app/datasets/[id]/page.tsx
@@ -7,8 +7,6 @@ import PageContainer from "@/components/PageContainer";
 import { datasetGet } from "@/services/discovery";
 import ClientSidebar from "./ClientSidebar";
 import DatasetMetadata from "./DatasetMetadata";
-import { FontAwesomeIcon } from "@fortawesome/react-fontawesome";
-import { faThLarge } from "@fortawesome/free-solid-svg-icons";
 import Tooltip from "./Tooltip";
 import axios from "axios";
 
@@ -27,10 +25,6 @@ export default async function Page({ params }: { params: { id: string } }) {
           <div className="flex w-full flex-col gap-5 lg:w-2/3 lg:px-5">
             {dataset.themes && dataset.themes.length > 0 && (
               <div className="tracking-widest uppercase flex items-center text-[14px] relative group">
-                <FontAwesomeIcon
-                  icon={faThLarge}
-                  className="text-primary mr-2"
-                />
                 {dataset.themes.map((theme) => theme.label).join("  |  ")}
                 <Tooltip message="Themes associated with the dataset." />
               </div>

--- a/src/components/DatasetCard.tsx
+++ b/src/components/DatasetCard.tsx
@@ -15,7 +15,6 @@ import {
   faCalendarAlt,
   faUser,
   faBookBookmark,
-  faThLarge,
   faFile,
 } from "@fortawesome/free-solid-svg-icons";
 import { FontAwesomeIcon } from "@fortawesome/react-fontawesome";
@@ -56,8 +55,7 @@ function DatasetCard({ dataset }: Readonly<DatasetCardProps>) {
       <div className="flex flex-col lg:flex-row gap-x-2 gap-y-4">
         <div className="flex flex-col gap-y-2 shrink w-full lg:w-[90%] lg:pr-4">
           {dataset.themes && dataset.themes.length > 0 && (
-            <div className="flex gap-2 font-normal text-sm sm:text-[12px] leading-[12px] uppercase pb-2">
-              <FontAwesomeIcon icon={faThLarge} className="text-primary" />
+            <div className="flex flex-wrap gap-2 font-normal text-sm sm:text-[12px] leading-[12px] uppercase pb-2">
               {dataset.themes?.map((theme, index) => (
                 <span
                   key={index}


### PR DESCRIPTION
<!-- Generated by sourcery-ai[bot]: start summary -->

## Summary by Sourcery

Fix the overflow issue of themes in the dataset card by using flex-wrap and remove the FontAwesome icon for a cleaner appearance.

Bug Fixes:
- Fix the overflow issue of themes in the dataset card by adjusting the layout to use flex-wrap.

Enhancements:
- Remove the FontAwesome icon from the themes display in the dataset card for a cleaner look.

<!-- Generated by sourcery-ai[bot]: end summary -->