### PR TITLE
feat: display distributionsCount and downloadUrl

### DIFF
--- a/src/app/datasets/[id]/DistributionAccordion.tsx
+++ b/src/app/datasets/[id]/DistributionAccordion.tsx
@@ -137,22 +137,28 @@ const DistributionAccordion = ({
                     <Tooltip message="File type of the distribution." />
                   </span>
                 </div>
-                <div className="flex items-center relative">
-                  <span className="group flex items-center">
-                    <FontAwesomeIcon
-                      icon={faLink}
-                      className="text-primary align-middle mr-2"
-                    />
-                    <strong className="text-sm font-semibold">Link:</strong>
-                    <a
-                      href={distribution.uri}
-                      className="text-sm text-primary ml-2 break-all"
-                    >
-                      Download
-                    </a>
-                    <Tooltip message="Link to download the distribution." />
-                  </span>
-                </div>
+                {distribution.downloadUrl && (
+                  <div className="flex items-center relative">
+                    <span className="group flex items-center">
+                      <FontAwesomeIcon
+                        icon={faLink}
+                        className="text-primary align-middle mr-2"
+                      />
+                      <strong className="text-sm font-semibold">
+                        Download URL:
+                      </strong>
+                      <a
+                        href={distribution.downloadUrl}
+                        className="text-sm text-primary ml-2 break-all"
+                        target="_blank"
+                        rel="noopener noreferrer"
+                      >
+                        here
+                      </a>
+                      <Tooltip message="Link to download the distribution." />
+                    </span>
+                  </div>
+                )}
               </div>
             </div>
           </div>

--- a/src/app/datasets/[id]/sidebarItems.tsx
+++ b/src/app/datasets/[id]/sidebarItems.tsx
@@ -35,7 +35,14 @@ function createDatasetSidebarItems(dataset: RetrievedDataset): SidebarItem[] {
   return [
     {
       label: "Request data access",
-      value: <AddToBasketButton dataset={dataset} />,
+      value: (
+        <AddToBasketButton
+          dataset={{
+            ...dataset,
+            distributionsCount: dataset.distributions.length,
+          }}
+        />
+      ),
       hideItem: !contentConfig.showBasketAndLogin,
     },
     {

--- a/src/app/datasets/__tests__/datasetCardItems.test.ts
+++ b/src/app/datasets/__tests__/datasetCardItems.test.ts
@@ -30,21 +30,7 @@ describe("datasetCardItems", () => {
           value: "keyword2",
         },
       ],
-      distributions: [
-        {
-          id: "r",
-          title: "distribution1",
-          description: "distribution1 description",
-          format: {
-            label: "format1",
-            value: "format1",
-          },
-          licenses: [],
-          createdAt: "2022-01-01T00:00:00.000Z",
-          modifiedAt: "2022-01-01T00:00:00.000Z",
-          uri: "distribution1",
-        },
-      ],
+      distributionsCount: 1,
       organization: {
         id: "1",
         title: "organization1",

--- a/src/app/datasets/datasetCardItems.ts
+++ b/src/app/datasets/datasetCardItems.ts
@@ -37,10 +37,10 @@ export function createDatasetCardItems(dataset: SearchedDataset): CardItem[] {
     },
     {
       text:
-        (dataset.distributions?.length &&
-          (dataset.distributions.length === 1
+        (dataset.distributionsCount &&
+          (dataset.distributionsCount === 1
             ? "1 Distribution"
-            : `${dataset.distributions.length} Distributions`)) ||
+            : `${dataset.distributionsCount} Distributions`)) ||
         "",
       icon: faFile,
     },

--- a/src/app/requests/entitlements/__tests__/entitlementCardItems.test.ts
+++ b/src/app/requests/entitlements/__tests__/entitlementCardItems.test.ts
@@ -30,34 +30,7 @@ describe("entitlementCardItems", () => {
           value: "keyword2",
         },
       ],
-      distributions: [
-        {
-          id: "1",
-          title: "distribution1",
-          description: "distribution1 description",
-          format: {
-            label: "format1",
-            value: "format1",
-          },
-          licenses: [],
-          createdAt: "2022-01-01T00:00:00.000Z",
-          modifiedAt: "2022-01-01T00:00:00.000Z",
-          uri: "distribution1",
-        },
-        {
-          id: "2",
-          title: "distribution2",
-          description: "distribution2 description",
-          format: {
-            label: "format1",
-            value: "format1",
-          },
-          licenses: [],
-          createdAt: "2022-01-01T00:00:00.000Z",
-          modifiedAt: "2022-01-01T00:00:00.000Z",
-          uri: "distribution1",
-        },
-      ],
+      distributionsCount: 2,
       organization: {
         id: "1",
         title: "organization1",

--- a/src/services/discovery/types/dataset.types.ts
+++ b/src/services/discovery/types/dataset.types.ts
@@ -34,11 +34,11 @@ export type SearchedDataset = {
   description?: string;
   themes?: ValueLabel[];
   keywords: ValueLabel[];
-  distributions: RetrievedDistribution[];
   organization: RetrievedPublisher;
   modifiedAt: string;
   createdAt: string;
   recordsCount?: number;
+  distributionsCount: number;
 };
 
 export type DatasetEntitlement = {
@@ -56,7 +56,7 @@ export interface RetrievedDistribution {
   modifiedAt: string;
   languages?: ValueLabel[];
   licenses?: ValueLabel[];
-  uri: string;
+  downloadUrl?: string;
 }
 
 export interface DatasetRelationEntry {


### PR DESCRIPTION
## Summary by Sourcery

Add new features to display the download URL for distributions and the count of distributions in dataset card items. Enhance the data types to support these features.

New Features:
- Add display of download URL for distributions in the DistributionAccordion component.
- Introduce a count of distributions in the dataset card items.

Enhancements:
- Update the SearchedDataset type to include distributionsCount and make downloadUrl optional in RetrievedDistribution.