### PR TITLE
fix: multiple themes not displaying correctly

### DIFF
--- a/src/app/datasets/[id]/page.tsx
+++ b/src/app/datasets/[id]/page.tsx
@@ -26,22 +26,25 @@ export default async function Page({ params }: { params: { id: string } }) {
       <PageContainer>
         <div className="flex flex-col items-start justify-start lg:flex-row">
           <div className="flex w-full flex-col gap-5 lg:w-2/3 lg:px-5">
-            <div className="sm:flex sm:justify-between">
-              <div className="flex items-center gap-x-4">
-                <PageHeading className="text-black">
-                  {dataset.title}
-                </PageHeading>
+            <div
+              className={`flex flex-col ${dataset.themes.length < 2 && "md:flex-row md:gap-y-0 items-start"} gap-y-5 gap-x-3 justify-between`}
+            >
+              <PageHeading className="text-black">{dataset.title}</PageHeading>
 
+              <ul className="flex gap-x-3 gap-y-2 flex-wrap">
                 {dataset.themes.map((theme) => (
-                  <div
+                  <li
                     key={theme.label}
-                    className="tracking-widest uppercase flex items-center text-xs lg:text-sm relative group"
+                    className="tracking-widest uppercase flex items-center relative group"
                   >
-                    <Chip className="text-center" chip={theme.label} />
-                    <Tooltip message="Themes associated with the dataset." />
-                  </div>
+                    <Chip
+                      className="flex justify-center items-center w-24 md:w-32 h-12 text-[10px] md:text-xs text-center px-1 md:px-2"
+                      chip={theme.label}
+                    />
+                    <Tooltip message="Theme associated with the dataset." />
+                  </li>
                 ))}
-              </div>
+              </ul>
             </div>
             <div className="flex items-center">
               <p className="text-gray">{dataset.description}</p>
@@ -55,7 +58,7 @@ export default async function Page({ params }: { params: { id: string } }) {
 
             <div className="h-[2px] bg-secondary opacity-80 lg:hidden"></div>
 
-            <div className="">
+            <div>
               <DatasetMetadata
                 dataset={dataset}
                 relationships={relationships}


### PR DESCRIPTION
<img width="976" alt="Screenshot 2024-10-23 at 15 48 27" src="https://github.com/user-attachments/assets/1a54ac5b-5cf0-4d38-a2d1-f921c760ba65">
<img width="573" alt="Screenshot 2024-10-23 at 15 48 41" src="https://github.com/user-attachments/assets/cb55f9ec-9112-4ea5-8700-94a4f4809901">
<img width="962" alt="Screenshot 2024-10-23 at 15 49 34" src="https://github.com/user-attachments/assets/590b96b3-715c-47ed-85ee-b251639da583">

## Summary by Sourcery

Fix the display issue with multiple themes on the dataset page by updating the layout and styling. Enhance the Sidebar component by ensuring unique keys for each item, even if labels repeat.

Bug Fixes:
- Fix the display of multiple themes in the dataset page by adjusting the layout and styling of theme elements.

Enhancements:
- Improve the uniqueness of keys in the Sidebar component by appending the index to the item label.