### PR TITLE
feat: Harvest data dictionaries from rdf and save it in local store

### DIFF
--- a/src/app/api/discovery/harvester/__tests__/dcat-harvester-service.test.ts
+++ b/src/app/api/discovery/harvester/__tests__/dcat-harvester-service.test.ts
@@ -162,6 +162,18 @@ describe("DcatHarvesterService", () => {
             label: "https://www.example.com/purpose/research",
           },
         ],
+        dataDictionary: [
+          {
+            name: "Data_1",
+            type: "string",
+            description: "This is a test description for field 1",
+          },
+          {
+            name: "Data_2",
+            type: "integer",
+            description: "This is a test description for field 2",
+          },
+        ],
         codeValues: undefined,
         codingSystem: undefined,
         isReferencedBy: [
@@ -263,6 +275,7 @@ describe("DcatHarvesterService", () => {
         applicableLegislation: undefined,
         personalData: undefined,
         purpose: undefined,
+        dataDictionary: undefined,
         codeValues: undefined,
         codingSystem: undefined,
         isReferencedBy: undefined,

--- a/src/app/api/discovery/harvester/dcat-dataset-dictionary-mapper.ts
+++ b/src/app/api/discovery/harvester/dcat-dataset-dictionary-mapper.ts
@@ -1,0 +1,74 @@
+// SPDX-FileCopyrightText: 2026 PNED G.I.E.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+import type * as RDF from "@rdfjs/types";
+import { LocalDatasetDictionaryEntry } from "@/app/api/discovery/local-store/types";
+import { RdfGraph } from "@/app/api/discovery/harvester/rdf-graph";
+
+const DCT_DESCRIPTION = "http://purl.org/dc/terms/description"; // NOSONAR
+const DC_DESCRIPTION = "http://purl.org/dc/elements/1.1/description"; // NOSONAR
+const FOAF_PAGE = "http://xmlns.com/foaf/0.1/page"; // NOSONAR
+const RDF_TYPE = "http://www.w3.org/1999/02/22-rdf-syntax-ns#type"; // NOSONAR
+const CSVW_TABLE_SCHEMA = "http://www.w3.org/ns/csvw#TableSchema"; // NOSONAR
+const CSVW_COLUMN = "http://www.w3.org/ns/csvw#column"; // NOSONAR
+const CSVW_NAME = "http://www.w3.org/ns/csvw#name"; // NOSONAR
+const CSVW_DATATYPE = "http://www.w3.org/ns/csvw#datatype"; // NOSONAR
+
+export const extractDataDictionary = (
+  datasetSubject: RDF.Term,
+  graph: RdfGraph
+): LocalDatasetDictionaryEntry[] | undefined => {
+  const result = graph
+    .getObjects(datasetSubject, FOAF_PAGE)
+    .filter((pageSubject) =>
+      graph
+        .getObjects(pageSubject, RDF_TYPE)
+        .some((object) => graph.getNamedNodeValue(object) === CSVW_TABLE_SCHEMA)
+    )
+    .flatMap((pageSubject) =>
+      graph
+        .getObjects(pageSubject, CSVW_COLUMN)
+        .map((columnSubject) => mapDictionaryEntry(columnSubject, graph))
+        .filter(
+          (entry): entry is LocalDatasetDictionaryEntry => entry !== undefined
+        )
+    );
+
+  return result.length > 0 ? result : undefined;
+};
+
+const mapDictionaryEntry = (
+  columnSubject: RDF.Term,
+  graph: RdfGraph
+): LocalDatasetDictionaryEntry | undefined => {
+  const name = graph.getLiteral(columnSubject, CSVW_NAME);
+  const type = extractColumnDatatype(columnSubject, graph);
+  const description = graph.getFirstLiteral(columnSubject, [
+    DCT_DESCRIPTION,
+    DC_DESCRIPTION,
+  ]);
+
+  if (!name || !type || !description) {
+    return undefined;
+  }
+
+  return { name, type, description };
+};
+
+const extractColumnDatatype = (
+  columnSubject: RDF.Term,
+  graph: RdfGraph
+): string => {
+  const datatype = graph.getObjects(columnSubject, CSVW_DATATYPE)[0];
+  if (!datatype) {
+    return "";
+  }
+
+  const value = graph.getNamedNodeValue(datatype) || datatype.value.trim();
+  if (!value) {
+    return "";
+  }
+
+  return value.split(/[/#]/).findLast(Boolean) || value;
+};

--- a/src/app/api/discovery/harvester/dcat-dataset-mapper.ts
+++ b/src/app/api/discovery/harvester/dcat-dataset-mapper.ts
@@ -9,6 +9,7 @@ import {
   SpatialCoverage,
 } from "@/app/api/discovery/local-store/types";
 import { extractContactPoints } from "@/app/api/discovery/harvester/dcat-contact-point-mapper";
+import { extractDataDictionary } from "@/app/api/discovery/harvester/dcat-dataset-dictionary-mapper";
 import { extractDatasetRelations } from "@/app/api/discovery/harvester/dcat-dataset-relation-mapper";
 import { extractDistributions } from "@/app/api/discovery/harvester/dcat-distribution-mapper";
 import { RdfGraph } from "@/app/api/discovery/harvester/rdf-graph";
@@ -173,6 +174,7 @@ export const mapDataset = (
     ),
     contacts: extractContactPoints(datasetSubject, graph),
     datasetRelationships: extractDatasetRelations(datasetSubject, graph),
+    dataDictionary: extractDataDictionary(datasetSubject, graph),
     distributions: extractDistributions(datasetSubject, graph, datasetId),
     publishers,
     publisherType: publisherTypes.length > 0 ? publisherTypes : undefined,

--- a/src/app/api/discovery/local-store/opensearch/__tests__/queries.test.ts
+++ b/src/app/api/discovery/local-store/opensearch/__tests__/queries.test.ts
@@ -201,6 +201,19 @@ describe("opensearch/queries", () => {
               label: { type: "keyword" },
             },
           },
+          dataDictionary: {
+            type: "object",
+            properties: {
+              name: {
+                type: "text",
+                fields: {
+                  keyword: { type: "keyword" },
+                },
+              },
+              type: { type: "keyword" },
+              description: { type: "text" },
+            },
+          },
           personalData: {
             properties: {
               value: { type: "keyword" },

--- a/src/app/api/discovery/local-store/opensearch/queries.ts
+++ b/src/app/api/discovery/local-store/opensearch/queries.ts
@@ -495,6 +495,17 @@ export const createIndexMappings = () => ({
       applicableLegislation: {
         properties: { value: { type: "keyword" }, label: { type: "keyword" } },
       },
+      dataDictionary: {
+        type: "object",
+        properties: {
+          name: {
+            type: "text",
+            fields: { keyword: { type: "keyword" } },
+          },
+          type: { type: "keyword" },
+          description: { type: "text" },
+        },
+      },
       personalData: {
         properties: { value: { type: "keyword" }, label: { type: "keyword" } },
       },

--- a/src/app/api/discovery/local-store/types.ts
+++ b/src/app/api/discovery/local-store/types.ts
@@ -47,6 +47,12 @@ export interface LocalDatasetRelation {
   target: string;
 }
 
+export interface LocalDatasetDictionaryEntry {
+  name: string;
+  type: string;
+  description: string;
+}
+
 export interface LocalDiscoveryDataset {
   id: string;
   identifier?: string;
@@ -84,6 +90,7 @@ export interface LocalDiscoveryDataset {
   distributionsCount?: number;
   contacts?: LocalContactPoint[];
   datasetRelationships?: LocalDatasetRelation[];
+  dataDictionary?: LocalDatasetDictionaryEntry[];
   publishers: LocalAgent[];
   hdab: LocalAgent[];
   creators: LocalAgent[];

--- a/src/app/api/discovery/providers/__tests__/local-index-discovery-provider.test.ts
+++ b/src/app/api/discovery/providers/__tests__/local-index-discovery-provider.test.ts
@@ -531,6 +531,18 @@ describe("LocalIndexDiscoveryProvider", () => {
           label: "https://www.example.com/purpose/research",
         },
       ],
+      dataDictionary: [
+        {
+          name: "Data_1",
+          type: "string",
+          description: "This is a test description for field 1",
+        },
+        {
+          name: "Data_2",
+          type: "integer",
+          description: "This is a test description for field 2",
+        },
+      ],
       distributions: [
         {
           id: "distribution-1",
@@ -731,6 +743,18 @@ describe("LocalIndexDiscoveryProvider", () => {
         {
           value: "https://www.example.com/purpose/research",
           label: "https://www.example.com/purpose/research",
+        },
+      ],
+      dataDictionary: [
+        {
+          name: "Data_1",
+          type: "string",
+          description: "This is a test description for field 1",
+        },
+        {
+          name: "Data_2",
+          type: "integer",
+          description: "This is a test description for field 2",
         },
       ],
       distributions: [

--- a/src/app/api/discovery/providers/local-index-discovery-provider.ts
+++ b/src/app/api/discovery/providers/local-index-discovery-provider.ts
@@ -187,6 +187,7 @@ export class LocalIndexDiscoveryProvider extends BasePlaceholderDiscoveryProvide
       ...this.mapLocalDataset(dataset),
       contacts: dataset.contacts,
       datasetRelationships: dataset.datasetRelationships,
+      dataDictionary: dataset.dataDictionary,
       healthTheme: dataset.healthTheme ?? [],
       healthCategory: dataset.healthCategory ?? [],
       dcatType,

--- a/src/app/api/discovery/test-utils/fixtures.ts
+++ b/src/app/api/discovery/test-utils/fixtures.ts
@@ -15,6 +15,7 @@ export const canonicalDiscoveryRdf = `
            xmlns:rdfs="http://www.w3.org/2000/01/rdf-schema#"
            xmlns:skos="http://www.w3.org/2004/02/skos/core#"
            xmlns:dpv="http://www.w3.org/ns/dpv#"
+           xmlns:csvw="http://www.w3.org/ns/csvw#"
            xmlns:foaf="http://xmlns.com/foaf/0.1/"
            xmlns:vcard="http://www.w3.org/2006/vcard/ns#">
     <dcat:Catalog rdf:about="https://example.org/catalogues/main">
@@ -117,6 +118,35 @@ export const canonicalDiscoveryRdf = `
           <dct:description xml:lang="eng">https://www.example.com/purpose/research</dct:description>
         </dpv:Purpose>
       </dpv:hasPurpose>
+      <foaf:page>
+        <foaf:Document rdf:nodeID="Nc7c963dbbd1a488fa763cf3e13cfaf21">
+          <rdf:type rdf:resource="http://www.w3.org/ns/csvw#TableSchema"/>
+          <csvw:column>
+            <csvw:Column rdf:nodeID="Ncfd77d58a1a54203a688390ef40d27d4">
+              <csvw:name>Data_1</csvw:name>
+              <csvw:datatype rdf:resource="http://www.w3.org/2001/XMLSchema#string"/>
+              <dct:description xml:lang="eng">This is a test description for field 1</dct:description>
+              <csvw:required rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</csvw:required>
+              <csvw:in xml:lang="eng">[1,2,3]</csvw:in>
+              <rdfs:comment xml:lang="eng">[1=Low, 2=Medium, 3=High]</rdfs:comment>
+            </csvw:Column>
+          </csvw:column>
+          <csvw:column>
+            <csvw:Column rdf:nodeID="N0a793d617ce247cd9364e1e295315ce5">
+              <rdf:type rdf:resource="http://www.w3.org/ns/dpv#PersonalData"/>
+              <csvw:name>Data_2</csvw:name>
+              <csvw:datatype rdf:resource="http://www.w3.org/2001/XMLSchema#integer"/>
+              <dct:description xml:lang="eng">This is a test description for field 2</dct:description>
+              <csvw:required rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">false</csvw:required>
+              <csvw:maxInclusive rdf:datatype="http://www.w3.org/2001/XMLSchema#decimal">100.0</csvw:maxInclusive>
+              <csvw:minInclusive rdf:datatype="http://www.w3.org/2001/XMLSchema#decimal">10.0</csvw:minInclusive>
+              <csvw:unit>kg</csvw:unit>
+              <csvw:in xml:lang="eng">[10,20,30]</csvw:in>
+              <rdfs:comment xml:lang="eng">[10=Low, 20=Medium, 30=High]</rdfs:comment>
+            </csvw:Column>
+          </csvw:column>
+        </foaf:Document>
+      </foaf:page>
       <dct:publisher>
         <foaf:Agent rdf:nodeID="Npublisher1">
           <foaf:name xml:lang="eng">org</foaf:name>
@@ -270,6 +300,18 @@ export const buildLocalDiscoveryDataset = (
     {
       value: "https://www.example.com/purpose/research", // NOSONAR
       label: "https://www.example.com/purpose/research",
+    },
+  ],
+  dataDictionary: [
+    {
+      name: "Data_1",
+      type: "string",
+      description: "This is a test description for field 1",
+    },
+    {
+      name: "Data_2",
+      type: "integer",
+      description: "This is a test description for field 2",
     },
   ],
   distributions: [


### PR DESCRIPTION
This PR adds harvesting support for dataset data dictionaries from DCAT RDF and exposes them through the local discovery flow so they can be shown in the dataset details UI

The parsing logic will change in future because the way we represent dictionaries in rdf if not fully correct

## Summary by Sourcery

Harvest dataset data dictionaries from DCAT RDF and store them in the local discovery index so they are available via the local discovery provider.

New Features:
- Add extraction of CSVW-based data dictionary entries from DCAT RDF datasets into local dataset models.
- Expose harvested data dictionary entries through the local discovery provider for use in dataset details views.

Enhancements:
- Extend local discovery dataset types and OpenSearch index mappings to support structured data dictionary entries.

Tests:
- Add unit tests and RDF fixtures to verify harvesting, storage, and exposure of dataset data dictionaries in the local discovery flow.