### PR TITLE
feat(ART-12204): add release trigger

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -77,6 +77,15 @@ jobs:
           echo "New tag pushed: $NEW_TAG"
           echo "new_tag=$NEW_TAG" >> $GITHUB_OUTPUT
 
+      - name: Set execute permissions for changelog script
+        run: chmod +x changelog.sh
+
+      - name: Update CHANGELOG.md
+        run: ./changelog.sh
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+
   publish-release:
     runs-on: ubuntu-latest
     needs: versioning
@@ -101,7 +110,7 @@ jobs:
             --generate-notes \
             --notes-start-tag "$PREVIOUS_TAG"
 
-  build-and-push-image:
+  publish-docker-image:
     runs-on: ubuntu-latest
     needs: publish-release
     permissions:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -174,7 +174,7 @@ jobs:
           labels: ${{ steps.meta.outputs.labels }}
 
       - name: Run Trivy Vulnerability Scanner
-        uses: aquasecurity/trivy-action@0.29.0
+        uses: aquasecurity/trivy-action@0.30.0
         with:
           image-ref: "${{ steps.tag.outputs.last_tag }}"
           format: "table"

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -173,7 +173,7 @@ jobs:
           tags: ${{ steps.tag.outputs.last_tag }}
           labels: ${{ steps.meta.outputs.labels }}
 
-      - name: Run Trivy Vulnerability Scanner
+      - name: Run Trivy vulnerability Scanner
         uses: aquasecurity/trivy-action@0.30.0
         with:
           image-ref: "${{ steps.tag.outputs.last_tag }}"

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -9,7 +9,7 @@ on:
   workflow_dispatch:
     inputs:
       version:
-        description: 'Version increment (major, minor, patch)'
+        description: 'Version Increment (major, minor, patch)'
         required: true
         default: 'patch'
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -173,7 +173,7 @@ jobs:
           tags: ${{ steps.tag.outputs.last_tag }}
           labels: ${{ steps.meta.outputs.labels }}
 
-      - name: Run Trivy vulnerability Scanner
+      - name: Run Trivy vulnerability scanner
         uses: aquasecurity/trivy-action@0.30.0
         with:
           image-ref: "${{ steps.tag.outputs.last_tag }}"

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -3,12 +3,15 @@
 #
 # SPDX-License-Identifier: Apache-2.0
 
-name: Publish release
+name: Publish Release
 
 on:
-  push:
-    tags:
-      - "v*"
+  workflow_dispatch:
+    inputs:
+      version:
+        description: 'Version increment (major, minor, patch)'
+        required: true
+        default: 'patch'
 
 env:
   REGISTRY: ghcr.io
@@ -32,9 +35,75 @@ jobs:
           fail-on: "issues"
           run: "cache-dependencies,cache-scan-results,labels,analyzer,evaluator,advisor,reporter,upload-results"
 
-  build-and-push-image:
+  versioning:
     runs-on: ubuntu-latest
     needs: ort
+    outputs:
+      new_tag: ${{ steps.tagging.outputs.new_tag }}
+    steps:
+      - name: Checkout Repository
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Set Git User Identity
+        run: |
+          git config --local user.email "github-actions@users.noreply.github.com"
+          git config --local user.name "GitHub Actions"
+
+      - name: Fetch Latest Tag and Increment Version
+        id: tagging
+        run: |
+          LATEST_TAG=$(git tag --sort=-creatordate | head -n 1)
+          echo "Latest tag: $LATEST_TAG"
+
+          # Extract Major, Minor, Patch
+          IFS='.' read -r MAJOR MINOR PATCH <<<"${LATEST_TAG//v/}"
+          INCREMENT=${{ github.event.inputs.version }}
+          echo "Updating : $INCREMENT version"
+
+          case "$INCREMENT" in
+            major) ((MAJOR++)); MINOR=0; PATCH=0 ;;
+            minor) ((MINOR++)); PATCH=0 ;;
+            patch|*) ((PATCH++)) ;;
+          esac
+
+          NEW_TAG="v$MAJOR.$MINOR.$PATCH"
+          echo "Pushing this tag: $NEW_TAG"
+
+          git tag -a "$NEW_TAG" -m "Release $NEW_TAG"
+          git push origin "$NEW_TAG"
+
+          echo "New tag pushed: $NEW_TAG"
+          echo "new_tag=$NEW_TAG" >> $GITHUB_OUTPUT
+
+  publish-release:
+    runs-on: ubuntu-latest
+    needs: versioning
+    steps:
+      - name: Checkout Repository
+        uses: actions/checkout@v4
+
+      - name: Install GitHub CLI
+        run: sudo apt-get install -y gh
+
+      - name: Generate and Publish GitHub Release
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          LATEST_TAG="${{ needs.versioning.outputs.new_tag }}"
+          PREVIOUS_TAG=$(git tag --sort=-creatordate | sed -n '2p')
+
+          echo "Creating GitHub release for $LATEST_TAG from previous release $PREVIOUS_TAG"
+
+          gh release create "$LATEST_TAG" \
+            --title "Release $LATEST_TAG" \
+            --generate-notes \
+            --notes-start-tag "$PREVIOUS_TAG"
+
+  build-and-push-image:
+    runs-on: ubuntu-latest
+    needs: publish-release
     permissions:
       contents: read
       packages: write
@@ -95,7 +164,7 @@ jobs:
           tags: ${{ steps.tag.outputs.last_tag }}
           labels: ${{ steps.meta.outputs.labels }}
 
-      - name: Run Trivy vulnerability scanner
+      - name: Run Trivy Vulnerability Scanner
         uses: aquasecurity/trivy-action@0.29.0
         with:
           image-ref: "${{ steps.tag.outputs.last_tag }}"
@@ -108,7 +177,7 @@ jobs:
           TRIVY_SKIP_DB_UPDATE: true
           TRIVY_SKIP_JAVA_DB_UPDATE: true
 
-      - name: Build and push Docker image
+      - name: Build and Push Docker Image
         uses: docker/build-push-action@v6
         with:
           context: .

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,13 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+## [1.3.3] - 2025-03-25
+
+### Changed
+- 
+
+
+
 
 ### Added
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,52 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 
+## [v1.3.8] - 2025-03-31
+
+### Added
+- feat(ART-12300): add debounce for handleScroll by @Antoine Dorard in d9b0ac4
+- feat(ART-12300): change getInitials behavior: always include all letters if less than 3 names by @Antoine Dorard in 863dfbd
+- feat(ART-12300): make return initials if the name is entirely lowercase by @Antoine Dorard in 3ea0b0a
+- feat(ART-12300): exclude lower case letters for initials by @Antoine Dorard in 75de64b
+- feat(ART-12300): add bottom navbar for small screens and dropdown menu for medium screens by @Antoine Dorard in 8135d02
+
+
+### Changed
+- chore(deps): update registry.access.redhat.com/ubi9/nodejs-22-minimal docker tag to v9.5-1738870241 by @Renovate Bot in cb90e39
+- refractor(ART12300): move avatar initials logic to src/utils by @Antoine Dorard in e4b28b3
+- test(ART-12300): add test for getInitials by @Antoine Dorard in 4cd5016
+- chore(deps): update dependency tailwindcss to v4 (#571) by @LNDS-Sysadmins in 394cada
+- chore(deps): update registry.access.redhat.com/ubi9/nodejs-22-minimal docker tag to v9.5-1738661183 by @Renovate Bot in d1df398
+- chore(deps): update registry.access.redhat.com/ubi9/nodejs-22-minimal docker tag to v9.5-1737939980 by @Renovate Bot in f20a268
+- chore(deps): update registry.access.redhat.com/ubi9/nodejs-22-minimal docker tag to v9.5-1737619681 by @Renovate Bot in 048b597
+- chore(deps): update registry.access.redhat.com/ubi9/nodejs-22-minimal docker tag to v9.5-1737562536 by @Renovate Bot in 58e2103
+- chore(deps): update registry.access.redhat.com/ubi9/nodejs-22-minimal docker tag to v9.5-1737531032 by @Renovate Bot in b4486c1
+
+
+### Fixed
+- fix: revert tailwind v4 (#577) by @Kacem Bechka in 8ab24b0
+- fix(ART-12300): fix typo by @Antoine Dorard in 5876007
+- fix(ART-12300): remove unused icon from imports by @Antoine Dorard in 2ffed0e
+- fix(deps): update dependency tailwind-merge to v3 (#573) by @LNDS-Sysadmins in 1ffdf13
+- fix: ART-12303/custom text not displayed by @Kacem Bechka in 82584b2
+- fix: ART-12303/custom text not displayed by @Kacem Bechka in d3288da
+- style(ART-12300): fix format by @Antoine Dorard in 62836c9
+- fix: ART-12303/custom text not displayed by @Kacem Bechka in fb0e0e9
+- fix: ART-12303/custom text not displayed by @Kacem Bechka in ad5516d
+- fix(deps): update dependency @opentelemetry/auto-instrumentations-node to ^0.56.0 by @Renovate Bot in e345102
+- fix lint by @Kacem Bechka in f3aa36b
+- fix test by @Kacem Bechka in d93aad7
+- fix test by @Kacem Bechka in 7596638
+- fix: ART-12382/missing form validation by @Kacem Bechka in 61c221a
+- fix(deps): update dependency next to v15.1.6 by @Renovate Bot in 1069748
+
+
+### Removed
+- remove About link from small screens' navbar (link in the footer for all screen sizes) by @Antoine Dorard in 585b7ef
+- refractor(ART-12300): loop through nav items to remove redundant code by @Antoine Dorard in 51e9760
+
+
+
 ## [v1.3.7] - 2025-03-25
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,26 +11,181 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [Unreleased]
-## [1.3.3] - 2025-03-25
 
-### Changed
-- 
-
-
-
+## [v1.3.7] - 2025-03-25
 
 ### Added
+- feat(ART-11336): add dataset type and frontend element to display it by @Antoine Dorard in a73f09b
+- feat(ART-11570): simplify open api by @jadz94 in 0fa6e26
+- feat(ART-11332): update customization by @jadz94 in 5bd3491
+- feat(ART-11332): update login button by @jadz94 in 257e167
+- feat(ART-11332): add license by @jadz94 in 73dbe1b
+- feat(ART-11332): fix format by @jadz94 in 87bf61c
+- feat(ART-11332): move customizations to separate folder by @jadz94 in c8f0991
+- feat: ART-11337/intergrate otel dev by @Kacem Bechka in c4a5882
+
 
 ### Changed
+- chore(deps): update dependency eslint-config-prettier to v10 by @Renovate Bot in eb52fcc
+- chore(deps): update registry.access.redhat.com/ubi9/nodejs-22-minimal docker tag to v9.5-1736731764 by @Renovate Bot in 09fba4d
+- chore: add missing variables by @Bruno Pacheco in cb8c958
+- chore(deps): update registry.access.redhat.com/ubi9/nodejs-22-minimal docker tag to v9.5-1736425083 by @Renovate Bot in 6362b8c
+- chore: add labels to docker image by @Bruno Pacheco in 58fcd2e
+- chore(ART-11570): polish by @jadz94 in 761a854
+- chore(deps): upgrade nodejs base image by @Bruno Pacheco in 721ee0f
+- chore(ART-11332): polish by @jadz94 in 2f3f044
+- chore(ART-11570): update test script by @jadz94 in 8e4f6d3
+- chore(ART-11570): update test script by @jadz94 in 17a87c1
+- chore(ART-11332): refactor customizations by @jadz94 in d824f0f
+- chore(deps): automerge in branches by @Bruno Pacheco in 1f3e96f
+- chore: update legal.md by @Bruno Pacheco in 588ff34
 
-### Deprecated
-
-### Removed
 
 ### Fixed
+- fix(deps): update dependency next to v15.1.5 by @Renovate Bot in 7dccd85
+- chore: fix missing labels by @Bruno Pacheco in 182cade
+- fix(ART-11336): remove formatDate around dcatType by @Antoine Dorard in c06f212
+- fix(ART-11336): formatting by @Antoine Dorard in 1b54b32
+- fix(ART-11336): update dataset type tooltip message by @Antoine Dorard in 79742be
+- fix(ART-11336): change attribute 'type' to 'dcatType' by @Antoine Dorard in 53f06a5
+- chore: fix REPOSITORY_URL by @Bruno Pacheco in 82ce5bc
+- chore: fix github actions env variables by @Bruno Pacheco in b5902aa
+- fix: react-19-upgrade by @Younès Adem in 0a582d5
+- fix(ART-11336): fix typo in footer and README by @Antoine Dorard in 972605b
+- fix(deps): update dependency next to v15.1.4 by @Renovate Bot in fbf227b
+- fix(deps): update dependency npm-run-all2 to v7 by @Renovate Bot in f0ef7d0
+- fix(deps): replace dependency npm-run-all with npm-run-all2 ^5.0.0 by @Renovate Bot in 435cc3e
+- fix(deps): update react monorepo to v19 by @Renovate Bot in 78de24d
+- chore(deps): automerge all types of patch PRs by @Bruno Pacheco in ecd3a09
+- chore(deps): automerge patches by @Bruno Pacheco in aa7bbda
 
-### Security
+
+
+## [v1.3.6] - 2025-03-25
+
+### Added
+- feat: improve external service integration (#531) by @Younès Adem in 7c63c1a
+
+
+### Changed
+- chore(deps): update dependency eslint-config-next to v14.2.21 by @Renovate Bot in 0c66174
+- chore: move sonar check to the end of the pipeline by @Bruno Pacheco in 133bd46
+- chore(deps): upgrade typescript by @Bruno Pacheco in 23a0ab9
+- chore(deps): upgrade multiple packages by @Bruno Pacheco in 6b0e814
+- chore(deps): upgrade @types packages by @Bruno Pacheco in 587661c
+- chore(deps): upgrade @radix-ui packages by @Bruno Pacheco in 37674b7
+- chore(deps): upgrade @opentelemetry packages by @Bruno Pacheco in d4bbb04
+- chore(deps): upgrade @headlessui by @Bruno Pacheco in 13abbbe
+- chore(deps): upgrade @fortawesome packages by @Bruno Pacheco in e0f34a9
+- chore(deps): update registry.access.redhat.com/ubi9/nodejs-20-minimal docker tag to v9.5-1734514731 by @Renovate Bot in 1952ed3
+- chore(deps): update dependency tailwindcss to v3.4.17 by @Renovate Bot in 2646215
+- chore: update open-api-specifications by @Younès Adem in a9df88a
+- chore(deps): update registry.access.redhat.com/ubi9/nodejs-20-minimal docker tag to v9.5-1734309067 by @Renovate Bot in fd7e3fa
+- chore(deps): update registry.access.redhat.com/ubi9/nodejs-20-minimal docker tag to v9.5-1733824671 by @Renovate Bot in ba37fad
+- chore(deps): update dependency eslint-config-next to v14.2.20 by @Renovate Bot in db3463a
+- chore(deps): update devdependencies by @Renovate Bot in 8555ea8
+
+
+### Fixed
+- fix: infinite rendering on dataset page by @Younès Adem in 4d2a8d7
+- fix(deps): update dependency next to v14.2.21 by @Renovate Bot in 613dd2f
+- fix: upgrade class-variance-authority from 0.7.0 to 0.7.1 by @snyk-bot in b443c90
+- fix: upgrade cmdk from 1.0.0 to 1.0.4 by @snyk-bot in 6d9f8d9
+- fix: upgrade tailwind-merge from 2.5.3 to 2.5.5 by @snyk-bot in d379f5e
+- fix(deps): update opentelemetry-js monorepo to ^0.56.0 by @Renovate Bot in a0668aa
+- fix(deps): update dependency next to v14.2.20 by @Renovate Bot in 3f8322a
+- fix(deps): update dependency next to v14.2.19 by @Renovate Bot in 1b9ffaa
+
+
+
+## [v1.3.5] - 2025-03-25
+
+### Added
+- ART-10311/feat: add variant filters (#517) by @Younès Adem in 231f503
+- feat: ART-9692/change themes in homepage by @Kacem Bechka in cb1b8aa
+- feat: ART-9692/add themes and publishers by @Kacem Bechka in fd8b844
+
+
+### Changed
+- chore(deps): update registry.access.redhat.com/ubi9/nodejs-20-minimal docker tag to v9.5-1732617235 by @Renovate Bot in 2eb321f
+- chore(deps): update registry.access.redhat.com/ubi9/nodejs-20-minimal docker tag to v9 by @Renovate Bot in abcc901
+- chore(deps): update aquasecurity/trivy-action action to v0.29.0 by @Renovate Bot in a49c1af
+- update prettier version by @jadz94 in 81207b9
+- update prettier version by @jadz94 in caf415a
+- update prettier version by @jadz94 in 95d6ffd
+- Revert "update prettier version" by @jadz94 in 99c0f04
+- update prettier version by @jadz94 in 00a1570
+- update prettier version by @jadz94 in 44f06d7
+- chore(deps): bump cross-spawn from 7.0.3 to 7.0.6 by @dependabot[bot] in b1c8154
+- chore(deps): update dependency tailwindcss to v3.4.15 by @Renovate Bot in cbc21d2
+- chore(deps): update fsfe/reuse-action action to v5 by @Renovate Bot in e235e7b
+- chore(deps): update dependency eslint-config-next to v14.2.18 by @Renovate Bot in 9705294
+- Revert "chore(deps): update registry.access.redhat.com/ubi9/nodejs-20-minimal docker tag to v9" by @Kacem Bechka in 8c6a904
+- addressing comments by @Kacem Bechka in de2547f
+- chore(deps): update registry.access.redhat.com/ubi9/nodejs-20-minimal docker tag to v9 by @Renovate Bot in d965b65
+- chore(deps): update sonarsource/sonarqube-scan-action action to v4 by @Renovate Bot in f5f854b
+- Feat/Introducing free text filters + removing filters from url (#499) by @Younès Adem in 25adf11
+
+
+### Fixed
+- Revert "fix(deps): update dependency next to v15" by @Bruno Pacheco in 635b5d9
+- fix version issue by @jadz94 in ee9acfe
+- fix(deps): update dependency next to v15 by @Renovate Bot in 9d50341
+- fix(deps): update opentelemetry-js monorepo to ^0.55.0 by @Renovate Bot in 167e9f0
+- fix: ART-10765/not showing filter labels in applied filters by @Kacem Bechka in afc1916
+- fix(deps): update dependency date-fns to v4 by @Renovate Bot in 7125f46
+- fix: ART-9692/displaying themes on homepage correctly (#511) by @Kacem Bechka in 7131c4b
+- fix: reduce temporarily severity of trivy scanner to CRITICAL by @Bruno Pacheco in 7786377
+- fix(deps): update dependency next to v14.2.18 by @Renovate Bot in 505fecf
+- fix linter by @Kacem Bechka in 686d48a
+- fix: free text values sync with global states (#503) by @Younès Adem in 13c3284
+
+
+
+
+## [v1.3.4] - 2025-03-25
+
+### Added
+- feat: add languages to distribution by @Bruno Pacheco in fb88eb4
+
+
+
+## [v1.3.3] - 2025-03-25
+
+### Added
+- feat: sort datasets by issue date by @Bruno Pacheco in 716b8d6
+- feat: add otel by @Bruno Pacheco in a926626
+- feat: ART-10196/Header changes (#493) by @Kacem Bechka in ba3248c
+- feat: align with new dataset search endpoint by @Younès Adem in 8b18e36
+- feat: add free text filters by @Younès Adem in 094b427
+- feat: display distributionsCount and downloadUrl by @Bruno Pacheco in ee35ebd
+- feat: display coniditional fields properly by @Sulejman Karisik in ae69afa
+
+
+### Changed
+- chore(deps): update dependency eslint-config-next to v14.2.17 by @Renovate Bot in 1e33c08
+- chore: use cached trivy db by @Bruno Pacheco in 1e9b91c
+- chore: cache trivy db by @Bruno Pacheco in 20b855d
+- chore(deps): update dependency eslint-config-next to v14.2.16 (#486) by @LNDS-Sysadmins in f857f26
+- chore(deps): update dependency tailwindcss to v3.4.14 by @Renovate Bot in 94b432e
+- chore(deps): update aquasecurity/trivy-action action to v0.28.0 by @Renovate Bot in 1c9ae08
+- chore(deps): update registry.access.redhat.com/ubi9/nodejs-20-minimal docker tag to v1-63.1726695170 by @Renovate Bot in 7d1154f
+- docs: update CHANGELOG.md by @Bruno Pacheco in 9db8b6e
+- docs: update CHANGELOG.md by @Bruno Pacheco in 7673372
+- chore(deps): update dependencies by @Bruno Pacheco in b1fb3ef
+- chore(deps): update aquasecurity/trivy-action action to v0.27.0 (#480) by @LNDS-Sysadmins in 6609945
+
+
+### Fixed
+- fix(deps): update dependency next to v14.2.17 by @Renovate Bot in 5f2ffae
+- fix: run prettier on yml files by @Bruno Pacheco in c207483
+- fix: do checks in same iteration by @Sulejman Karisik in b3b03ec
+- fix: multiple themes not displaying correctly by @Younès Adem in 5207059
+- fix(deps): update dependency next to v14.2.16 (#487) by @LNDS-Sysadmins in 3057350
+- fix(docs): run prettier on CHANGELOG.md by @Bruno Pacheco in c6e51db
+
+
+
 
 ## [v1.3.2] - 2024-10-09
 

--- a/changelog.sh
+++ b/changelog.sh
@@ -1,0 +1,72 @@
+# SPDX-FileCopyrightText: 2024 PNED G.I.E.
+#
+# SPDX-License-Identifier: Apache-2.0
+
+#!/bin/bash
+
+# Ensure GH CLI is authenticated
+if ! gh auth status &>/dev/null; then
+  echo "❌ GitHub CLI is not authenticated. Run: gh auth login"
+  exit 1
+fi
+
+# File where the changelog will be updated
+CHANGELOG_FILE="CHANGELOG.md"
+
+# Initialize CHANGELOG if it does not exist
+if [ ! -f "$CHANGELOG_FILE" ]; then
+  echo -e "# Changelog\n\nAll notable changes to this project will be documented in this file.\n\nThe format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/) and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).\n" > "$CHANGELOG_FILE"
+fi
+
+# Get all tags sorted by date (latest first)
+TAGS=($(git tag --sort=-creatordate))
+
+# Get latest and previous tag
+LATEST_TAG=${TAGS[1]}
+PREVIOUS_TAG=${TAGS[2]}
+
+echo "📢 Generating changelog for $LATEST_TAG (since $PREVIOUS_TAG)..."
+
+# Get commit history between the two tags
+COMMITS=$(git log "$PREVIOUS_TAG".."$LATEST_TAG" --no-merges --pretty=format:"%s by @%an in %h")
+
+# Categorize changes
+ADDED=""
+CHANGED=""
+FIXED=""
+REMOVED=""
+SECURITY=""
+
+while IFS= read -r line; do
+  case "$line" in
+    *feat*|*implement*) ADDED+="- ${line}\n" ;;
+    *fix*|*bug*|*resolve*|*patch*) FIXED+="- ${line}\n" ;;
+    *update*|*modify*|*change*|*refactor*|*chore*) CHANGED+="- ${line}\n" ;;
+    *decommission*|*delete*|*remove*) REMOVED+="- ${line}\n" ;;
+    *security*|*vuln*|*"patch security"*) SECURITY+="- ${line}\n" ;;
+    *) CHANGED+="- ${line}\n" ;;  # Default to "Changed"
+  esac
+done <<< "$COMMITS"
+
+# Format the changelog entry
+{
+  echo -e "## [$LATEST_TAG] - $(date +'%Y-%m-%d')\n"
+  [[ -n "$ADDED" ]] && echo -e "### Added\n$ADDED\n"
+  [[ -n "$CHANGED" ]] && echo -e "### Changed\n$CHANGED\n"
+  [[ -n "$FIXED" ]] && echo -e "### Fixed\n$FIXED\n"
+  [[ -n "$REMOVED" ]] && echo -e "### Removed\n$REMOVED\n"
+  [[ -n "$SECURITY" ]] && echo -e "### Security\n$SECURITY\n"
+  echo ""
+} >> temp_changelog.md
+
+# Append existing changelog content
+sed -i '' '14r temp_changelog.md' "$CHANGELOG_FILE"
+# Clean up temporary file
+rm temp_changelog.md
+
+# Commit and push the updated CHANGELOG.md
+git add "$CHANGELOG_FILE"
+git commit -m "📜 Update CHANGELOG.md for $LATEST_TAG"
+git push origin main
+
+echo "✅ CHANGELOG.md updated successfully!"

--- a/changelog.sh
+++ b/changelog.sh
@@ -65,8 +65,8 @@ sed -i '' '14r temp_changelog.md' "$CHANGELOG_FILE"
 rm temp_changelog.md
 
 # Commit and push the updated CHANGELOG.md
-#git add "$CHANGELOG_FILE"
-#git commit -m "📜 Update CHANGELOG.md for $LATEST_TAG"
-#git push origin main
+git add "$CHANGELOG_FILE"
+git commit -m "📜 Update CHANGELOG.md for $LATEST_TAG"
+git push origin main
 
 echo "✅ CHANGELOG.md updated successfully!"

--- a/changelog.sh
+++ b/changelog.sh
@@ -22,8 +22,8 @@ fi
 TAGS=($(git tag --sort=-creatordate))
 
 # Get latest and previous tag
-LATEST_TAG=${TAGS[1]}
-PREVIOUS_TAG=${TAGS[2]}
+LATEST_TAG=v1.3.7
+PREVIOUS_TAG=v1.3.6
 
 echo "📢 Generating changelog for $LATEST_TAG (since $PREVIOUS_TAG)..."
 
@@ -65,8 +65,8 @@ sed -i '' '14r temp_changelog.md' "$CHANGELOG_FILE"
 rm temp_changelog.md
 
 # Commit and push the updated CHANGELOG.md
-git add "$CHANGELOG_FILE"
-git commit -m "📜 Update CHANGELOG.md for $LATEST_TAG"
-git push origin main
+#git add "$CHANGELOG_FILE"
+#git commit -m "📜 Update CHANGELOG.md for $LATEST_TAG"
+#git push origin main
 
 echo "✅ CHANGELOG.md updated successfully!"

--- a/changelog.sh
+++ b/changelog.sh
@@ -22,8 +22,8 @@ fi
 TAGS=($(git tag --sort=-creatordate))
 
 # Get latest and previous tag
-LATEST_TAG=v1.3.7
-PREVIOUS_TAG=v1.3.6
+LATEST_TAG=${TAGS[1]}
+PREVIOUS_TAG=${TAGS[2]}
 
 echo "📢 Generating changelog for $LATEST_TAG (since $PREVIOUS_TAG)..."
 


### PR DESCRIPTION
## Summary by Sourcery

This pull request modifies the release workflow to allow manual triggering of releases and automates version incrementing and release note generation. It replaces the previous tag-based trigger with a `workflow_dispatch` trigger, enabling users to specify the version increment. It also adds steps to automatically increment the version, create a Git tag, and generate and publish a GitHub release with release notes.

New Features:
- Introduces a manual release trigger via `workflow_dispatch` in the release workflow, allowing users to specify the version increment (major, minor, patch) when creating a new release.

Enhancements:
- Improves the release process by automatically incrementing the version based on the latest tag and the specified increment type.
- Adds a step to generate and publish GitHub releases using the GitHub CLI, including release notes generated from the changes since the previous tag.

CI:
- Updates the release workflow to use `workflow_dispatch` for manual triggering, replacing the previous tag-based trigger.
- Adds steps to determine the next version tag, create the tag in Git, and push it to the repository.
- Integrates the GitHub CLI to automate the creation of GitHub releases with generated release notes.