### PR TITLE
feat: make about content shown as html

### DIFF
--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -138,16 +138,12 @@ const HomePage = ({ searchParams }: HomePageProps) => {
         ></div>
         <div className="relative z-10 w-full md:w-3/4 lg:w-2/3 xl:w-3/5">
           <h3 className="mb-4 text-2xl">About the data portal</h3>
-          <p className="text-lg">
-            {contentConfig.aboutContent.split("\n").map((line, index) => (
-              <span key={index}>
-                {line}
-                {index < contentConfig.aboutContent.split("\n").length - 1 && (
-                  <br />
-                )}
-              </span>
-            ))}
-          </p>
+          <p
+            className="text-lg"
+            dangerouslySetInnerHTML={{
+              __html: contentConfig.aboutContent.replace(/\n/g, "<br />"),
+            }}
+          />
           <br />
           <a
             className="link-arrow text-primary hover:text-hover-color"


### PR DESCRIPTION
This pr allows the about content on the home page to be rendered as html.

## Summary by Sourcery

New Features:
- Support HTML-formatted about content on the home page, including proper handling of line breaks.