### PR TITLE
fix: ignore cache folder for prettier

### DIFF
--- a/.prettierignore
+++ b/.prettierignore
@@ -1,1 +1,2 @@
 *.hbs
+.cache/


### PR DESCRIPTION
To resolve: https://github.com/GenomicDataInfrastructure/gdi-userportal-frontend/actions/runs/14239699397/job/39906874976

## Summary by Sourcery

CI:
- Modify Prettier ignore file to address formatting checks in the CI pipeline