### PR TITLE
feat: Generate Data Dictionary in RDF export

### DIFF
--- a/src/app/api/discovery/harvester/__tests__/dcat-dataset-rdf-generator.test.ts
+++ b/src/app/api/discovery/harvester/__tests__/dcat-dataset-rdf-generator.test.ts
@@ -580,7 +580,9 @@ describe("DCAT dataset export generators", () => {
           .map((q) => q.subject.value)
       ),
     ].sort();
-    expect(typeSubjects).toEqual([
+    expect(
+      typeSubjects.filter((subject) => dataset.documentation?.includes(subject))
+    ).toEqual([
       "https://example.org/docs/dataset-1",
       "https://example.org/docs/dataset-1-guide",
     ]);

--- a/src/app/api/discovery/harvester/__tests__/dcat-dataset-rdf-generator.test.ts
+++ b/src/app/api/discovery/harvester/__tests__/dcat-dataset-rdf-generator.test.ts
@@ -23,6 +23,13 @@ import { buildLocalDiscoveryDataset } from "@/app/api/discovery/test-utils/fixtu
 
 describe("DCAT dataset export generators", () => {
   const originalBaseUrl = process.env.NEXT_PUBLIC_BASE_URL;
+  const FOAF_PAGE = "http://xmlns.com/foaf/0.1/page";
+  const RDF_TYPE = "http://www.w3.org/1999/02/22-rdf-syntax-ns#type";
+  const CSVW_TABLE_SCHEMA = "http://www.w3.org/ns/csvw#TableSchema";
+  const CSVW_COLUMN = "http://www.w3.org/ns/csvw#column";
+  const CSVW_NAME = "http://www.w3.org/ns/csvw#name";
+  const CSVW_DATATYPE = "http://www.w3.org/ns/csvw#datatype";
+  const DCT_DESCRIPTION = "http://purl.org/dc/terms/description";
 
   beforeEach(() => {
     process.env.NEXT_PUBLIC_BASE_URL = "https://portal.example.org/";
@@ -229,6 +236,7 @@ describe("DCAT dataset export generators", () => {
       publishers: [],
       hdab: [],
       creators: [],
+      dataDictionary: undefined,
       keywords: undefined,
       themes: undefined,
       healthTheme: undefined,
@@ -281,6 +289,119 @@ describe("DCAT dataset export generators", () => {
       graph.some(
         (item) =>
           item["@id"] === "https://portal.example.org/datasets/dataset-1"
+      )
+    ).toBe(true);
+  });
+
+  test("emits data dictionary entries in all export formats", async () => {
+    const dataset = buildLocalDiscoveryDataset({
+      id: "https://example.org/datasets/export-1",
+      dataDictionary: [
+        {
+          name: "patient_id",
+          type: "string",
+          description: "Pseudonymous patient identifier",
+        },
+        {
+          name: "visit_count",
+          type: "integer",
+          description: "Number of recorded visits",
+        },
+      ],
+      documentation: undefined,
+    });
+
+    const rdfXml = await serializeDatasetAsRdfXml(dataset);
+    const turtle = await serializeDatasetAsTurtle(dataset);
+    const jsonLd = JSON.parse(
+      await serializeDatasetAsJsonLd(dataset)
+    ) as Record<string, unknown>;
+    const quads = await parseRdfXmlToQuads(rdfXml);
+
+    const schemaNodes = [
+      ...new Set(
+        quads
+          .filter(
+            (q) =>
+              q.subject.value === "https://example.org/datasets/export-1" &&
+              q.predicate.value === FOAF_PAGE
+          )
+          .map((q) => q.object.value)
+      ),
+    ];
+
+    expect(schemaNodes).toHaveLength(1);
+    expect(
+      quads.some(
+        (q) =>
+          q.subject.value === schemaNodes[0] &&
+          q.predicate.value === RDF_TYPE &&
+          q.object.value === CSVW_TABLE_SCHEMA
+      )
+    ).toBe(true);
+
+    const columnNodes = quads
+      .filter(
+        (q) =>
+          q.subject.value === schemaNodes[0] &&
+          q.predicate.value === CSVW_COLUMN
+      )
+      .map((q) => q.object.value);
+    expect(columnNodes).toHaveLength(2);
+
+    expect(
+      quads.some(
+        (q) =>
+          columnNodes.includes(q.subject.value) &&
+          q.predicate.value === CSVW_NAME &&
+          q.object.value === "patient_id"
+      )
+    ).toBe(true);
+    expect(
+      quads.some(
+        (q) =>
+          columnNodes.includes(q.subject.value) &&
+          q.predicate.value === CSVW_DATATYPE &&
+          q.object.value === "http://www.w3.org/2001/XMLSchema#string"
+      )
+    ).toBe(true);
+    expect(
+      quads.some(
+        (q) =>
+          columnNodes.includes(q.subject.value) &&
+          q.predicate.value === DCT_DESCRIPTION &&
+          q.object.value === "Pseudonymous patient identifier"
+      )
+    ).toBe(true);
+
+    expect(turtle).toContain("@prefix csvw:");
+    expect(turtle).toContain("csvw:TableSchema");
+    expect(turtle).toContain('csvw:name "patient_id"');
+    expect(turtle).toContain("csvw:datatype xsd:string");
+
+    const graph = jsonLd["@graph"] as Array<Record<string, unknown>>;
+    expect(
+      graph.some(
+        (item) =>
+          item["@id"] === "https://example.org/datasets/export-1" &&
+          Array.isArray(item["foaf:page"])
+      )
+    ).toBe(true);
+    expect(
+      graph.some(
+        (item) =>
+          Array.isArray(item["@type"]) &&
+          (item["@type"] as string[]).includes("csvw:TableSchema") &&
+          Array.isArray(item["csvw:column"])
+      )
+    ).toBe(true);
+    expect(
+      graph.some(
+        (item) =>
+          Array.isArray(item["@type"]) &&
+          (item["@type"] as string[]).includes("csvw:Column") &&
+          JSON.stringify(item).includes("patient_id") &&
+          JSON.stringify(item).includes("xsd:string")
       )
     ).toBe(true);
   });

--- a/src/app/api/discovery/harvester/__tests__/dcat-dataset-rdf-shared.test.ts
+++ b/src/app/api/discovery/harvester/__tests__/dcat-dataset-rdf-shared.test.ts
@@ -64,6 +64,7 @@ describe("dcat dataset rdf shared helpers", () => {
       rdfs: "http://www.w3.org/2000/01/rdf-schema#",
       skos: "http://www.w3.org/2004/02/skos/core#",
       dpv: "http://www.w3.org/ns/dpv#",
+      csvw: "http://www.w3.org/ns/csvw#",
       foaf: "http://xmlns.com/foaf/0.1/",
       vcard: "http://www.w3.org/2006/vcard/ns#",
       xsd: "http://www.w3.org/2001/XMLSchema#",

--- a/src/app/api/discovery/harvester/dcat-dataset-quad-builder.ts
+++ b/src/app/api/discovery/harvester/dcat-dataset-quad-builder.ts
@@ -13,6 +13,7 @@ import { addDatasetClassificationQuads } from "@/app/api/discovery/harvester/rdf
 import { addDatasetContactQuads } from "@/app/api/discovery/harvester/rdf/mappers/dataset-contact-quad-mapper";
 import { addDatasetCoreQuads } from "@/app/api/discovery/harvester/rdf/mappers/dataset-core-quad-mapper";
 import { addDatasetCoverageQuads } from "@/app/api/discovery/harvester/rdf/mappers/dataset-coverage-quad-mapper";
+import { addDatasetDictionaryQuads } from "@/app/api/discovery/harvester/rdf/mappers/dataset-dictionary-quad-mapper";
 import { addDatasetDistributionQuads } from "@/app/api/discovery/harvester/rdf/mappers/dataset-distribution-quad-mapper";
 import { addDatasetGovernanceQuads } from "@/app/api/discovery/harvester/rdf/mappers/dataset-governance-quad-mapper";
 import { addDatasetRelationQuads } from "@/app/api/discovery/harvester/rdf/mappers/dataset-relation-quad-mapper";
@@ -28,6 +29,7 @@ export const buildDatasetRdfStore = (
   addDatasetGovernanceQuads(context);
   addDatasetAgentQuads(context);
   addDatasetContactQuads(context);
+  addDatasetDictionaryQuads(context);
   addDatasetRelationQuads(context);
   addDatasetDistributionQuads(context);
 

--- a/src/app/api/discovery/harvester/dcat-dataset-rdf-shared.ts
+++ b/src/app/api/discovery/harvester/dcat-dataset-rdf-shared.ts
@@ -16,6 +16,7 @@ export const DATASET_EXPORT_PREFIXES = {
   rdfs: "http://www.w3.org/2000/01/rdf-schema#", // NOSONAR
   skos: "http://www.w3.org/2004/02/skos/core#", // NOSONAR
   dpv: "http://www.w3.org/ns/dpv#", // NOSONAR
+  csvw: "http://www.w3.org/ns/csvw#", // NOSONAR
   foaf: "http://xmlns.com/foaf/0.1/", // NOSONAR
   vcard: "http://www.w3.org/2006/vcard/ns#", // NOSONAR
   xsd: "http://www.w3.org/2001/XMLSchema#", // NOSONAR

--- a/src/app/api/discovery/harvester/rdf/context.ts
+++ b/src/app/api/discovery/harvester/rdf/context.ts
@@ -32,6 +32,7 @@ export const ns = {
   rdfs: rdf.Namespace(DATASET_EXPORT_PREFIXES.rdfs),
   skos: rdf.Namespace(DATASET_EXPORT_PREFIXES.skos),
   dpv: rdf.Namespace(DATASET_EXPORT_PREFIXES.dpv),
+  csvw: rdf.Namespace(DATASET_EXPORT_PREFIXES.csvw),
   foaf: rdf.Namespace(DATASET_EXPORT_PREFIXES.foaf),
   vcard: rdf.Namespace(DATASET_EXPORT_PREFIXES.vcard),
   xsd: rdf.Namespace(DATASET_EXPORT_PREFIXES.xsd),

--- a/src/app/api/discovery/harvester/rdf/mappers/dataset-dictionary-quad-mapper.ts
+++ b/src/app/api/discovery/harvester/rdf/mappers/dataset-dictionary-quad-mapper.ts
@@ -6,8 +6,8 @@ import {
   DATASET_EXPORT_PREFIXES,
   DatasetRdfContext,
   addLiteral,
-  createBlankNode,
   createNamedNode,
+  createNestedNode,
   isAbsoluteUri,
   isNonEmptyString,
   ns,
@@ -27,12 +27,15 @@ export const addDatasetDictionaryQuads = ({
     return;
   }
 
-  const schemaNode = createBlankNode();
+  const schemaNode = createNestedNode(
+    { dataset, store, datasetNode },
+    "data-dictionary"
+  );
   store.add(datasetNode, ns.foaf("page"), schemaNode);
   store.add(schemaNode, ns.rdf("type"), ns.foaf("Document"));
   store.add(schemaNode, ns.rdf("type"), ns.csvw("TableSchema"));
 
-  dataset.dataDictionary.forEach((entry) => {
+  dataset.dataDictionary.forEach((entry, index) => {
     if (
       !isNonEmptyString(entry.name) ||
       !isNonEmptyString(entry.type) ||
@@ -41,7 +44,10 @@ export const addDatasetDictionaryQuads = ({
       return;
     }
 
-    const columnNode = createBlankNode();
+    const columnNode = createNestedNode(
+      { dataset, store, datasetNode },
+      `data-dictionary-column-${index + 1}`
+    );
     store.add(schemaNode, ns.csvw("column"), columnNode);
     store.add(columnNode, ns.rdf("type"), ns.csvw("Column"));
     addLiteral(store, columnNode, ns.csvw("name"), entry.name);

--- a/src/app/api/discovery/harvester/rdf/mappers/dataset-dictionary-quad-mapper.ts
+++ b/src/app/api/discovery/harvester/rdf/mappers/dataset-dictionary-quad-mapper.ts
@@ -1,0 +1,55 @@
+// SPDX-FileCopyrightText: 2026 PNED G.I.E.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+import {
+  DATASET_EXPORT_PREFIXES,
+  DatasetRdfContext,
+  addLiteral,
+  createBlankNode,
+  createNamedNode,
+  isAbsoluteUri,
+  isNonEmptyString,
+  ns,
+} from "@/app/api/discovery/harvester/rdf/context";
+
+const toDictionaryDatatypeNode = (value: string) =>
+  createNamedNode(
+    isAbsoluteUri(value) ? value : `${DATASET_EXPORT_PREFIXES.xsd}${value}`
+  );
+
+export const addDatasetDictionaryQuads = ({
+  dataset,
+  store,
+  datasetNode,
+}: DatasetRdfContext): void => {
+  if (!dataset.dataDictionary?.length) {
+    return;
+  }
+
+  const schemaNode = createBlankNode();
+  store.add(datasetNode, ns.foaf("page"), schemaNode);
+  store.add(schemaNode, ns.rdf("type"), ns.foaf("Document"));
+  store.add(schemaNode, ns.rdf("type"), ns.csvw("TableSchema"));
+
+  dataset.dataDictionary.forEach((entry) => {
+    if (
+      !isNonEmptyString(entry.name) ||
+      !isNonEmptyString(entry.type) ||
+      !isNonEmptyString(entry.description)
+    ) {
+      return;
+    }
+
+    const columnNode = createBlankNode();
+    store.add(schemaNode, ns.csvw("column"), columnNode);
+    store.add(columnNode, ns.rdf("type"), ns.csvw("Column"));
+    addLiteral(store, columnNode, ns.csvw("name"), entry.name);
+    store.add(
+      columnNode,
+      ns.csvw("datatype"),
+      toDictionaryDatatypeNode(entry.type)
+    );
+    addLiteral(store, columnNode, ns.dct("description"), entry.description);
+  });
+};


### PR DESCRIPTION
<img width="883" height="403" alt="Screenshot 2026-04-16 at 11 04 03" src="https://github.com/user-attachments/assets/384b1377-ee27-4a77-ad66-a0d34b9fa56f" />

## Summary by Sourcery

Export dataset data dictionaries as CSVW table schemas in RDF outputs.

New Features:
- Include dataset data dictionaries in RDF exports as CSVW TableSchema/Column structures linked via foaf:page across RDF/XML, Turtle, and JSON-LD formats.

Enhancements:
- Wire CSVW and related FOAF/XSD prefixes and namespaces into the RDF context and dataset quad builder to support data dictionary emission.

Tests:
- Add comprehensive tests verifying data dictionary export across RDF/XML, Turtle, and JSON-LD, including structure, datatypes, and descriptions.