### PR TITLE
feat: add dataset series filter to search functionality and update tests and documentation

### DIFF
--- a/.prettierignore
+++ b/.prettierignore
@@ -1,2 +1,3 @@
 *.hbs
 .cache/
+CHANGELOG.md

--- a/documentation/docs/user-guide/explore-datasets/search-and-filter.md
+++ b/documentation/docs/user-guide/explore-datasets/search-and-filter.md
@@ -32,7 +32,7 @@ On the **Home** or **Datasets** page, enter any term or phrase to search across 
 
 ## Filter your results
 
-Use the filters on the left side of the search results page to narrow down your results. These filters are based on dataset metadata, and signing in gives you access to additional metadata-based filters. Common filters include: Access Rights, Data Types, Themes, and Publishers.
+Use the filters on the left side of the search results page to narrow down your results. These filters are based on dataset metadata, and signing in gives you access to additional metadata-based filters. Common filters include: Access Rights, Data Types, Themes, Dataset series, and Publishers.
 
 Here's an example of a search result for the word "cancer", with filters applied for Access Rights: `Public`.
 

--- a/tests/datasets.spec.ts
+++ b/tests/datasets.spec.ts
@@ -41,11 +41,20 @@ test("Dataset list renders filters and results", async ({ page }) => {
   await expect(themeFilterButton).toBeVisible({ timeout: 15000 });
   await themeFilterButton.click();
   await page.getByLabel("Oncology").check();
+  const datasetSeriesFilterButton = page.getByRole("button", {
+    name: /dataset series/i,
+  });
+  await expect(datasetSeriesFilterButton).toBeVisible();
+  await datasetSeriesFilterButton.click();
+  await page.getByLabel("Colorectal cohort").check();
 
   await expect(
     page.getByRole("heading", { name: /active filters/i })
   ).toBeVisible();
   await expect(page.getByText(/theme\s*:\s*oncology/i)).toBeVisible();
+  await expect(
+    page.getByText(/dataset series\s*:\s*colorectal cohort/i)
+  ).toBeVisible();
 
   // Dataset list
   await expect(

--- a/tests/mocks/discovery.json
+++ b/tests/mocks/discovery.json
@@ -28,6 +28,25 @@
       "source": "ckan",
       "group": "catalog",
       "type": "DROPDOWN",
+      "key": "vocab_in_series_title",
+      "label": "Dataset series",
+      "values": [
+        {
+          "value": "colorectal-cohort",
+          "label": "Colorectal cohort",
+          "count": 4
+        },
+        {
+          "value": "rare-disease-panel",
+          "label": "Rare disease panel",
+          "count": 2
+        }
+      ]
+    },
+    {
+      "source": "ckan",
+      "group": "catalog",
+      "type": "DROPDOWN",
       "key": "publisher_name",
       "label": "Publisher",
       "values": [
@@ -106,6 +125,18 @@
         "value": "public_health",
         "label": "Public Health",
         "count": 5
+      }
+    ],
+    "vocab_in_series_title": [
+      {
+        "value": "colorectal-cohort",
+        "label": "Colorectal cohort",
+        "count": 4
+      },
+      {
+        "value": "rare-disease-panel",
+        "label": "Rare disease panel",
+        "count": 2
       }
     ],
     "publisher_name": [


### PR DESCRIPTION
- Added "Dataset series" filter option to the search and filter functionality in the dataset list.
- Updated the user guide documentation to reflect the new filter option.
- Added "CHANGELOG.md" to the Prettier ignore list.

## Summary by Sourcery

Add support and coverage for a new dataset series filter in dataset search and update related docs and tooling configuration.

New Features:
- Introduce a dataset series metadata filter in the dataset search experience.

Build:
- Exclude CHANGELOG.md from Prettier formatting via the ignore configuration.

Documentation:
- Update the user guide search-and-filter documentation to describe the new dataset series filter option.

Tests:
- Extend dataset list UI tests and supporting mocks to cover filtering by dataset series.