### PR TITLE
chore: update workflow configurations to optimize deployment speed

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -33,7 +33,8 @@ jobs:
         with:
           allow-dynamic-versions: "true"
           fail-on: "issues"
-          run: "cache-dependencies,cache-scan-results,labels,analyzer,evaluator,advisor,reporter,upload-results"
+          # Keep main deployments fast; full ORT advisory runs stay in weekly/manual security scans.
+          run: "cache-dependencies,cache-scan-results,labels,analyzer,evaluator,reporter,upload-results"
 
   build-and-push-image:
     runs-on: ubuntu-latest

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -36,7 +36,8 @@ jobs:
         with:
           allow-dynamic-versions: "true"
           fail-on: "issues"
-          run: "cache-dependencies,cache-scan-results,labels,analyzer,evaluator,advisor,reporter,upload-results"
+          # Keep release pipeline fast; full ORT advisory runs stay in weekly/manual security scans.
+          run: "cache-dependencies,cache-scan-results,labels,analyzer,evaluator,reporter,upload-results"
 
   e2e-tests:
     runs-on: ubuntu-latest


### PR DESCRIPTION
## Summary by Sourcery

Simplify ORT scanning steps in main and release GitHub Actions workflows to keep deployment and release pipelines fast while relying on separate security scans for full advisory checks.

CI:
- Adjust ORT run configuration in main workflow to omit advisory steps and document reliance on separate security scans.
- Adjust ORT run configuration in release workflow to omit advisory steps and document reliance on separate security scans.