### PR TITLE
feature: Pin Trivy to a specific version

### DIFF
--- a/.github/workflows/weekly_vuln_scan.yml
+++ b/.github/workflows/weekly_vuln_scan.yml
@@ -66,7 +66,7 @@ jobs:
             echo "Pulling $IMAGE_TAG"
             docker pull $IMAGE_TAG || exit 1
             echo "Scanning $IMAGE_TAG with Trivy"
-            docker run --rm -v /var/run/docker.sock:/var/run/docker.sock aquasec/trivy:latest image --severity CRITICAL,HIGH --exit-code 1 "$IMAGE_TAG" || exit 1
+            docker run --rm -v /var/run/docker.sock:/var/run/docker.sock aquasec/trivy:0.69.3 image --severity CRITICAL,HIGH --exit-code 1 "$IMAGE_TAG" || exit 1
 
           done
 


### PR DESCRIPTION
This commit changes Trivy version from `latest` to specific version

## Summary by Sourcery

CI:
- Update the weekly vulnerability scan GitHub Actions workflow to use Trivy image version 0.69.3.