### PR TITLE
chore: update workflow configurations to optimize deployment speed

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -21,25 +21,23 @@ env:
 permissions: {}
 
 jobs:
-  ort:
-    runs-on: ubuntu-latest
-    permissions:
-      contents: read
-    steps:
-      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
-        with:
-          persist-credentials: false
-      - uses: oss-review-toolkit/ort-ci-github-action@1805edcf1f4f55f35ae6e4d2d9795ccfb29b6021 # v1
-        with:
-          allow-dynamic-versions: "true"
-          fail-on: "issues"
-          # Keep deploy pipeline fast: run dependency analysis only.
-          # Full evaluator / advisor / reporter still run in weekly/manual security scans.
-          run: "cache-dependencies,labels,analyzer,upload-results"
+  # TEMPORARY: ORT job is disabled for this workflow.
+  # ort:
+  #   runs-on: ubuntu-latest
+  #   permissions:
+  #     contents: read
+  #   steps:
+  #     - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+  #       with:
+  #         persist-credentials: false
+  #     - uses: oss-review-toolkit/ort-ci-github-action@1805edcf1f4f55f35ae6e4d2d9795ccfb29b6021 # v1
+  #       with:
+  #         allow-dynamic-versions: "true"
+  #         fail-on: "issues"
+  #         run: "cache-dependencies,cache-scan-results,labels,analyzer,evaluator,advisor,reporter,upload-results"
 
   build-and-push-image:
     runs-on: ubuntu-latest
-    needs: ort
     environment: catalogue-test
     permissions:
       contents: read

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -24,25 +24,23 @@ env:
 permissions: {}
 
 jobs:
-  ort:
-    runs-on: ubuntu-latest
-    permissions:
-      contents: read
-    steps:
-      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
-        with:
-          persist-credentials: false
-      - uses: oss-review-toolkit/ort-ci-github-action@1805edcf1f4f55f35ae6e4d2d9795ccfb29b6021 # v1
-        with:
-          allow-dynamic-versions: "true"
-          fail-on: "issues"
-          # Keep release pipeline fast: run dependency analysis only.
-          # Full evaluator / advisor / reporter still run in weekly/manual security scans.
-          run: "cache-dependencies,labels,analyzer,upload-results"
+  # TEMPORARY: ORT job is disabled for this workflow.
+  # ort:
+  #   runs-on: ubuntu-latest
+  #   permissions:
+  #     contents: read
+  #   steps:
+  #     - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+  #       with:
+  #         persist-credentials: false
+  #     - uses: oss-review-toolkit/ort-ci-github-action@1805edcf1f4f55f35ae6e4d2d9795ccfb29b6021 # v1
+  #       with:
+  #         allow-dynamic-versions: "true"
+  #         fail-on: "issues"
+  #         run: "cache-dependencies,cache-scan-results,labels,analyzer,evaluator,advisor,reporter,upload-results"
 
   e2e-tests:
     runs-on: ubuntu-latest
-    needs: ort
     permissions:
       contents: read
     env:
@@ -71,7 +69,7 @@ jobs:
 
   versioning:
     runs-on: ubuntu-latest
-    needs: [ort, e2e-tests]
+    needs: [e2e-tests]
     permissions:
       contents: write
     outputs:

--- a/.ort.yml
+++ b/.ort.yml
@@ -6,7 +6,3 @@ excludes:
     - pattern: "documentation/**"
       reason: "DOCUMENTATION_OF"
       comment: "Documentation folder that is not shipped"
-  scopes:
-    - pattern: "devDependencies"
-      reason: "DEV_DEPENDENCY_OF"
-      comment: "NPM development dependencies are not part of the runtime deployment."


### PR DESCRIPTION
## Summary by Sourcery

Temporarily disable ORT checks in main and release GitHub workflows and adjust related configuration to streamline the deployment pipeline while broadening future ORT scan coverage.

Enhancements:
- Remove the devDependencies scope exclusion from .ort.yml so development dependencies are no longer ignored by ORT.

CI:
- Comment out the ORT job in the main and release workflows and remove downstream job dependencies on it to speed up CI and deployment.
- Update the commented ORT configuration to run full analysis (including evaluator, advisor, reporter, and cache-scan-results) when re-enabled.