### PR TITLE
fix: infinite rendering on dataset page

### DIFF
--- a/src/app/datasets/FilterList/EntriesFilterContent.tsx
+++ b/src/app/datasets/FilterList/EntriesFilterContent.tsx
@@ -2,13 +2,13 @@
 //
 // SPDX-License-Identifier: Apache-2.0
 
-import { FilterItemProps } from "./FilterItem";
-import { useFilters } from "@/providers/filters/FilterProvider";
-import { Disclosure } from "@headlessui/react";
 import Button from "@/components/Button";
+import { useFilters } from "@/providers/filters/FilterProvider";
 import { faCheck, faXmarkCircle } from "@fortawesome/free-solid-svg-icons";
 import { FontAwesomeIcon } from "@fortawesome/react-fontawesome";
-import { useEffect, useState } from "react";
+import { Disclosure } from "@headlessui/react";
+import { useEffect, useMemo, useState } from "react";
+import { FilterItemProps } from "./FilterItem";
 
 type EntriesFilterContentProps = FilterItemProps;
 
@@ -27,10 +27,14 @@ export default function EntriesFilterContent({
     (f) => f.key === filter.key && f.source === filter.source
   );
 
-  const initialEntryFormItems = filter.entries!.map((entry) => ({
-    ...entry,
-    value: "",
-  }));
+  const initialEntryFormItems = useMemo(
+    () =>
+      filter.entries!.map((entry) => ({
+        ...entry,
+        value: "",
+      })),
+    [filter.entries]
+  );
 
   const [entries, setEntries] = useState<EntryFormItem[]>(
     initialEntryFormItems


### PR DESCRIPTION
## Summary by Sourcery

Bug Fixes:
- Fixed an infinite rendering bug on the dataset page by using useMemo to memoize the initialEntryFormItems variable.