### PR TITLE
fix: ART-10765/not showing filter labels in applied filters

### DIFF
--- a/src/components/ActiveFilters.tsx
+++ b/src/components/ActiveFilters.tsx
@@ -51,7 +51,7 @@ export default function ActiveFilters() {
               className="flex items-center gap-2 bg-surface rounded-lg px-3 py-1"
             >
               <span className="font-body text-md">
-                {`${f.label} ${v.operator || ":"} ${v.label ?? v.value}`}
+                {`${f.label} ${v.operator || ":"} ${v.label}`}
               </span>
               <button
                 onClick={() => removeActiveValue(f, v.value, v.operator)}

--- a/src/providers/FilterProvider.tsx
+++ b/src/providers/FilterProvider.tsx
@@ -55,14 +55,34 @@ function reducer(
           f.key === newActiveFilter.key && f.source === newActiveFilter.source
       );
 
+      const originalFilter = state.filters.find(
+        (f) =>
+          f.key === newActiveFilter.key && f.source === newActiveFilter.source
+      );
+
+      const valuesWithLabels = newActiveFilter.values?.map((v) => {
+        const originalValue = originalFilter?.values?.find(
+          (ov) => ov.value === v.value
+        );
+        return {
+          ...v,
+          label: originalValue?.label || v.label || v.value,
+        };
+      });
+
+      const updatedFilter = {
+        ...newActiveFilter,
+        values: valuesWithLabels,
+      };
+
       return {
         ...state,
         activeFilters:
           existingIndex >= 0
             ? state.activeFilters.map((f, i) =>
-                i === existingIndex ? newActiveFilter : f
+                i === existingIndex ? updatedFilter : f
               )
-            : [...state.activeFilters, newActiveFilter],
+            : [...state.activeFilters, updatedFilter],
         error: null,
       };
     }


### PR DESCRIPTION
<img width="1711" alt="image" src="https://github.com/user-attachments/assets/e51c1e37-5d27-4ab7-8ca7-b326f79540fa">

## Summary by Sourcery

Bug Fixes:
- Ensure filter labels are displayed correctly in the applied filters section by mapping values to their corresponding labels.