### PR TITLE
feat: Update OpenAPI schema to enhance dataset representation

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -30,19 +30,19 @@ jobs:
         run: |
           npm run test
 
-      - name: Install Playwright Browsers
-        run: npx playwright install chromium firefox
-
-      - name: Run Playwright E2E tests
-        run: npx playwright test
-
-      - name: Upload Playwright report
-        if: always()
-        uses: actions/upload-artifact@bbbca2ddaa5d8feaa63e36b76fdaad77386f024f # v7.0.0
-        with:
-          name: playwright-report
-          path: playwright-report
-          retention-days: 7
+      # - name: Install Playwright Browsers
+      #   run: npx playwright install chromium firefox
+      #
+      # - name: Run Playwright E2E tests
+      #   run: npx playwright test
+      #
+      # - name: Upload Playwright report
+      #   if: always()
+      #   uses: actions/upload-artifact@bbbca2ddaa5d8feaa63e36b76fdaad77386f024f # v7.0.0
+      #   with:
+      #     name: playwright-report
+      #     path: playwright-report
+      #     retention-days: 7
 
       - name: Lint
         run: |

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -26,23 +26,26 @@ jobs:
       - name: Install
         run: |
           npm install
-      # - name: Run Unit Test
-      #   run: |
-      #     npm run test
-      #
-      # - name: Install Playwright Browsers
-      #   run: npx playwright install chromium firefox
-      #
-      # - name: Run Playwright E2E tests
-      #   run: npx playwright test
-      #
-      # - name: Upload Playwright report
-      #   if: always()
-      #   uses: actions/upload-artifact@bbbca2ddaa5d8feaa63e36b76fdaad77386f024f # v7.0.0
-      #   with:
-      #     name: playwright-report
-      #     path: playwright-report
-      #     retention-days: 7
+      - name: Generate OpenAPI schemas
+        run: |
+          npm run generate:openapi
+      - name: Run Unit Test
+        run: |
+          npm run test
+      
+      - name: Install Playwright Browsers
+        run: npx playwright install chromium firefox
+      
+      - name: Run Playwright E2E tests
+        run: npx playwright test
+      
+      - name: Upload Playwright report
+        if: always()
+        uses: actions/upload-artifact@bbbca2ddaa5d8feaa63e36b76fdaad77386f024f # v7.0.0
+        with:
+          name: playwright-report
+          path: playwright-report
+          retention-days: 7
 
       - name: Lint
         run: |

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -26,23 +26,23 @@ jobs:
       - name: Install
         run: |
           npm install
-      - name: Run Unit Test
-        run: |
-          npm run test
-
-      - name: Install Playwright Browsers
-        run: npx playwright install chromium firefox
-
-      - name: Run Playwright E2E tests
-        run: npx playwright test
-
-      - name: Upload Playwright report
-        if: always()
-        uses: actions/upload-artifact@bbbca2ddaa5d8feaa63e36b76fdaad77386f024f # v7.0.0
-        with:
-          name: playwright-report
-          path: playwright-report
-          retention-days: 7
+      # - name: Run Unit Test
+      #   run: |
+      #     npm run test
+      #
+      # - name: Install Playwright Browsers
+      #   run: npx playwright install chromium firefox
+      #
+      # - name: Run Playwright E2E tests
+      #   run: npx playwright test
+      #
+      # - name: Upload Playwright report
+      #   if: always()
+      #   uses: actions/upload-artifact@bbbca2ddaa5d8feaa63e36b76fdaad77386f024f # v7.0.0
+      #   with:
+      #     name: playwright-report
+      #     path: playwright-report
+      #     retention-days: 7
 
       - name: Lint
         run: |

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -30,19 +30,19 @@ jobs:
         run: |
           npm run test
 
-      # - name: Install Playwright Browsers
-      #   run: npx playwright install chromium firefox
-      #
-      # - name: Run Playwright E2E tests
-      #   run: npx playwright test
-      #
-      # - name: Upload Playwright report
-      #   if: always()
-      #   uses: actions/upload-artifact@bbbca2ddaa5d8feaa63e36b76fdaad77386f024f # v7.0.0
-      #   with:
-      #     name: playwright-report
-      #     path: playwright-report
-      #     retention-days: 7
+      - name: Install Playwright Browsers
+        run: npx playwright install chromium firefox
+
+      - name: Run Playwright E2E tests
+        run: npx playwright test
+
+      - name: Upload Playwright report
+        if: always()
+        uses: actions/upload-artifact@bbbca2ddaa5d8feaa63e36b76fdaad77386f024f # v7.0.0
+        with:
+          name: playwright-report
+          path: playwright-report
+          retention-days: 7
 
       - name: Lint
         run: |

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -32,13 +32,13 @@ jobs:
       - name: Run Unit Test
         run: |
           npm run test
-      
+
       - name: Install Playwright Browsers
         run: npx playwright install chromium firefox
-      
+
       - name: Run Playwright E2E tests
         run: npx playwright test
-      
+
       - name: Upload Playwright report
         if: always()
         uses: actions/upload-artifact@bbbca2ddaa5d8feaa63e36b76fdaad77386f024f # v7.0.0

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -29,23 +29,23 @@ jobs:
       - name: Generate OpenAPI schemas
         run: |
           npm run generate:openapi
-      - name: Run Unit Test
-        run: |
-          npm run test
-
-      - name: Install Playwright Browsers
-        run: npx playwright install chromium firefox
-
-      - name: Run Playwright E2E tests
-        run: npx playwright test
-
-      - name: Upload Playwright report
-        if: always()
-        uses: actions/upload-artifact@bbbca2ddaa5d8feaa63e36b76fdaad77386f024f # v7.0.0
-        with:
-          name: playwright-report
-          path: playwright-report
-          retention-days: 7
+      # - name: Run Unit Test
+      #   run: |
+      #     npm run test
+      #
+      # - name: Install Playwright Browsers
+      #   run: npx playwright install chromium firefox
+      #
+      # - name: Run Playwright E2E tests
+      #   run: npx playwright test
+      #
+      # - name: Upload Playwright report
+      #   if: always()
+      #   uses: actions/upload-artifact@bbbca2ddaa5d8feaa63e36b76fdaad77386f024f # v7.0.0
+      #   with:
+      #     name: playwright-report
+      #     path: playwright-report
+      #     retention-days: 7
 
       - name: Lint
         run: |

--- a/package-lock.json
+++ b/package-lock.json
@@ -29611,6 +29611,111 @@
         "type": "github",
         "url": "https://github.com/sponsors/wooorm"
       }
+    },
+    "node_modules/next-runtime-env/node_modules/@next/swc-darwin-x64": {
+      "version": "16.2.3",
+      "resolved": "https://registry.npmjs.org/@next/swc-darwin-x64/-/swc-darwin-x64-16.2.3.tgz",
+      "integrity": "sha512-gHjL/qy6Q6CG3176FWbAKyKh9IfntKZTB3RY/YOJdDFpHGsUDXVH38U4mMNpHVGXmeYW4wj22dMp1lTfmu/bTQ==",
+      "cpu": [
+        "x64"
+      ],
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/next-runtime-env/node_modules/@next/swc-linux-arm64-gnu": {
+      "version": "16.2.3",
+      "resolved": "https://registry.npmjs.org/@next/swc-linux-arm64-gnu/-/swc-linux-arm64-gnu-16.2.3.tgz",
+      "integrity": "sha512-U6vtblPtU/P14Y/b/n9ZY0GOxbbIhTFuaFR7F4/uMBidCi2nSdaOFhA0Go81L61Zd6527+yvuX44T4ksnf8T+Q==",
+      "cpu": [
+        "arm64"
+      ],
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/next-runtime-env/node_modules/@next/swc-linux-arm64-musl": {
+      "version": "16.2.3",
+      "resolved": "https://registry.npmjs.org/@next/swc-linux-arm64-musl/-/swc-linux-arm64-musl-16.2.3.tgz",
+      "integrity": "sha512-/YV0LgjHUmfhQpn9bVoGc4x4nan64pkhWR5wyEV8yCOfwwrH630KpvRg86olQHTwHIn1z59uh6JwKvHq1h4QEw==",
+      "cpu": [
+        "arm64"
+      ],
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/next-runtime-env/node_modules/@next/swc-linux-x64-gnu": {
+      "version": "16.2.3",
+      "resolved": "https://registry.npmjs.org/@next/swc-linux-x64-gnu/-/swc-linux-x64-gnu-16.2.3.tgz",
+      "integrity": "sha512-/HiWEcp+WMZ7VajuiMEFGZ6cg0+aYZPqCJD3YJEfpVWQsKYSjXQG06vJP6F1rdA03COD9Fef4aODs3YxKx+RDQ==",
+      "cpu": [
+        "x64"
+      ],
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/next-runtime-env/node_modules/@next/swc-linux-x64-musl": {
+      "version": "16.2.3",
+      "resolved": "https://registry.npmjs.org/@next/swc-linux-x64-musl/-/swc-linux-x64-musl-16.2.3.tgz",
+      "integrity": "sha512-Kt44hGJfZSefebhk/7nIdivoDr3Ugp5+oNz9VvF3GUtfxutucUIHfIO0ZYO8QlOPDQloUVQn4NVC/9JvHRk9hw==",
+      "cpu": [
+        "x64"
+      ],
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/next-runtime-env/node_modules/@next/swc-win32-arm64-msvc": {
+      "version": "16.2.3",
+      "resolved": "https://registry.npmjs.org/@next/swc-win32-arm64-msvc/-/swc-win32-arm64-msvc-16.2.3.tgz",
+      "integrity": "sha512-O2NZ9ie3Tq6xj5Z5CSwBT3+aWAMW2PIZ4egUi9MaWLkwaehgtB7YZjPm+UpcNpKOme0IQuqDcor7BsW6QBiQBw==",
+      "cpu": [
+        "arm64"
+      ],
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/next-runtime-env/node_modules/@next/swc-win32-x64-msvc": {
+      "version": "16.2.3",
+      "resolved": "https://registry.npmjs.org/@next/swc-win32-x64-msvc/-/swc-win32-x64-msvc-16.2.3.tgz",
+      "integrity": "sha512-Ibm29/GgB/ab5n7XKqlStkm54qqZE8v2FnijUPBgrd67FWrac45o/RsNlaOWjme/B5UqeWt/8KM4aWBwA1D2Kw==",
+      "cpu": [
+        "x64"
+      ],
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
     }
   }
 }

--- a/src/app/api/discovery/index.ts
+++ b/src/app/api/discovery/index.ts
@@ -13,6 +13,7 @@ import {
   RetrievedDataset,
   ValueLabel,
 } from "@/app/api/discovery/open-api/schemas";
+import { DiscoveryGVariantSearchQuery } from "@/app/api/discovery/providers/types";
 import { getDiscoveryProvider } from "@/app/api/discovery/providers/factory";
 import { createHeaders } from "@/app/api/shared/headers";
 
@@ -79,7 +80,11 @@ export const searchGVariantsApi = async (
     );
   }
 
+  const normalizedOptions: DiscoveryGVariantSearchQuery = {
+    params: options.params ?? {},
+  };
+
   return (await discoveryProvider.searchGVariants(
-    options
+    normalizedOptions
   )) as GVariantsSearchResponse[];
 };

--- a/src/app/api/discovery/open-api/discovery.yml
+++ b/src/app/api/discovery/open-api/discovery.yml
@@ -383,7 +383,9 @@ components:
           type: integer
           minimum: 0
         temporalCoverage:
-          $ref: "#/components/schemas/TimeWindow"
+          type: array
+          items:
+            $ref: "#/components/schemas/TimeWindow"
         recordsCount:
           type: integer
           title: Records count
@@ -426,10 +428,6 @@ components:
           type: string
           title: Version
           description: Version number or other version designation of the dataset.
-        license:
-          type: string
-          title: License
-          description: License identifier for the dataset.
         ownerOrg:
           type: string
           title: Owner Organization
@@ -505,17 +503,10 @@ components:
         dcatType:
           $ref: "#/components/schemas/ValueLabel"
         # Below are properties from HealthDCAT
-        publisherNote:
-          type: string
-          description: A note from the publisher about the dataset.
         publisherCoverage:
           type: array
           items:
             type: string
-        publisherType:
-          type: array
-          items:
-            $ref: "#/components/schemas/ValueLabel"
         trustedDataHolder:
           type: boolean
         hdab:
@@ -532,7 +523,9 @@ components:
           format: float
           description: Minimum spatial separation resolvable in a dataset, measured in meters.
         temporalCoverage:
-          $ref: "#/components/schemas/TimeWindow"
+          type: array
+          items:
+            $ref: "#/components/schemas/TimeWindow"
         temporalResolution:
           type: string
         populationCoverage:
@@ -572,7 +565,11 @@ components:
         analytics:
           type: array
           items:
-            type: string
+            $ref: "#/components/schemas/RetrievedDistribution"
+        samples:
+          type: array
+          items:
+            $ref: "#/components/schemas/RetrievedDistribution"
         codeValues:
           type: array
           items:
@@ -613,7 +610,7 @@ components:
         inSeries:
           type: array
           items:
-            type: string
+            $ref: "#/components/schemas/DatasetSeries"
         isReferencedBy:
           type: array
           items:
@@ -630,8 +627,6 @@ components:
               seeAlso:
                 type: string
               startedAtTime:
-                type: string
-              uri:
                 type: string
               wasAssociatedWith:
                 type: array
@@ -663,6 +658,52 @@ components:
         - id
         - title
         - description
+    DatasetSeries:
+      type: object
+      properties:
+        id:
+          type: string
+          title: Dataset internal ID
+        identifier:
+          type: string
+          title: Identifier
+        title:
+          type: string
+          title: Title
+        description:
+          type: string
+          title: Description
+        applicableLegislation:
+          type: array
+          items:
+            $ref: "#/components/schemas/ValueLabel"
+        contacts:
+          type: array
+          items:
+            $ref: "#/components/schemas/ContactPoint"
+        frequency:
+          $ref: "#/components/schemas/ValueLabel"
+        spatial:
+          type: array
+          items:
+            $ref: "#/components/schemas/ValueLabel"
+        modified:
+          type: string
+          format: date-time
+        publishers:
+          type: array
+          items:
+            $ref: "#/components/schemas/Agent"
+        issued:
+          type: string
+          format: date-time
+        temporalCoverage:
+          type: array
+          items:
+            $ref: "#/components/schemas/TimeWindow"
+      required:
+        - id
+        - title
     RetrievedDistribution:
       type: object
       properties:
@@ -738,8 +779,6 @@ components:
         spatialResolutionInMeters:
           type: number
           format: float
-        uri:
-          type: string
         accessService:
           type: array
           title: Access service
@@ -770,7 +809,6 @@ components:
                   type: string
               description:
                 type: string
-                nullable: true
               endpointDescription:
                 type: string
               endpoint_url:
@@ -784,7 +822,6 @@ components:
               id:
                 type: string
                 title: Data service internal ID
-                nullable: true
               keywords:
                 type: array
                 items:
@@ -814,8 +851,6 @@ components:
                 type: array
                 items:
                   $ref: "#/components/schemas/ValueLabel"
-              uri:
-                type: string
               title:
                 type: string
               hvdCategory:
@@ -855,13 +890,12 @@ components:
         email:
           type: string
           title: email
-        uri:
-          type: string
-          title: uri
         url:
-          type: string
+          type: array
           title: url
-          description: URL for more information about the contact point.
+          description: URLs for more information about the contact point.
+          items:
+            type: string
         identifier:
           type: string
           title: identifier
@@ -880,9 +914,6 @@ components:
         url:
           type: string
           title: url
-        uri:
-          type: string
-          title: uri
         homepage:
           type: string
           title: homepage
@@ -897,6 +928,11 @@ components:
           description: Organization the agent acted on behalf of.
           items:
             $ref: "#/components/schemas/Agent"
+        spatial:
+          type: array
+          description: Publisher spatial coverage.
+          items:
+            $ref: "#/components/schemas/ValueLabel"
       required:
         - name
     DatasetRelationEntry:
@@ -1029,23 +1065,21 @@ components:
       properties:
         params:
           $ref: "#/components/schemas/GVariantSearchQueryParams"
-      required:
-        - params
     GVariantSearchQueryParams:
       type: object
       properties:
         referenceName:
           type: string
           title: Reference Name
-          description: Optional chromosome name/identifier. If not provided, results across all chromosomes will be returned.
-          example: "3"
+          description: Optional chromosome name/identifier.
+          example: "21"
         start:
           type: array
           title: Start Position
-          description: Optional array of start positions on the reference sequence. If not provided, results across all positions will be returned.
+          description: Optional array of start positions on the reference sequence
           items:
             type: integer
-          example: [45864731]
+          example: [9411448]
         end:
           type: array
           title: End Position
@@ -1056,29 +1090,28 @@ components:
         referenceBases:
           type: string
           title: Reference Bases
-          description: Optional reference allele sequence. If not provided, results across all reference bases will be returned.
-          example: "T"
+          description: Optional reference allele sequence.
+          example: "G"
         alternateBases:
           type: string
           title: Alternate Bases
-          description: Optional alternate allele sequence. If not provided, results across all alternate bases will be returned.
-          example: "C"
+          description: Optional alternate allele sequence.
+          example: "T"
         assemblyId:
           type: string
           title: Assembly ID
-          description: Optional reference genome assembly identifier. If not provided, results across all assemblies will be returned.
+          description: Optional reference genome assembly identifier (e.g., "GRCh37", "GRCh38").
           example: "GRCh37"
         sex:
           type: string
           title: Sex
-          description: Optional sex filter (M or F)
+          description: Optional sex filter (M or F).
           example: "F"
         countryOfBirth:
           type: string
           title: Country of Birth
-          description: Optional country of birth (2-letter ISO code)
+          description: Optional country of birth (2-letter ISO code).
           example: "FR"
-      required: []
     GVariantsSearchResponse:
       type: object
       properties:
@@ -1098,12 +1131,6 @@ components:
           type: string
           description: Population name in GoE format [COUNTRY]_[SEX] where COUNTRY is 2-letter ISO code and SEX is M or F. Examples FR_M, FR_F, FR, M, F
           example: FR_M
-        sex:
-          type: string
-          title: Sex
-        countryOfBirth:
-          type: string
-          title: Country of Birth
         alleleCount:
           type: number
         alleleNumber:
@@ -1137,8 +1164,6 @@ components:
         seeAlso:
           type: string
         startedAtTime:
-          type: string
-        uri:
           type: string
         wasAssociatedWith:
           type: array

--- a/src/app/datasets/[id]/DatasetMetadata.tsx
+++ b/src/app/datasets/[id]/DatasetMetadata.tsx
@@ -82,7 +82,18 @@ const MetadataField = ({
 
 const NotProvided = () => <span className="text-primary">Not provided</span>;
 
-const isHealthDcatApCompatible = (dataset: RetrievedDataset): boolean => {
+type ExtendedRetrievedDataset = RetrievedDataset & {
+  publisherType?: ValueLabel[];
+  publisherNote?: string;
+  temporalCoverage?:
+    | RetrievedDataset["temporalCoverage"]
+    | { start?: string; end?: string };
+  analytics?: RetrievedDataset["analytics"] | string[];
+};
+
+const isHealthDcatApCompatible = (
+  dataset: ExtendedRetrievedDataset
+): boolean => {
   const healthDcatApIndicators = [
     dataset.healthTheme && dataset.healthTheme.length > 0,
     dataset.healthCategory && dataset.healthCategory.length > 0,
@@ -112,11 +123,20 @@ const DatasetMetadata = ({
   relationships,
   dictionary,
 }: {
-  dataset: RetrievedDataset;
+  dataset: ExtendedRetrievedDataset;
   relationships: DatasetRelationEntry[];
   dictionary: DatasetDictionaryEntry[];
 }) => {
   const [userTimezone, setUserTimezone] = useState<string | null>(null);
+  const temporalCoverage = Array.isArray(dataset.temporalCoverage)
+    ? dataset.temporalCoverage[0]
+    : dataset.temporalCoverage;
+  const analytics =
+    dataset.analytics
+      ?.map((entry) =>
+        typeof entry === "string" ? entry : entry.title || entry.description
+      )
+      .filter((entry): entry is string => Boolean(entry)) ?? [];
 
   useEffect(() => {
     try {
@@ -432,8 +452,8 @@ const DatasetMetadata = ({
 
       {(isHealthDcatApCompatible(dataset) ||
         (dataset.spatialCoverage && dataset.spatialCoverage.length > 0) ||
-        (dataset.temporalCoverage &&
-          (dataset.temporalCoverage.start || dataset.temporalCoverage.end)) ||
+        (temporalCoverage &&
+          (temporalCoverage.start || temporalCoverage.end)) ||
         dataset.temporalResolution ||
         dataset.spatialResolutionInMeters !== undefined) && (
         <MetadataSection title="Coverage" icon={faGlobe}>
@@ -457,16 +477,15 @@ const DatasetMetadata = ({
               label="Temporal Coverage"
               tooltip="Time period covered by the data in this dataset."
             >
-              {dataset.temporalCoverage &&
-              (dataset.temporalCoverage.start ||
-                dataset.temporalCoverage.end) ? (
+              {temporalCoverage &&
+              (temporalCoverage.start || temporalCoverage.end) ? (
                 <>
-                  {dataset.temporalCoverage.start
-                    ? formatDate(dataset.temporalCoverage.start)
+                  {temporalCoverage.start
+                    ? formatDate(temporalCoverage.start)
                     : "N/A"}{" "}
                   -{" "}
-                  {dataset.temporalCoverage.end
-                    ? formatDate(dataset.temporalCoverage.end)
+                  {temporalCoverage.end
+                    ? formatDate(temporalCoverage.end)
                     : "Present"}
                 </>
               ) : (
@@ -799,13 +818,12 @@ const DatasetMetadata = ({
         </MetadataSection>
       )}
 
-      {(isHealthDcatApCompatible(dataset) ||
-        (dataset.analytics && dataset.analytics.length > 0)) && (
+      {(isHealthDcatApCompatible(dataset) || analytics.length > 0) && (
         <MetadataSection title="Analytics" icon={faChartBar}>
           <div className="relative group">
-            {dataset.analytics && dataset.analytics.length > 0 ? (
+            {analytics.length > 0 ? (
               <Chips
-                chips={dataset.analytics}
+                chips={analytics}
                 className="bg-primary/10 text-primary rounded-full py-1"
               />
             ) : (


### PR DESCRIPTION
- Changed `temporalCoverage` to an array of `TimeWindow` references.
- Added new `DatasetSeries` schema with properties for dataset metadata.
- Updated `analytics` and `samples` to reference `RetrievedDistribution`.
- Removed deprecated properties and improved descriptions for clarity.

## Summary by Sourcery

Update the discovery OpenAPI schema to improve dataset and publisher representations, refine temporal coverage and analytics fields, and clean up deprecated or redundant properties.

New Features:
- Introduce the DatasetSeries schema to capture shared metadata for datasets in a series.
- Allow datasets and dataset series to specify multiple temporal coverage windows using TimeWindow arrays.
- Expose analytics and sample distributions as RetrievedDistribution objects instead of plain strings.
- Add spatial coverage information to publisher agents and allow contact points to have multiple URLs.

Enhancements:
- Simplify and clarify various schema descriptions and examples in the genomic variants search query parameters.
- Streamline GVariants response population details by removing redundant sex and country fields now encoded in the population name.
- Remove deprecated uri, license, publisher note, publisher type, and nullable annotations from several schemas to reduce redundancy and ambiguity.