### PR TITLE
Revert "chore(deps): update registry.access.redhat.com/ubi9/nodejs-20-minimal docker tag to v9"

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,7 @@
 # SPDX-FileCopyrightText: 2024 PNED G.I.E.
 #
 # SPDX-License-Identifier: Apache-2.0
-FROM registry.access.redhat.com/ubi9/nodejs-20-minimal:9.5-1730525319 AS base
+FROM registry.access.redhat.com/ubi9/nodejs-20-minimal:1-63.1726695170 AS base
 
 # Install dependencies only when needed
 FROM base AS deps


### PR DESCRIPTION
Reverts GenomicDataInfrastructure/gdi-userportal-frontend#502

## Summary by Sourcery

Chores:
- Revert the update of the Docker base image tag from v9.5-1730525319 to v1-63.1726695170.