### PR TITLE
chore: add missing variables

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -17,6 +17,8 @@ env:
   IMAGE_NAME: ghcr.io/genomicdatainfrastructure/gdi-userportal-frontend
   AZURE_WEBAPP_NAME: catalogue-test
   REPOSITORY_URL: ${{ github.server_url }}/${{ github.repository }}
+  GITHUB_SHA: ${{ github.sha }}
+  GITHUB_REF_NAME: ${{ github.ref_name }}
   BUILD_DATE: ""
 
 jobs:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -15,6 +15,8 @@ env:
   IMAGE_NAME: ghcr.io/genomicdatainfrastructure/gdi-userportal-frontend
   DOCKER_METADATA_OUTPUT_TAGS:
   REPOSITORY_URL: ${{ github.server_url }}/${{ github.repository }}
+  GITHUB_SHA: ${{ github.sha }}
+  GITHUB_REF_NAME: ${{ github.ref_name }}
   BUILD_DATE: ""
 
 jobs:


### PR DESCRIPTION
## Summary by Sourcery

CI:
- Add `GITHUB_SHA` and `GITHUB_REF_NAME` environment variables.