### PR TITLE
feat: Add dataset series count and implement DataSeriesAccordion component

### DIFF
--- a/src/app/api/discovery/open-api/discovery.yml
+++ b/src/app/api/discovery/open-api/discovery.yml
@@ -392,6 +392,9 @@ components:
         distributionsCount:
           type: integer
           title: Distributions count
+        inSeriesCount:
+          type: integer
+          title: Dataset series count
       required:
         - id
         - title

--- a/src/app/datasets/[id]/DataSeriesAccordion.tsx
+++ b/src/app/datasets/[id]/DataSeriesAccordion.tsx
@@ -1,0 +1,176 @@
+// SPDX-FileCopyrightText: 2026 PNED G.I.E.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+"use client";
+
+import React, { useEffect, useRef, useState } from "react";
+import Link from "next/link";
+import { FontAwesomeIcon } from "@fortawesome/react-fontawesome";
+import {
+  faChevronDown,
+  faChevronUp,
+  faCalendarAlt,
+  faClock,
+  faLayerGroup,
+  faBuilding,
+} from "@fortawesome/free-solid-svg-icons";
+import { formatDate } from "@/utils/formatDate";
+import { DatasetSeries } from "@/app/api/discovery/open-api/schemas";
+import Tooltip from "./Tooltip";
+
+type DataSeriesAccordionProps = {
+  series: DatasetSeries[];
+};
+
+const isExternalUrl = (value?: string): value is string =>
+  Boolean(value && /^https?:\/\//i.test(value));
+
+const resolveSeriesHref = (seriesItem: DatasetSeries): string =>
+  isExternalUrl(seriesItem.identifier)
+    ? seriesItem.identifier
+    : `/datasets/${encodeURIComponent(seriesItem.id)}`;
+
+export default function DataSeriesAccordion({
+  series,
+}: DataSeriesAccordionProps) {
+  const [openIndex, setOpenIndex] = useState<null | number>(null);
+  const contentRefs = useRef<(HTMLDivElement | null)[]>([]);
+
+  useEffect(() => {
+    contentRefs.current = contentRefs.current.slice(0, series.length);
+  }, [series]);
+
+  const toggleItem = (index: number) => {
+    setOpenIndex((current) => (current === index ? null : index));
+  };
+
+  return (
+    <div className="accordion w-full">
+      {series.map((seriesItem, index) => {
+        const href = resolveSeriesHref(seriesItem);
+        const external = isExternalUrl(href);
+
+        return (
+          <div
+            className="w-full border-b border-primary/20 last:border-b-0"
+            key={seriesItem.id}
+          >
+            <button
+              type="button"
+              onClick={() => toggleItem(index)}
+              className={`flex w-full cursor-pointer items-center justify-between rounded-md px-2 py-3 text-left transition-colors ${
+                openIndex === index ? "bg-hover" : "hover:bg-hover"
+              }`}
+              aria-expanded={openIndex === index}
+            >
+              <span className="flex items-center relative group">
+                <FontAwesomeIcon icon={faLayerGroup} className="text-primary" />
+                <span className="ml-2 break-all font-medium">
+                  {external ? (
+                    <a
+                      href={href}
+                      target="_blank"
+                      rel="noopener noreferrer"
+                      className="text-info hover:text-hover-color hover:underline"
+                      onClick={(event) => event.stopPropagation()}
+                    >
+                      {seriesItem.title}
+                    </a>
+                  ) : (
+                    <Link
+                      href={href}
+                      className="text-info hover:text-hover-color hover:underline"
+                      onClick={(event) => event.stopPropagation()}
+                    >
+                      {seriesItem.title}
+                    </Link>
+                  )}
+                </span>
+                <Tooltip message="Open dataset series details." />
+              </span>
+              <FontAwesomeIcon
+                icon={openIndex === index ? faChevronUp : faChevronDown}
+                className="text-primary"
+              />
+            </button>
+            <div
+              ref={(el: HTMLDivElement | null) => {
+                contentRefs.current[index] = el;
+              }}
+              style={{
+                maxHeight:
+                  openIndex === index
+                    ? `${contentRefs.current[index]?.scrollHeight}px`
+                    : "0",
+                overflow: "hidden",
+                transition: "max-height 0.5s ease",
+              }}
+              className="overflow-hidden"
+            >
+              <div className="px-2 pb-4 text-sm">
+                <div className="ml-3 border-l-2 border-primary/20 pl-4">
+                  <div className="mb-2 relative group">
+                    <strong>Description: </strong>
+                    <span>{seriesItem.description || "NA"}</span>
+                    <Tooltip message="Description of the dataset series." />
+                  </div>
+                  <div className="grid grid-cols-1 sm:grid-cols-2 gap-3">
+                    <div className="flex items-center gap-2 relative group">
+                      <FontAwesomeIcon
+                        icon={faCalendarAlt}
+                        className="text-primary align-middle"
+                      />
+                      <strong>Issued:</strong>
+                      <span>
+                        {seriesItem.issued
+                          ? formatDate(seriesItem.issued)
+                          : "NA"}
+                      </span>
+                      <Tooltip message="Date when the dataset series was issued." />
+                    </div>
+                    <div className="flex items-center gap-2 relative group">
+                      <FontAwesomeIcon
+                        icon={faCalendarAlt}
+                        className="text-primary align-middle"
+                      />
+                      <strong>Modified:</strong>
+                      <span>
+                        {seriesItem.modified
+                          ? formatDate(seriesItem.modified)
+                          : "NA"}
+                      </span>
+                      <Tooltip message="Date when the dataset series was last modified." />
+                    </div>
+                    <div className="flex items-center gap-2 relative group">
+                      <FontAwesomeIcon
+                        icon={faClock}
+                        className="text-primary align-middle"
+                      />
+                      <strong>Frequency:</strong>
+                      <span>{seriesItem.frequency?.label || "NA"}</span>
+                      <Tooltip message="Update frequency for the dataset series." />
+                    </div>
+                    <div className="flex items-center gap-2 relative group">
+                      <FontAwesomeIcon
+                        icon={faBuilding}
+                        className="text-primary align-middle"
+                      />
+                      <strong>Publisher:</strong>
+                      <span>
+                        {seriesItem.publishers
+                          ?.map((publisher) => publisher.name)
+                          .join(", ") || "NA"}
+                      </span>
+                      <Tooltip message="Publishers responsible for the dataset series." />
+                    </div>
+                  </div>
+                </div>
+              </div>
+            </div>
+          </div>
+        );
+      })}
+    </div>
+  );
+}

--- a/src/app/datasets/[id]/DatasetMetadata.tsx
+++ b/src/app/datasets/[id]/DatasetMetadata.tsx
@@ -25,6 +25,7 @@ import {
   faChartBar,
   faCode,
   faLink,
+  faLayerGroup,
   faInfoCircle,
   faUserShield,
   faNoteSticky,
@@ -33,6 +34,7 @@ import {
 } from "@fortawesome/free-solid-svg-icons";
 import { formatDate } from "@/utils/formatDate";
 import DistributionAccordion from "./DistributionAccordion";
+import DataSeriesAccordion from "./DataSeriesAccordion";
 import Link from "next/link";
 import Tooltip from "./Tooltip";
 import Chips from "@/components/Chips";
@@ -267,6 +269,23 @@ const DatasetMetadata = ({
                   : `${dataset.distributions.length} Distributions`}
               </span>
               <Tooltip message="Number of distributions available for the dataset." />
+            </span>
+          </>
+        )}
+        {dataset.inSeries && dataset.inSeries.length > 0 && (
+          <>
+            <div className="text-lightaccent hidden sm:inline-block">|</div>
+            <span className="flex gap-2 items-center relative group">
+              <FontAwesomeIcon
+                icon={faLayerGroup}
+                className="align-middle text-primary"
+              />
+              <span className="align-middle">
+                {dataset.inSeries.length === 1
+                  ? "1 Dataset series"
+                  : `${dataset.inSeries.length} Dataset series`}
+              </span>
+              <Tooltip message="Number of dataset series this dataset belongs to." />
             </span>
           </>
         )}
@@ -834,10 +853,16 @@ const DatasetMetadata = ({
         </MetadataSection>
       )}
 
+      {dataset.inSeries && dataset.inSeries.length > 0 && (
+        <MetadataSection title="Data Series" icon={faLayerGroup}>
+          <DataSeriesAccordion series={dataset.inSeries} />
+        </MetadataSection>
+      )}
+
       {dataset.distributions && dataset.distributions.length > 0 && (
-        <div className="mt-4">
+        <MetadataSection title="Distributions" icon={faFile}>
           <DistributionAccordion distributions={dataset.distributions} />
-        </div>
+        </MetadataSection>
       )}
     </>
   );

--- a/src/app/datasets/[id]/DistributionAccordion.tsx
+++ b/src/app/datasets/[id]/DistributionAccordion.tsx
@@ -48,20 +48,23 @@ const DistributionAccordion = ({
   };
 
   return (
-    <div className="accordion flex w-full flex-col items-center justify-center">
+    <div className="accordion w-full">
       {distributions.map((distribution, index) => (
         <div
-          className="mb-2 w-full rounded-2xl bg-surface hover:bg-hover transition relative"
+          className="w-full border-b border-primary/20 last:border-b-0"
           key={distribution.id}
         >
-          <div
+          <button
+            type="button"
             onClick={() => toggleItem(index)}
-            onKeyPress={() => toggleItem(index)}
-            className="flex cursor-pointer items-center justify-between rounded-2xl p-4"
+            className={`flex w-full cursor-pointer items-center justify-between rounded-md px-2 py-3 text-left transition-colors ${
+              openIndex === index ? "bg-hover" : "hover:bg-hover"
+            }`}
+            aria-expanded={openIndex === index}
           >
             <span className="flex items-center">
               <FontAwesomeIcon icon={faFile} className="text-primary" />
-              <span className="struncate ml-2 break-all">
+              <span className="ml-2 break-all font-medium">
                 {distribution.title}
               </span>
             </span>
@@ -69,7 +72,7 @@ const DistributionAccordion = ({
               icon={openIndex === index ? faChevronUp : faChevronDown}
               className="text-primary"
             />
-          </div>
+          </button>
           <div
             ref={(el: HTMLDivElement | null) => {
               contentRefs.current[index] = el;
@@ -82,205 +85,211 @@ const DistributionAccordion = ({
               overflow: "hidden",
               transition: "max-height 0.5s ease",
             }}
-            className="rounded-b-2xl bg-white"
+            className="overflow-hidden"
           >
-            <div className="p-4 pb-8">
-              <div className="relative group">
-                <strong className="block text-sm font-semibold">
-                  <FontAwesomeIcon
-                    icon={faFileAlt}
-                    className="text-primary align-middle mr-2"
-                  />
-                  Description:
-                </strong>
-                <span className="text-sm">{distribution.description}</span>
-                <Tooltip message="Description of the distribution." />
-              </div>
-              <div className="grid grid-cols-1 sm:grid-cols-2 gap-4 mt-4">
-                <div className="flex items-center relative">
-                  <span className="group flex items-center">
+            <div className="px-2 pb-4">
+              <div className="ml-3 border-l-2 border-primary/20 pl-4">
+                <div className="relative group">
+                  <strong className="block text-sm font-semibold">
                     <FontAwesomeIcon
-                      icon={faCalendarAlt}
+                      icon={faFileAlt}
                       className="text-primary align-middle mr-2"
                     />
-                    <strong className="text-sm font-semibold">
-                      Created On:
-                    </strong>
-                    <span className="text-sm ml-2">
-                      {distribution.createdAt
-                        ? formatDate(distribution.createdAt)
-                        : "NA"}
-                    </span>
-                    <Tooltip message="Date when the distribution was created." />
-                  </span>
+                    Description:
+                  </strong>
+                  <span className="text-sm">{distribution.description}</span>
+                  <Tooltip message="Description of the distribution." />
                 </div>
-                <div className="flex items-center relative">
-                  <span className="group flex items-center">
-                    <FontAwesomeIcon
-                      icon={faCalendarAlt}
-                      className="text-primary align-middle mr-2"
-                    />
-                    <strong className="text-sm font-semibold">
-                      Modified On:
-                    </strong>
-                    <span className="text-sm ml-2">
-                      {distribution.modifiedAt
-                        ? formatDate(distribution.modifiedAt)
-                        : "NA"}
+                <div className="grid grid-cols-1 sm:grid-cols-2 gap-4 mt-4">
+                  <div className="flex items-center relative">
+                    <span className="group flex items-center">
+                      <FontAwesomeIcon
+                        icon={faCalendarAlt}
+                        className="text-primary align-middle mr-2"
+                      />
+                      <strong className="text-sm font-semibold">
+                        Created On:
+                      </strong>
+                      <span className="text-sm ml-2">
+                        {distribution.createdAt
+                          ? formatDate(distribution.createdAt)
+                          : "NA"}
+                      </span>
+                      <Tooltip message="Date when the distribution was created." />
                     </span>
-                    <Tooltip message="Date when the distribution was last modified." />
-                  </span>
-                </div>
-                <div className="flex items-center relative">
-                  <span className="group flex items-center">
-                    <FontAwesomeIcon
-                      icon={faFile}
-                      className="text-primary align-middle mr-2"
-                    />
-                    <strong className="text-sm font-semibold">
-                      File Type:
-                    </strong>
-                    <span className="text-sm ml-2">
-                      {getFormatLabel(distribution)}
+                  </div>
+                  <div className="flex items-center relative">
+                    <span className="group flex items-center">
+                      <FontAwesomeIcon
+                        icon={faCalendarAlt}
+                        className="text-primary align-middle mr-2"
+                      />
+                      <strong className="text-sm font-semibold">
+                        Modified On:
+                      </strong>
+                      <span className="text-sm ml-2">
+                        {distribution.modifiedAt
+                          ? formatDate(distribution.modifiedAt)
+                          : "NA"}
+                      </span>
+                      <Tooltip message="Date when the distribution was last modified." />
                     </span>
-                    <Tooltip message="File type of the distribution." />
-                  </span>
-                </div>
-                <div className="flex items-center relative">
-                  <span className="group flex items-center">
-                    <FontAwesomeIcon
-                      icon={faFile}
-                      className="text-primary align-middle mr-2"
-                    />
-                    <strong className="text-sm font-semibold">
-                      Media Type:
-                    </strong>
-                    <span className="text-sm ml-2">
-                      {distribution.mediaType?.label ||
-                        distribution.mediaType?.value?.split("/").pop() ||
-                        "NA"}
+                  </div>
+                  <div className="flex items-center relative">
+                    <span className="group flex items-center">
+                      <FontAwesomeIcon
+                        icon={faFile}
+                        className="text-primary align-middle mr-2"
+                      />
+                      <strong className="text-sm font-semibold">
+                        File Type:
+                      </strong>
+                      <span className="text-sm ml-2">
+                        {getFormatLabel(distribution)}
+                      </span>
+                      <Tooltip message="File type of the distribution." />
                     </span>
-                    <Tooltip message="Media type of the distribution." />
-                  </span>
-                </div>
-                <div className="flex items-center relative">
-                  <span className="group flex items-center">
-                    <FontAwesomeIcon
-                      icon={faBalanceScale}
-                      className="text-primary align-middle mr-2"
-                    />
-                    <strong className="text-sm font-semibold">License:</strong>
-                    <span className="text-sm ml-2">
-                      {distribution.license?.label ||
-                        distribution.license?.value?.split("/").pop() ||
-                        "NA"}
+                  </div>
+                  <div className="flex items-center relative">
+                    <span className="group flex items-center">
+                      <FontAwesomeIcon
+                        icon={faFile}
+                        className="text-primary align-middle mr-2"
+                      />
+                      <strong className="text-sm font-semibold">
+                        Media Type:
+                      </strong>
+                      <span className="text-sm ml-2">
+                        {distribution.mediaType?.label ||
+                          distribution.mediaType?.value?.split("/").pop() ||
+                          "NA"}
+                      </span>
+                      <Tooltip message="Media type of the distribution." />
                     </span>
-                    <Tooltip message="License under which the distribution is made available." />
-                  </span>
-                </div>
-                <div className="flex items-center relative">
-                  <span className="group flex items-center">
-                    <FontAwesomeIcon
-                      icon={faDatabase}
-                      className="text-primary align-middle mr-2"
-                    />
-                    <strong className="text-sm font-semibold">
-                      Byte Size:
-                    </strong>
-                    <span className="text-sm ml-2">
-                      {distribution.byteSize !== undefined &&
-                      distribution.byteSize !== null
-                        ? distribution.byteSize.toLocaleString()
-                        : "NA"}
+                  </div>
+                  <div className="flex items-center relative">
+                    <span className="group flex items-center">
+                      <FontAwesomeIcon
+                        icon={faBalanceScale}
+                        className="text-primary align-middle mr-2"
+                      />
+                      <strong className="text-sm font-semibold">
+                        License:
+                      </strong>
+                      <span className="text-sm ml-2">
+                        {distribution.license?.label ||
+                          distribution.license?.value?.split("/").pop() ||
+                          "NA"}
+                      </span>
+                      <Tooltip message="License under which the distribution is made available." />
                     </span>
-                    <Tooltip message="Size of the distribution in bytes." />
-                  </span>
-                </div>
-                {distribution.conformsTo &&
-                  distribution.conformsTo.length > 0 && (
+                  </div>
+                  <div className="flex items-center relative">
+                    <span className="group flex items-center">
+                      <FontAwesomeIcon
+                        icon={faDatabase}
+                        className="text-primary align-middle mr-2"
+                      />
+                      <strong className="text-sm font-semibold">
+                        Byte Size:
+                      </strong>
+                      <span className="text-sm ml-2">
+                        {distribution.byteSize !== undefined &&
+                        distribution.byteSize !== null
+                          ? distribution.byteSize.toLocaleString()
+                          : "NA"}
+                      </span>
+                      <Tooltip message="Size of the distribution in bytes." />
+                    </span>
+                  </div>
+                  {distribution.conformsTo &&
+                    distribution.conformsTo.length > 0 && (
+                      <div className="flex items-center relative">
+                        <span className="group flex items-center">
+                          <FontAwesomeIcon
+                            icon={faCheckCircle}
+                            className="text-primary align-middle mr-2"
+                          />
+                          <strong className="text-sm font-semibold">
+                            Conforms To:
+                          </strong>
+                          <span className="text-sm ml-2">
+                            {distribution.conformsTo
+                              .map(
+                                (c) =>
+                                  c.label ||
+                                  c.value?.split("/").pop() ||
+                                  c.value
+                              )
+                              .join(", ")}
+                          </span>
+                          <Tooltip message="Standards or specifications the distribution conforms to." />
+                        </span>
+                      </div>
+                    )}
+                  {distribution.accessUrl && (
                     <div className="flex items-center relative">
                       <span className="group flex items-center">
                         <FontAwesomeIcon
-                          icon={faCheckCircle}
+                          icon={faLink}
                           className="text-primary align-middle mr-2"
                         />
                         <strong className="text-sm font-semibold">
-                          Conforms To:
+                          Access URL:
                         </strong>
-                        <span className="text-sm ml-2">
-                          {distribution.conformsTo
-                            .map(
-                              (c) =>
-                                c.label || c.value?.split("/").pop() || c.value
-                            )
-                            .join(", ")}
-                        </span>
-                        <Tooltip message="Standards or specifications the distribution conforms to." />
+                        <a
+                          href={distribution.accessUrl}
+                          className="text-sm text-primary ml-2 break-all"
+                          target="_blank"
+                          rel="noopener noreferrer"
+                        >
+                          here
+                        </a>
+                        <Tooltip message="Link to access the distribution." />
                       </span>
                     </div>
                   )}
-                {distribution.accessUrl && (
-                  <div className="flex items-center relative">
-                    <span className="group flex items-center">
-                      <FontAwesomeIcon
-                        icon={faLink}
-                        className="text-primary align-middle mr-2"
-                      />
-                      <strong className="text-sm font-semibold">
-                        Access URL:
-                      </strong>
-                      <a
-                        href={distribution.accessUrl}
-                        className="text-sm text-primary ml-2 break-all"
-                        target="_blank"
-                        rel="noopener noreferrer"
-                      >
-                        here
-                      </a>
-                      <Tooltip message="Link to access the distribution." />
-                    </span>
-                  </div>
-                )}
-                {distribution.downloadUrl && (
-                  <div className="flex items-center relative">
-                    <span className="group flex items-center">
-                      <FontAwesomeIcon
-                        icon={faLink}
-                        className="text-primary align-middle mr-2"
-                      />
-                      <strong className="text-sm font-semibold">
-                        Download URL:
-                      </strong>
-                      <a
-                        href={distribution.downloadUrl}
-                        className="text-sm text-primary ml-2 break-all"
-                        target="_blank"
-                        rel="noopener noreferrer"
-                      >
-                        here
-                      </a>
-                      <Tooltip message="Link to download the distribution." />
-                    </span>
-                  </div>
-                )}
-                {distribution.languages &&
-                  distribution.languages.length > 0 && (
+                  {distribution.downloadUrl && (
                     <div className="flex items-center relative">
                       <span className="group flex items-center">
                         <FontAwesomeIcon
-                          icon={faLanguage}
+                          icon={faLink}
                           className="text-primary align-middle mr-2"
                         />
-                        <span className="align-middle">
-                          Languages:{" "}
-                          {distribution.languages
-                            .map((lang) => lang.label)
-                            .join(", ")}
-                        </span>
-                        <Tooltip message="Languages in which the distribution is available." />
+                        <strong className="text-sm font-semibold">
+                          Download URL:
+                        </strong>
+                        <a
+                          href={distribution.downloadUrl}
+                          className="text-sm text-primary ml-2 break-all"
+                          target="_blank"
+                          rel="noopener noreferrer"
+                        >
+                          here
+                        </a>
+                        <Tooltip message="Link to download the distribution." />
                       </span>
                     </div>
                   )}
+                  {distribution.languages &&
+                    distribution.languages.length > 0 && (
+                      <div className="flex items-center relative">
+                        <span className="group flex items-center">
+                          <FontAwesomeIcon
+                            icon={faLanguage}
+                            className="text-primary align-middle mr-2"
+                          />
+                          <span className="align-middle">
+                            Languages:{" "}
+                            {distribution.languages
+                              .map((lang) => lang.label)
+                              .join(", ")}
+                          </span>
+                          <Tooltip message="Languages in which the distribution is available." />
+                        </span>
+                      </div>
+                    )}
+                </div>
               </div>
             </div>
           </div>

--- a/src/app/datasets/__tests__/datasetCardItems.test.ts
+++ b/src/app/datasets/__tests__/datasetCardItems.test.ts
@@ -34,15 +34,17 @@ describe("datasetCardItems", () => {
       createdAt: "2024-03-01T00:00:00.000Z",
       modifiedAt: "",
       recordsCount: 21,
+      inSeriesCount: 1,
     };
 
     const items = createDatasetCardItems(dataset);
-    expect(items.length).toBe(5);
+    expect(items.length).toBe(6);
     expect(items[0].text).toBe("Created on 1 March 2024");
     expect(items[1].text).toBe("");
     expect(items[2].text).toBe("Published by publisher1");
     expect(items[3].text).toBe("1 Distribution");
-    expect(items[4].text).toBe("21 Records");
+    expect(items[4].text).toBe("1 Dataset series");
+    expect(items[5].text).toBe("21 Records");
   });
 
   it("should handle missing optional fields without crashing", () => {
@@ -52,6 +54,7 @@ describe("datasetCardItems", () => {
       description: "",
       publishers: [],
       distributionsCount: 2,
+      inSeriesCount: 2,
       recordsCount: 1,
     };
 
@@ -60,6 +63,7 @@ describe("datasetCardItems", () => {
     expect(items[1].text).toBe("");
     expect(items[2].text).toBe("");
     expect(items[3].text).toBe("2 Distributions");
-    expect(items[4].text).toBe("1 Record");
+    expect(items[4].text).toBe("2 Dataset series");
+    expect(items[5].text).toBe("1 Record");
   });
 });

--- a/src/app/datasets/datasetCardItems.ts
+++ b/src/app/datasets/datasetCardItems.ts
@@ -8,6 +8,7 @@ import {
   faBookBookmark,
   faCalendarAlt,
   faFile,
+  faLayerGroup,
   faSyncAlt,
   faUser,
 } from "@fortawesome/free-solid-svg-icons";
@@ -47,6 +48,15 @@ export function createDatasetCardItems(dataset: SearchedDataset): CardItem[] {
             : `${dataset.distributionsCount} Distributions`)) ||
         "",
       icon: faFile,
+    },
+    {
+      text:
+        (dataset.inSeriesCount &&
+          (dataset.inSeriesCount === 1
+            ? "1 Dataset series"
+            : `${dataset.inSeriesCount} Dataset series`)) ||
+        "",
+      icon: faLayerGroup,
     },
     {
       text:

--- a/src/app/requests/entitlements/__tests__/entitlementCardItems.test.ts
+++ b/src/app/requests/entitlements/__tests__/entitlementCardItems.test.ts
@@ -37,13 +37,14 @@ describe("entitlementCardItems", () => {
 
     const items = createEntitlementCardItems(dataset, "2024-06-23", "");
 
-    expect(items.length).toBe(7);
+    expect(items.length).toBe(8);
     expect(items[0].text).toBe("Created on 1 March 2024");
     expect(items[1].text).toBe("");
     expect(items[2].text).toBe("Published by publisher1");
     expect(items[3].text).toBe("2 Distributions");
     expect(items[4].text).toBe("");
-    expect(items[5].text).toBe("Start: 23 June 2024");
-    expect(items[6].text).toBe("End: N/A");
+    expect(items[5].text).toBe("");
+    expect(items[6].text).toBe("Start: 23 June 2024");
+    expect(items[7].text).toBe("End: N/A");
   });
 });

--- a/tests/dataset-detail.spec.ts
+++ b/tests/dataset-detail.spec.ts
@@ -57,6 +57,22 @@ test("Dataset detail renders metadata and distributions", async ({ page }) => {
     page.getByRole("heading", { name: /dataset dictionary/i })
   ).toBeVisible();
 
+  await expect(
+    page.getByRole("heading", { name: /data series/i })
+  ).toBeVisible();
+  await expect(
+    page.getByRole("link", { name: /synthetic cohort series/i })
+  ).toBeVisible();
+  await page.getByRole("link", { name: /synthetic cohort series/i }).click();
+  await expect(page).toHaveURL(/\/datasets\/series-001$/);
+  await expect(
+    page.getByRole("heading", { name: /synthetic cohort series/i })
+  ).toBeVisible();
+  await page.goBack();
+  await expect(
+    page.getByRole("heading", { name: /cancer cohort study/i })
+  ).toBeVisible();
+
   await expect(page.getByText("Clinical CSV Export")).toBeVisible();
   await page.getByText("Clinical CSV Export").click();
   await expect(

--- a/tests/datasets.spec.ts
+++ b/tests/datasets.spec.ts
@@ -60,6 +60,7 @@ test("Dataset list renders filters and results", async ({ page }) => {
   await expect(
     page.getByRole("link", { name: /cancer cohort study/i })
   ).toBeVisible();
+  await expect(page.getByText(/1 dataset series/i)).toBeVisible();
   await expect(page.getByText(/externally governed/i)).toBeVisible();
 
   // 6. Ensure there are no console errors

--- a/tests/mocks/discovery.json
+++ b/tests/mocks/discovery.json
@@ -173,6 +173,7 @@
           }
         ],
         "distributionsCount": 2,
+        "inSeriesCount": 1,
         "recordsCount": 1200,
         "conformsTo": [
           {
@@ -201,6 +202,7 @@
           }
         ],
         "distributionsCount": 1,
+        "inSeriesCount": 0,
         "recordsCount": 48,
         "conformsTo": [
           {
@@ -229,6 +231,7 @@
           }
         ],
         "distributionsCount": 0,
+        "inSeriesCount": 0,
         "recordsCount": 0,
         "conformsTo": [
           {
@@ -257,6 +260,7 @@
           }
         ],
         "distributionsCount": 3,
+        "inSeriesCount": 0,
         "recordsCount": 320,
         "conformsTo": [
           {
@@ -470,6 +474,31 @@
             }
           ]
         }
+      ],
+      "inSeries": [
+        {
+          "id": "series-001",
+          "identifier": "series-001",
+          "title": "Synthetic Cohort Series",
+          "description": "Series grouping synthetic cohort datasets.",
+          "frequency": {
+            "value": "monthly",
+            "label": "Monthly"
+          },
+          "issued": "2023-01-01T00:00:00Z",
+          "modified": "2024-01-15T00:00:00Z",
+          "publishers": [
+            {
+              "name": "GDI Oncology Institute"
+            }
+          ],
+          "temporalCoverage": [
+            {
+              "start": "2020-01-01T00:00:00Z",
+              "end": "2024-12-31T00:00:00Z"
+            }
+          ]
+        }
       ]
     },
     "ds-002": {
@@ -582,6 +611,33 @@
       "publishers": [
         {
           "name": "GDI Pharmacology Unit"
+        }
+      ],
+      "distributions": []
+    },
+    "series-001": {
+      "id": "series-001",
+      "title": "Synthetic Cohort Series",
+      "description": "Series grouping synthetic cohort datasets.",
+      "createdAt": "2023-01-01T00:00:00Z",
+      "modifiedAt": "2024-01-15T00:00:00Z",
+      "identifier": "series-001",
+      "publishers": [
+        {
+          "name": "GDI Oncology Institute"
+        }
+      ],
+      "themes": [
+        {
+          "value": "oncology",
+          "label": "Oncology"
+        }
+      ],
+      "keywords": ["cohort", "series"],
+      "conformsTo": [
+        {
+          "value": "http://example.org/schema/gdi-core",
+          "label": "GDI Core"
         }
       ],
       "distributions": []


### PR DESCRIPTION
- Introduced `inSeriesCount` field in the OpenAPI schema to track the number of dataset series.
- Updated dataset card items to display the dataset series count with appropriate icons.
- Created `DataSeriesAccordion` component to display details of dataset series, enhancing the dataset metadata view.
- Adjusted tests to validate the new dataset series functionality and ensure proper rendering in the UI.

## Summary by Sourcery

Add support for dataset series metadata across the API schema and UI, and improve accordion layouts for dataset distributions and series details.

New Features:
- Expose dataset series count via the discovery OpenAPI schema and surface it on dataset cards and entitlement cards.
- Introduce a DataSeriesAccordion component to display dataset series details with navigation to series pages in the dataset detail view.

Enhancements:
- Restyle the DistributionAccordion to use button-based headers and a more compact, bordered layout for distribution details.
- Add a dedicated metadata section for distributions in the dataset detail page.

Tests:
- Extend dataset list, dataset detail, dataset card, and entitlement card tests to cover dataset series counts, links, and navigation behaviour.