### PR TITLE
chore: add labels to docker image

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -16,6 +16,8 @@ env:
   REGISTRY: ghcr.io
   IMAGE_NAME: ghcr.io/genomicdatainfrastructure/gdi-userportal-frontend
   AZURE_WEBAPP_NAME: catalogue-test
+  REPOSITORY_URL: ${GITHUB_SERVER_URL}/${GITHUB_REPOSITORY}
+  BUILD_DATE: ""
 
 jobs:
   ort:
@@ -39,6 +41,9 @@ jobs:
       - name: Checkout repository
         uses: actions/checkout@v4
 
+      - name: Set BUILD_DATE
+        run: echo "BUILD_DATE=$(date -u +'%Y-%m-%dT%H:%M:%SZ')" >> $GITHUB_ENV
+
       - name: Log in to the Container registry
         uses: docker/login-action@v3
         with:
@@ -59,6 +64,19 @@ jobs:
             type=semver,pattern={{major}}.{{minor}},priority=900
             type=semver,pattern={{major}},priority=800
             type=sha,priority=1000
+          labels: |
+            vcs-ref=${GITHUB_SHA}
+            build-date=${env.BUILD_DATE}
+            org.opencontainers.image.created=${env.BUILD_DATE}
+            release=${env.BUILD_DATE}
+            version=${GITHUB_REF_NAME}
+            org.opencontainers.image.version=${GITHUB_REF_NAME}
+            org.opencontainers.image.url=${env.REPOSITORY_URL}
+            org.opencontainers.image.source=${env.REPOSITORY_URL}
+            org.opencontainers.image.documentation=${env.REPOSITORY_URL}
+            help=${env.REPOSITORY_URL}
+            url=${env.REPOSITORY_URL}
+            name=${env.IMAGE_NAME}
 
       - name: Extract last tag
         id: tag

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -14,6 +14,8 @@ env:
   REGISTRY: ghcr.io
   IMAGE_NAME: ghcr.io/genomicdatainfrastructure/gdi-userportal-frontend
   DOCKER_METADATA_OUTPUT_TAGS:
+  REPOSITORY_URL: ${GITHUB_SERVER_URL}/${GITHUB_REPOSITORY}
+  BUILD_DATE: ""
 
 jobs:
   ort:
@@ -38,6 +40,9 @@ jobs:
       - name: Checkout repository
         uses: actions/checkout@v4
 
+      - name: Set BUILD_DATE
+        run: echo "BUILD_DATE=$(date -u +'%Y-%m-%dT%H:%M:%SZ')" >> $GITHUB_ENV
+
       - name: Log in to the Container registry
         uses: docker/login-action@v3
         with:
@@ -58,6 +63,19 @@ jobs:
             type=semver,pattern={{major}}.{{minor}},priority=900
             type=semver,pattern={{major}},priority=800
             type=sha,priority=1000
+          labels: |
+            vcs-ref=${GITHUB_SHA}
+            build-date=${env.BUILD_DATE}
+            org.opencontainers.image.created=${env.BUILD_DATE}
+            release=${env.BUILD_DATE}
+            version=${GITHUB_REF_NAME}
+            org.opencontainers.image.version=${GITHUB_REF_NAME}
+            org.opencontainers.image.url=${env.REPOSITORY_URL}
+            org.opencontainers.image.source=${env.REPOSITORY_URL}
+            org.opencontainers.image.documentation=${env.REPOSITORY_URL}
+            help=${env.REPOSITORY_URL}
+            url=${env.REPOSITORY_URL}
+            name=${env.IMAGE_NAME}
 
       - name: Extract last tag
         id: tag

--- a/Dockerfile
+++ b/Dockerfile
@@ -48,4 +48,20 @@ EXPOSE 3000
 ENV PORT 3000
 ENV HOSTNAME "0.0.0.0"
 
+ENV MAINTAINER "PNED G.I.E."
+ENV APP_TITLE "userportal-frontend"
+ENV APP_DESCRIPTION "Frontend of user portal."
+
+LABEL maintainer ${MAINTAINER}
+LABEL summary ${APP_TITLE}
+LABEL description ${APP_DESCRIPTION}
+
+LABEL org.opencontainers.image.vendor ${MAINTAINER}
+LABEL org.opencontainers.image.licenses Apache-2.0
+LABEL org.opencontainers.image.title ${APP_TITLE}
+LABEL org.opencontainers.image.description ${APP_DESCRIPTION}
+
+LABEL io.k8s.display-name ${APP_TITLE}
+LABEL io.k8s.description ${APP_DESCRIPTION}
+
 CMD ["node", "server.js"]


### PR DESCRIPTION
## Summary by Sourcery

Add labels to the Docker image with metadata such as VCS ref, build date, version, repository URL, and maintainer information.

Enhancements:
- Add labels to the Dockerfile with image metadata, including maintainer, summary, description, vendor, licenses, title, and Kubernetes display name and description.

CI:
- Add labels to Docker images built in release and main workflows.