### PR TITLE
ART-9681/Display selected filters on top of the dataset cards

### DIFF
--- a/src/app/datasets/FilterList/ClearFilterButton.tsx
+++ b/src/app/datasets/FilterList/ClearFilterButton.tsx
@@ -40,7 +40,7 @@ export default function ClearFilterButton({
   }
 
   return (
-    <div className="mt-4 flex justify-end">
+    <div className="flex justify-end">
       {isAnyGroupFilterApplied() && (
         <Button
           href={`/datasets?page=1${getQueryStringWithoutGroupFilter()}`}

--- a/src/app/datasets/FilterList/FilterItem.tsx
+++ b/src/app/datasets/FilterList/FilterItem.tsx
@@ -58,7 +58,7 @@ function FilterItem({ field, label, data, groupKey }: FilterItemProps) {
                 <span className="text-base px-1.5">
                   {label}
                   {options.length > 0 && (
-                    <span className="text-info">
+                    <span className="text-info mx-1">
                       ({options.length} filter{options.length > 1 ? "s" : ""}{" "}
                       applied)
                     </span>

--- a/src/app/datasets/FilterList/index.tsx
+++ b/src/app/datasets/FilterList/index.tsx
@@ -8,17 +8,12 @@ import {
 } from "@/utils/convertDataToFilterItemProps";
 import FilterItem from "./FilterItem";
 import { Facet } from "@/services/discovery/types/facets.type";
-import ClearFilterButton from "./ClearFilterButton";
 
 type FilterListProps = {
   searchFacets: Facet[];
 };
 
 export default async function FilterList({ searchFacets }: FilterListProps) {
-  const facetGroups = Array.from(
-    new Set(searchFacets.map((facet) => facet.facetGroup))
-  );
-
   const filterItemProps: FilterItemProps[] = convertDataToFilterItemProps(
     searchFacets
   ).sort((f1, f2) => f2.groupKey.localeCompare(f1.groupKey));
@@ -35,7 +30,6 @@ export default async function FilterList({ searchFacets }: FilterListProps) {
           />
         </li>
       ))}
-      <ClearFilterButton facetGroups={facetGroups} />
     </div>
   );
 }

--- a/src/app/datasets/NoDatasetMessage.tsx
+++ b/src/app/datasets/NoDatasetMessage.tsx
@@ -1,0 +1,34 @@
+// SPDX-FileCopyrightText: 2024 PNED G.I.E.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+"use client";
+
+import React from "react";
+import { useDatasets } from "@/providers/datasets/DatasetsProvider";
+import { useSearchParams } from "next/navigation";
+
+export default function NoDatasetMessage() {
+  const { datasetCount, isLoading } = useDatasets();
+  const searchParams = useSearchParams();
+
+  const hasAppliedFilters = React.useMemo(() => {
+    if (!searchParams) return false;
+    return Array.from(searchParams.entries()).some(
+      ([key]) => key !== "page" && key.includes("-")
+    );
+  }, [searchParams]);
+
+  if (isLoading || datasetCount !== 0 || !hasAppliedFilters) {
+    return null;
+  }
+
+  return (
+    <div className="text-center py-8 mt-4">
+      <p className="text-lg text-primary mb-4">
+        No datasets found matching your criteria. Try adjusting your search or
+        filters.
+      </p>
+    </div>
+  );
+}

--- a/src/app/datasets/page.tsx
+++ b/src/app/datasets/page.tsx
@@ -12,6 +12,8 @@ import { redirect } from "next/navigation";
 import { GET } from "../api/facets/route";
 import { Facet } from "@/services/discovery/types/facets.type";
 import Error from "@/app/error";
+import AppliedFilters from "@/components/AppliedFilters";
+import NoDatasetMessage from "./NoDatasetMessage";
 
 export default async function DatasetsPage({
   searchParams,
@@ -47,7 +49,11 @@ export default async function DatasetsPage({
               <FilterList searchFacets={searchFacets} />
             </div>
           </div>
-          <DatasetListContainer />
+          <div className="col-span-12 xl:col-span-8">
+            <AppliedFilters searchFacets={searchFacets} />
+            <NoDatasetMessage />
+            <DatasetListContainer />
+          </div>
         </DatasetsProvider>
       </div>
     </PageContainer>

--- a/src/components/AppliedFilters.tsx
+++ b/src/components/AppliedFilters.tsx
@@ -1,0 +1,108 @@
+/* SPDX-FileCopyrightText: 2024 PNED G.I.E. */
+
+/* SPDX-License-Identifier: Apache-2.0 */
+"use client";
+
+import React from "react";
+import { useSearchParams, useRouter } from "next/navigation";
+import { FontAwesomeIcon } from "@fortawesome/react-fontawesome";
+import { faTimes } from "@fortawesome/free-solid-svg-icons";
+import ClearFilterButton from "@/app/datasets/FilterList/ClearFilterButton";
+import {
+  FilterItemProps,
+  convertDataToFilterItemProps,
+} from "@/utils/convertDataToFilterItemProps";
+import { Facet } from "@/services/discovery/types/facets.type";
+
+const AppliedFilters = ({ searchFacets }: { searchFacets: Facet[] }) => {
+  const searchParams = useSearchParams();
+  const router = useRouter();
+
+  const filterItemProps: FilterItemProps[] = React.useMemo(() => {
+    return convertDataToFilterItemProps(searchFacets);
+  }, [searchFacets]);
+
+  const appliedFilters = React.useMemo(() => {
+    if (!searchParams) return [];
+
+    return Array.from(searchParams.entries())
+      .filter(([key]) => key !== "page" && key.includes("-"))
+      .map(([key, value]) => {
+        const [groupKey, field] = key.split("-");
+        const filterItem = filterItemProps.find(
+          (item) => item.groupKey === groupKey && item.field === field
+        );
+        return {
+          groupKey,
+          field,
+          values: value.split(",").map((val) => ({
+            value: val,
+            label:
+              filterItem?.data.find((option) => option.value === val)?.label ||
+              val,
+          })),
+          label: filterItem?.label || field,
+        };
+      });
+  }, [searchParams, filterItemProps]);
+
+  const facetGroups = React.useMemo(() => {
+    return Array.from(new Set(appliedFilters.map((filter) => filter.groupKey)));
+  }, [appliedFilters]);
+
+  const handleRemoveFilter = (
+    groupKey: string,
+    field: string,
+    value: string
+  ) => {
+    if (!searchParams) return;
+
+    const params = new URLSearchParams(searchParams.toString());
+    const currentValues = params.get(`${groupKey}-${field}`)?.split(",") || [];
+    const newValues = currentValues.filter((v) => v !== value);
+
+    if (newValues.length > 0) {
+      params.set(`${groupKey}-${field}`, newValues.join(","));
+    } else {
+      params.delete(`${groupKey}-${field}`);
+    }
+
+    params.set("page", "1");
+    router.push(`${window.location.pathname}?${params.toString()}`);
+  };
+
+  if (appliedFilters.length === 0) {
+    return null;
+  }
+
+  return (
+    <div className="mb-4">
+      <div className="flex justify-between items-center mb-4">
+        <h3 className="text-lg font-subheading">Applied Filters</h3>
+        <ClearFilterButton facetGroups={facetGroups} />
+      </div>
+      <div className="flex flex-wrap gap-2">
+        {appliedFilters.flatMap(({ groupKey, field, values, label }) =>
+          values.map(({ value, label: valueLabel }) => (
+            <div
+              key={`${groupKey}-${field}-${value}`}
+              className="flex items-center gap-2 bg-surface rounded-lg px-3 py-1"
+            >
+              <span className="font-body text-md">
+                {label}: {valueLabel}
+              </span>
+              <button
+                onClick={() => handleRemoveFilter(groupKey, field, value)}
+                className="text-info hover:text-secondary"
+              >
+                <FontAwesomeIcon icon={faTimes} className="h-4 w-4" />
+              </button>
+            </div>
+          ))
+        )}
+      </div>
+    </div>
+  );
+};
+
+export default AppliedFilters;

--- a/src/components/PaginationContainer.tsx
+++ b/src/components/PaginationContainer.tsx
@@ -36,6 +36,10 @@ function PaginationContainer({
     return `${pathname}?${params}`;
   }
 
+  if (datasetCount === 0) {
+    return <div className="h-10 mb-4" aria-hidden="true"></div>;
+  }
+
   return (
     <Pagination>
       <PaginationContent>


### PR DESCRIPTION
<img width="1250" alt="Screenshot 2024-10-01 at 14 06 02" src="https://github.com/user-attachments/assets/4c8423aa-1687-4b5c-a341-29a40e44b30b">

<!-- Generated by sourcery-ai[bot]: start summary -->

## Summary by Sourcery

Display selected filters on top of the dataset cards by adding an AppliedFilters component. Introduce a NoDatasetMessage component to notify users when no datasets match the applied filters. Adjust the layout of the DatasetsPage to accommodate these new components and enhance the PaginationContainer to handle empty dataset scenarios.

New Features:
- Introduce a new component, AppliedFilters, to display the currently selected filters above the dataset cards.
- Add a NoDatasetMessage component to inform users when no datasets match the applied filters.

Enhancements:
- Modify the layout of the DatasetsPage to include the AppliedFilters and NoDatasetMessage components above the DatasetListContainer.
- Improve the PaginationContainer to handle cases where there are no datasets by displaying an empty space.

<!-- Generated by sourcery-ai[bot]: end summary -->