### PR TITLE
feat(helpdesk): implement contact us feature with Zammad integration

### DIFF
--- a/.env.local.example
+++ b/.env.local.example
@@ -26,6 +26,7 @@ CSP_HEADER="
 NEXT_PUBLIC_BASE_URL=https://portal.dev.gdi.lu
 
 NEXT_PUBLIC_HOME_NOTICE_ENABLED=false
+NEXT_PUBLIC_FEATURE_CONTACT_US=true
 OTEL_ENABLED=true
 OTEL_EXPORTER_OTLP_ENDPOINT=http://openobserve-dev-env.ss-dev.lnds.internal:4319
 OTEL_EXPORTER_OTLP_PROTOCOL=http/json
@@ -46,3 +47,13 @@ OPENSEARCH_TLS_INSECURE=true
 HARVEST_OIDC_TOKEN_URL=
 HARVEST_OIDC_CLIENT_ID=
 HARVEST_OIDC_CLIENT_SECRET=
+
+# Helpdesk topic routing (topic -> recipient email + optional Zammad group)
+HELPDESK_TOPIC_ROUTING=[{"value":"general","label":"General inquiry","recipientEmail":"helpdesk@example.org","zammadGroup":"Users"},{"value":"technical","label":"Technical issue","recipientEmail":"helpdesk@example.org","zammadGroup":"2nd Level"}]
+
+# Zammad (community edition) integration
+HELPDESK_ZAMMAD_URL=https://gdi-ticketing-test-srv-01.global-net.lnds.internal
+HELPDESK_ZAMMAD_API_TOKEN=<token-from-zammad-user-profile>
+HELPDESK_ZAMMAD_DEFAULT_GROUP=Users
+# Optional for internal/self-signed HTTPS certificates
+HELPDESK_ZAMMAD_TLS_INSECURE=true

--- a/README.md
+++ b/README.md
@@ -135,6 +135,24 @@ In case of changes in the OpenAPI specifications, you must upgrade the client an
 
 Additionally, you must export all the types defined in `schemas.ts` (can not be done automatically).
 
+## Helpdesk / Zammad setup (local)
+
+The footer includes a `Get in touch` modal that submits inquiries to Zammad via backend APIs.
+
+Set these environment variables in `.env.local`:
+
+```bash
+HELPDESK_TOPIC_ROUTING=[{"value":"general","label":"General inquiry","recipientEmail":"helpdesk@example.org","zammadGroup":"Users"},{"value":"technical","label":"Technical issue","recipientEmail":"helpdesk@example.org","zammadGroup":"2nd Level"}]
+HELPDESK_ZAMMAD_URL=http://localhost:8080
+HELPDESK_ZAMMAD_API_TOKEN=<token-from-zammad-user-profile>
+HELPDESK_ZAMMAD_DEFAULT_GROUP=Users
+HELPDESK_ZAMMAD_TLS_INSECURE=false
+NEXT_PUBLIC_FEATURE_CONTACT_US=true
+```
+
+If your Zammad endpoint uses an internal/self-signed HTTPS certificate, set
+`HELPDESK_ZAMMAD_TLS_INSECURE=true`.
+
 ## Build
 
 Run `npm run build` to build the project. The build artifacts will be stored in the `.next/` directory.

--- a/src/app/Footer.tsx
+++ b/src/app/Footer.tsx
@@ -19,6 +19,7 @@ import { FontAwesomeIcon } from "@fortawesome/react-fontawesome";
 import Image from "next/image";
 import contentConfig from "@/config/contentConfig";
 import Link from "next/link";
+import ContactUsModal from "@/components/ContactUsModal";
 
 function Footer() {
   return (
@@ -198,6 +199,7 @@ function Footer() {
                 {contentConfig.email}
               </a>
             )}
+            {contentConfig.contactUsEnabled && <ContactUsModal />}
           </div>
         </div>
       </footer>

--- a/src/app/api/helpdesk/__tests__/config.test.ts
+++ b/src/app/api/helpdesk/__tests__/config.test.ts
@@ -23,7 +23,7 @@ describe("helpdesk config", () => {
       {
         value: "general",
         label: "General inquiry",
-        recipientEmail: "bechkal198@gmail.com",
+        recipientEmail: "helpdesk@example.org",
         zammadGroup: "Users",
       },
     ]);

--- a/src/app/api/helpdesk/__tests__/config.test.ts
+++ b/src/app/api/helpdesk/__tests__/config.test.ts
@@ -1,0 +1,89 @@
+// SPDX-FileCopyrightText: 2026 PNED G.I.E.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+import {
+  getHelpdeskTopicByValue,
+  parseHelpdeskTopicRoutingFromEnv,
+} from "@/app/api/helpdesk/config";
+
+describe("helpdesk config", () => {
+  const originalRouting = process.env.HELPDESK_TOPIC_ROUTING;
+
+  afterEach(() => {
+    process.env.HELPDESK_TOPIC_ROUTING = originalRouting;
+  });
+
+  test("returns default routing when env is not set", () => {
+    delete process.env.HELPDESK_TOPIC_ROUTING;
+
+    const routing = parseHelpdeskTopicRoutingFromEnv();
+
+    expect(routing).toEqual([
+      {
+        value: "general",
+        label: "General inquiry",
+        recipientEmail: "bechkal198@gmail.com",
+        zammadGroup: "Users",
+      },
+    ]);
+  });
+
+  test("parses valid routing from env", () => {
+    process.env.HELPDESK_TOPIC_ROUTING = JSON.stringify([
+      {
+        value: "technical",
+        label: "Technical issue",
+        recipientEmail: "tech@example.org",
+        zammadGroup: "2nd Level",
+      },
+    ]);
+
+    const routing = parseHelpdeskTopicRoutingFromEnv();
+
+    expect(routing).toEqual([
+      {
+        value: "technical",
+        label: "Technical issue",
+        recipientEmail: "tech@example.org",
+        zammadGroup: "2nd Level",
+      },
+    ]);
+  });
+
+  test("throws when same topic value appears twice", () => {
+    process.env.HELPDESK_TOPIC_ROUTING = JSON.stringify([
+      {
+        value: "general",
+        label: "General",
+        recipientEmail: "one@example.org",
+      },
+      {
+        value: "general",
+        label: "General duplicate",
+        recipientEmail: "two@example.org",
+      },
+    ]);
+
+    expect(() => parseHelpdeskTopicRoutingFromEnv()).toThrow(
+      'Duplicate topic value "general" in HELPDESK_TOPIC_ROUTING.'
+    );
+  });
+
+  test("getHelpdeskTopicByValue returns matching topic", () => {
+    process.env.HELPDESK_TOPIC_ROUTING = JSON.stringify([
+      {
+        value: "ops",
+        label: "Operations",
+        recipientEmail: "ops@example.org",
+      },
+    ]);
+
+    expect(getHelpdeskTopicByValue("ops")).toEqual({
+      value: "ops",
+      label: "Operations",
+      recipientEmail: "ops@example.org",
+      zammadGroup: undefined,
+    });
+  });
+});

--- a/src/app/api/helpdesk/__tests__/zammad.test.ts
+++ b/src/app/api/helpdesk/__tests__/zammad.test.ts
@@ -1,0 +1,246 @@
+// SPDX-FileCopyrightText: 2026 PNED G.I.E.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+import { jest } from "@jest/globals";
+import { createZammadTicket } from "@/app/api/helpdesk/zammad";
+
+describe("createZammadTicket", () => {
+  const originalBaseUrl = process.env.HELPDESK_ZAMMAD_URL;
+  const originalApiToken = process.env.HELPDESK_ZAMMAD_API_TOKEN;
+  const originalDefaultGroup = process.env.HELPDESK_ZAMMAD_DEFAULT_GROUP;
+  const originalFetch = global.fetch;
+
+  beforeEach(() => {
+    process.env.HELPDESK_ZAMMAD_URL = "http://localhost:8080";
+    process.env.HELPDESK_ZAMMAD_API_TOKEN = "test-token";
+    process.env.HELPDESK_ZAMMAD_DEFAULT_GROUP = "Users";
+  });
+
+  afterEach(() => {
+    jest.restoreAllMocks();
+    global.fetch = originalFetch;
+    process.env.HELPDESK_ZAMMAD_URL = originalBaseUrl;
+    process.env.HELPDESK_ZAMMAD_API_TOKEN = originalApiToken;
+    process.env.HELPDESK_ZAMMAD_DEFAULT_GROUP = originalDefaultGroup;
+  });
+
+  test("uses customer_id guess to allow unknown sender emails", async () => {
+    const fetchMock = jest
+      .fn<typeof fetch>()
+      .mockResolvedValueOnce({
+        ok: true,
+        status: 201,
+        text: async () => '{"id":73,"customer_id":12}',
+      } as Response)
+      .mockResolvedValueOnce({
+        ok: true,
+        status: 200,
+        text: async () => '{"id":12}',
+      } as Response);
+    global.fetch = fetchMock as typeof fetch;
+
+    const result = await createZammadTicket({
+      title: "Portal issue",
+      firstName: "Safe",
+      lastName: "User",
+      email: "safe@lnds.lu",
+      topicLabel: "General inquiry",
+      topicValue: "general",
+      recipientEmail: "bechkal198@gmail.com",
+      message: "I cannot see datasets",
+    });
+
+    expect(fetchMock).toHaveBeenCalledTimes(2);
+    expect(fetchMock).toHaveBeenCalledWith(
+      "http://localhost:8080/api/v1/tickets",
+      expect.objectContaining({
+        method: "POST",
+        headers: expect.objectContaining({
+          Authorization: "Token token=test-token",
+          "Content-Type": "application/json",
+        }),
+      })
+    );
+
+    const [, requestInit] = fetchMock.mock.calls[0];
+    const payload = JSON.parse((requestInit?.body as string) ?? "{}");
+
+    expect(payload).toEqual(
+      expect.objectContaining({
+        title: "Portal issue",
+        group: "Users",
+        customer_id: "guess:safe@lnds.lu",
+        article: expect.objectContaining({
+          type: "email",
+          sender: "Agent",
+          to: "bechkal198@gmail.com",
+          reply_to: "safe@lnds.lu",
+        }),
+      })
+    );
+    expect(payload).not.toHaveProperty("customer");
+
+    expect(fetchMock).toHaveBeenNthCalledWith(
+      2,
+      "http://localhost:8080/api/v1/users/12",
+      expect.objectContaining({
+        method: "PUT",
+      })
+    );
+    const [, userUpdateInit] = fetchMock.mock.calls[1];
+    const userUpdatePayload = JSON.parse(
+      (userUpdateInit?.body as string) ?? "{}"
+    );
+    expect(userUpdatePayload).toEqual({
+      firstname: "Safe",
+      lastname: "User",
+      email: "safe@lnds.lu",
+    });
+    expect(result).toEqual({ ticketId: 73 });
+  });
+
+  test("normalizes sender email before guess/reply-to", async () => {
+    const fetchMock = jest
+      .fn<typeof fetch>()
+      .mockResolvedValueOnce({
+        ok: true,
+        status: 201,
+        text: async () => '{"id":74,"customer_id":13}',
+      } as Response)
+      .mockResolvedValueOnce({
+        ok: true,
+        status: 200,
+        text: async () => '{"id":13}',
+      } as Response);
+    global.fetch = fetchMock as typeof fetch;
+
+    await createZammadTicket({
+      title: "Portal issue",
+      firstName: "Safe",
+      lastName: "User",
+      email: "Safe.User@LNDS.LU",
+      topicLabel: "General inquiry",
+      topicValue: "general",
+      recipientEmail: "bechkal198@gmail.com",
+      message: "I cannot see datasets",
+    });
+
+    const [, requestInit] = fetchMock.mock.calls[0];
+    const payload = JSON.parse((requestInit?.body as string) ?? "{}");
+
+    expect(payload).toEqual(
+      expect.objectContaining({
+        customer_id: "guess:safe.user@lnds.lu",
+        article: expect.objectContaining({
+          reply_to: "safe.user@lnds.lu",
+        }),
+      })
+    );
+
+    const [, userUpdateInit] = fetchMock.mock.calls[1];
+    const userUpdatePayload = JSON.parse(
+      (userUpdateInit?.body as string) ?? "{}"
+    );
+    expect(userUpdatePayload).toEqual(
+      expect.objectContaining({
+        email: "safe.user@lnds.lu",
+      })
+    );
+  });
+
+  test("falls back to web article when group has no sender email", async () => {
+    const fetchMock = jest
+      .fn<typeof fetch>()
+      .mockResolvedValueOnce({
+        ok: false,
+        status: 500,
+        text: async () =>
+          `{"error":"No email address found for group 'Users' (1)"}`,
+      } as Response)
+      .mockResolvedValueOnce({
+        ok: true,
+        status: 201,
+        text: async () => '{"id":75,"customer_id":14}',
+      } as Response)
+      .mockResolvedValueOnce({
+        ok: true,
+        status: 200,
+        text: async () => '{"id":14}',
+      } as Response);
+    global.fetch = fetchMock as typeof fetch;
+
+    const result = await createZammadTicket({
+      title: "Portal issue",
+      firstName: "Safe",
+      lastName: "User",
+      email: "safe@lnds.lu",
+      topicLabel: "General inquiry",
+      topicValue: "general",
+      recipientEmail: "bechkal198@gmail.com",
+      message: "I cannot see datasets",
+    });
+
+    expect(fetchMock).toHaveBeenCalledTimes(3);
+
+    const [, firstRequestInit] = fetchMock.mock.calls[0];
+    const firstPayload = JSON.parse((firstRequestInit?.body as string) ?? "{}");
+    expect(firstPayload).toEqual(
+      expect.objectContaining({
+        article: expect.objectContaining({
+          type: "email",
+          sender: "Agent",
+        }),
+      })
+    );
+
+    const [, secondRequestInit] = fetchMock.mock.calls[1];
+    const secondPayload = JSON.parse(
+      (secondRequestInit?.body as string) ?? "{}"
+    );
+    expect(secondPayload).toEqual(
+      expect.objectContaining({
+        customer_id: "guess:safe@lnds.lu",
+        article: expect.objectContaining({
+          type: "web",
+          sender: "Customer",
+        }),
+      })
+    );
+    expect(secondPayload.article).not.toHaveProperty("to");
+    expect(secondPayload.article).not.toHaveProperty("reply_to");
+
+    expect(fetchMock).toHaveBeenNthCalledWith(
+      3,
+      "http://localhost:8080/api/v1/users/14",
+      expect.objectContaining({
+        method: "PUT",
+      })
+    );
+    expect(result).toEqual({ ticketId: 75 });
+  });
+
+  test("throws useful error when zammad returns failure response", async () => {
+    const fetchMock = jest.fn<typeof fetch>().mockResolvedValue({
+      ok: false,
+      status: 422,
+      text: async () => '{"error":"No lookup value found"}',
+    } as Response);
+    global.fetch = fetchMock as typeof fetch;
+
+    await expect(
+      createZammadTicket({
+        title: "Portal issue",
+        firstName: "Safe",
+        lastName: "User",
+        email: "safe@lnds.lu",
+        topicLabel: "General inquiry",
+        topicValue: "general",
+        recipientEmail: "bechkal198@gmail.com",
+        message: "I cannot see datasets",
+      })
+    ).rejects.toThrow(
+      'Zammad ticket creation failed with status 422: {"error":"No lookup value found"}'
+    );
+  });
+});

--- a/src/app/api/helpdesk/__tests__/zammad.test.ts
+++ b/src/app/api/helpdesk/__tests__/zammad.test.ts
@@ -9,12 +9,14 @@ describe("createZammadTicket", () => {
   const originalBaseUrl = process.env.HELPDESK_ZAMMAD_URL;
   const originalApiToken = process.env.HELPDESK_ZAMMAD_API_TOKEN;
   const originalDefaultGroup = process.env.HELPDESK_ZAMMAD_DEFAULT_GROUP;
+  const originalTlsInsecure = process.env.HELPDESK_ZAMMAD_TLS_INSECURE;
   const originalFetch = global.fetch;
 
   beforeEach(() => {
     process.env.HELPDESK_ZAMMAD_URL = "http://localhost:8080";
     process.env.HELPDESK_ZAMMAD_API_TOKEN = "test-token";
     process.env.HELPDESK_ZAMMAD_DEFAULT_GROUP = "Users";
+    process.env.HELPDESK_ZAMMAD_TLS_INSECURE = "false";
   });
 
   afterEach(() => {
@@ -23,6 +25,7 @@ describe("createZammadTicket", () => {
     process.env.HELPDESK_ZAMMAD_URL = originalBaseUrl;
     process.env.HELPDESK_ZAMMAD_API_TOKEN = originalApiToken;
     process.env.HELPDESK_ZAMMAD_DEFAULT_GROUP = originalDefaultGroup;
+    process.env.HELPDESK_ZAMMAD_TLS_INSECURE = originalTlsInsecure;
   });
 
   test("uses customer_id guess to allow unknown sender emails", async () => {
@@ -242,5 +245,154 @@ describe("createZammadTicket", () => {
     ).rejects.toThrow(
       'Zammad ticket creation failed with status 422: {"error":"No lookup value found"}'
     );
+  });
+
+  test("throws clear connectivity guidance when fetch throws", async () => {
+    const fetchMock = jest
+      .fn<typeof fetch>()
+      .mockRejectedValueOnce(new Error("certificate has expired"));
+    global.fetch = fetchMock as typeof fetch;
+
+    await expect(
+      createZammadTicket({
+        title: "Portal issue",
+        firstName: "Safe",
+        lastName: "User",
+        email: "safe@lnds.lu",
+        topicLabel: "General inquiry",
+        topicValue: "general",
+        recipientEmail: "bechkal198@gmail.com",
+        message: "I cannot see datasets",
+      })
+    ).rejects.toThrow(
+      "If this host uses an internal/self-signed certificate, set HELPDESK_ZAMMAD_TLS_INSECURE=true."
+    );
+  });
+
+  test("mentions disabled TLS verification when configured insecure", async () => {
+    process.env.HELPDESK_ZAMMAD_URL = "https://zammad.example.org";
+    process.env.HELPDESK_ZAMMAD_TLS_INSECURE = "true";
+
+    const fetchMock = jest
+      .fn<typeof fetch>()
+      .mockRejectedValueOnce(new Error("fetch failed"));
+    global.fetch = fetchMock as typeof fetch;
+
+    await expect(
+      createZammadTicket({
+        title: "Portal issue",
+        firstName: "Safe",
+        lastName: "User",
+        email: "safe@lnds.lu",
+        topicLabel: "General inquiry",
+        topicValue: "general",
+        recipientEmail: "bechkal198@gmail.com",
+        message: "I cannot see datasets",
+      })
+    ).rejects.toThrow(
+      "TLS verification is disabled via HELPDESK_ZAMMAD_TLS_INSECURE=true."
+    );
+  });
+
+  test("handles non-JSON success response from ticket create", async () => {
+    const fetchMock = jest.fn<typeof fetch>().mockResolvedValue({
+      ok: true,
+      status: 201,
+      text: async () => "<html>ok</html>",
+    } as Response);
+    global.fetch = fetchMock as typeof fetch;
+
+    await expect(
+      createZammadTicket({
+        title: "Portal issue",
+        firstName: "Safe",
+        lastName: "User",
+        email: "safe@lnds.lu",
+        topicLabel: "General inquiry",
+        topicValue: "general",
+        recipientEmail: "bechkal198@gmail.com",
+        message: "I cannot see datasets",
+      })
+    ).rejects.toThrow("response was not valid JSON");
+  });
+
+  test("throws fallback failure when fallback ticket creation fails", async () => {
+    const fetchMock = jest
+      .fn<typeof fetch>()
+      .mockResolvedValueOnce({
+        ok: false,
+        status: 500,
+        text: async () =>
+          `{"error":"No email address found for group 'Users' (1)"}`,
+      } as Response)
+      .mockResolvedValueOnce({
+        ok: false,
+        status: 503,
+        text: async () => '{"error":"service unavailable"}',
+      } as Response);
+    global.fetch = fetchMock as typeof fetch;
+
+    await expect(
+      createZammadTicket({
+        title: "Portal issue",
+        firstName: "Safe",
+        lastName: "User",
+        email: "safe@lnds.lu",
+        topicLabel: "General inquiry",
+        topicValue: "general",
+        recipientEmail: "bechkal198@gmail.com",
+        message: "I cannot see datasets",
+      })
+    ).rejects.toThrow(
+      'Zammad ticket creation failed with status 503: {"error":"service unavailable"}'
+    );
+  });
+
+  test("does not fail when user profile sync request fails", async () => {
+    const fetchMock = jest
+      .fn<typeof fetch>()
+      .mockResolvedValueOnce({
+        ok: true,
+        status: 201,
+        text: async () => '{"id":80,"customer_id":40}',
+      } as Response)
+      .mockRejectedValueOnce(new Error("user update failed"));
+    global.fetch = fetchMock as typeof fetch;
+
+    await expect(
+      createZammadTicket({
+        title: "Portal issue",
+        firstName: "Safe",
+        lastName: "User",
+        email: "safe@lnds.lu",
+        topicLabel: "General inquiry",
+        topicValue: "general",
+        recipientEmail: "bechkal198@gmail.com",
+        message: "I cannot see datasets",
+      })
+    ).resolves.toEqual({ ticketId: 80 });
+  });
+
+  test("skips profile sync when ticket response has no customer_id", async () => {
+    const fetchMock = jest.fn<typeof fetch>().mockResolvedValueOnce({
+      ok: true,
+      status: 201,
+      text: async () => '{"id":81}',
+    } as Response);
+    global.fetch = fetchMock as typeof fetch;
+
+    const result = await createZammadTicket({
+      title: "Portal issue",
+      firstName: "Safe",
+      lastName: "User",
+      email: "safe@lnds.lu",
+      topicLabel: "General inquiry",
+      topicValue: "general",
+      recipientEmail: "bechkal198@gmail.com",
+      message: "I cannot see datasets",
+    });
+
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+    expect(result).toEqual({ ticketId: 81 });
   });
 });

--- a/src/app/api/helpdesk/__tests__/zammad.test.ts
+++ b/src/app/api/helpdesk/__tests__/zammad.test.ts
@@ -50,7 +50,7 @@ describe("createZammadTicket", () => {
       email: "safe@lnds.lu",
       topicLabel: "General inquiry",
       topicValue: "general",
-      recipientEmail: "bechkal198@gmail.com",
+      recipientEmail: "helpdesk@example.org",
       message: "I cannot see datasets",
     });
 
@@ -77,7 +77,7 @@ describe("createZammadTicket", () => {
         article: expect.objectContaining({
           type: "email",
           sender: "Agent",
-          to: "bechkal198@gmail.com",
+          to: "helpdesk@example.org",
           reply_to: "safe@lnds.lu",
         }),
       })
@@ -125,7 +125,7 @@ describe("createZammadTicket", () => {
       email: "Safe.User@LNDS.LU",
       topicLabel: "General inquiry",
       topicValue: "general",
-      recipientEmail: "bechkal198@gmail.com",
+      recipientEmail: "helpdesk@example.org",
       message: "I cannot see datasets",
     });
 
@@ -180,7 +180,7 @@ describe("createZammadTicket", () => {
       email: "safe@lnds.lu",
       topicLabel: "General inquiry",
       topicValue: "general",
-      recipientEmail: "bechkal198@gmail.com",
+      recipientEmail: "helpdesk@example.org",
       message: "I cannot see datasets",
     });
 
@@ -239,7 +239,7 @@ describe("createZammadTicket", () => {
         email: "safe@lnds.lu",
         topicLabel: "General inquiry",
         topicValue: "general",
-        recipientEmail: "bechkal198@gmail.com",
+        recipientEmail: "helpdesk@example.org",
         message: "I cannot see datasets",
       })
     ).rejects.toThrow(
@@ -261,7 +261,7 @@ describe("createZammadTicket", () => {
         email: "safe@lnds.lu",
         topicLabel: "General inquiry",
         topicValue: "general",
-        recipientEmail: "bechkal198@gmail.com",
+        recipientEmail: "helpdesk@example.org",
         message: "I cannot see datasets",
       })
     ).rejects.toThrow(
@@ -286,7 +286,7 @@ describe("createZammadTicket", () => {
         email: "safe@lnds.lu",
         topicLabel: "General inquiry",
         topicValue: "general",
-        recipientEmail: "bechkal198@gmail.com",
+        recipientEmail: "helpdesk@example.org",
         message: "I cannot see datasets",
       })
     ).rejects.toThrow(
@@ -310,7 +310,7 @@ describe("createZammadTicket", () => {
         email: "safe@lnds.lu",
         topicLabel: "General inquiry",
         topicValue: "general",
-        recipientEmail: "bechkal198@gmail.com",
+        recipientEmail: "helpdesk@example.org",
         message: "I cannot see datasets",
       })
     ).rejects.toThrow("response was not valid JSON");
@@ -340,7 +340,7 @@ describe("createZammadTicket", () => {
         email: "safe@lnds.lu",
         topicLabel: "General inquiry",
         topicValue: "general",
-        recipientEmail: "bechkal198@gmail.com",
+        recipientEmail: "helpdesk@example.org",
         message: "I cannot see datasets",
       })
     ).rejects.toThrow(
@@ -367,7 +367,7 @@ describe("createZammadTicket", () => {
         email: "safe@lnds.lu",
         topicLabel: "General inquiry",
         topicValue: "general",
-        recipientEmail: "bechkal198@gmail.com",
+        recipientEmail: "helpdesk@example.org",
         message: "I cannot see datasets",
       })
     ).resolves.toEqual({ ticketId: 80 });
@@ -388,7 +388,7 @@ describe("createZammadTicket", () => {
       email: "safe@lnds.lu",
       topicLabel: "General inquiry",
       topicValue: "general",
-      recipientEmail: "bechkal198@gmail.com",
+      recipientEmail: "helpdesk@example.org",
       message: "I cannot see datasets",
     });
 

--- a/src/app/api/helpdesk/config.ts
+++ b/src/app/api/helpdesk/config.ts
@@ -17,7 +17,7 @@ const DEFAULT_HELPDESK_TOPIC_ROUTING: HelpdeskTopicRouting[] = [
   {
     value: "general",
     label: "General inquiry",
-    recipientEmail: "bechkal198@gmail.com",
+    recipientEmail: "helpdesk@example.org",
     zammadGroup: "Users",
   },
 ];

--- a/src/app/api/helpdesk/config.ts
+++ b/src/app/api/helpdesk/config.ts
@@ -2,6 +2,8 @@
 //
 // SPDX-License-Identifier: Apache-2.0
 
+import { z } from "zod";
+
 export type HelpdeskTopicRouting = {
   value: string;
   label: string;
@@ -19,8 +21,7 @@ const DEFAULT_HELPDESK_TOPIC_ROUTING: HelpdeskTopicRouting[] = [
     zammadGroup: "Users",
   },
 ];
-
-const EMAIL_REGEX = /^[^\s@]+@[^\s@]+\.[^\s@]+$/;
+const EMAIL_SCHEMA = z.string().email();
 
 function assertNonEmptyString(value: unknown, fieldName: string): string {
   if (typeof value !== "string" || value.trim().length === 0) {
@@ -48,7 +49,7 @@ function parseHelpdeskTopicRoutingEntry(
     "recipientEmail"
   );
 
-  if (!EMAIL_REGEX.test(recipientEmail)) {
+  if (!EMAIL_SCHEMA.safeParse(recipientEmail).success) {
     throw new Error(
       `Invalid recipientEmail for HELPDESK_TOPIC_ROUTING entry "${value}".`
     );

--- a/src/app/api/helpdesk/config.ts
+++ b/src/app/api/helpdesk/config.ts
@@ -1,0 +1,148 @@
+// SPDX-FileCopyrightText: 2026 PNED G.I.E.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+export type HelpdeskTopicRouting = {
+  value: string;
+  label: string;
+  recipientEmail: string;
+  zammadGroup?: string;
+};
+
+export type HelpdeskTopicOption = Pick<HelpdeskTopicRouting, "value" | "label">;
+
+const DEFAULT_HELPDESK_TOPIC_ROUTING: HelpdeskTopicRouting[] = [
+  {
+    value: "general",
+    label: "General inquiry",
+    recipientEmail: "bechkal198@gmail.com",
+    zammadGroup: "Users",
+  },
+];
+
+const EMAIL_REGEX = /^[^\s@]+@[^\s@]+\.[^\s@]+$/;
+
+function assertNonEmptyString(value: unknown, fieldName: string): string {
+  if (typeof value !== "string" || value.trim().length === 0) {
+    throw new Error(`Invalid ${fieldName} in HELPDESK_TOPIC_ROUTING.`);
+  }
+
+  return value.trim();
+}
+
+function parseHelpdeskTopicRoutingEntry(
+  item: unknown,
+  index: number
+): HelpdeskTopicRouting {
+  if (!item || typeof item !== "object") {
+    throw new Error(
+      `Invalid HELPDESK_TOPIC_ROUTING entry at index ${index}: expected object.`
+    );
+  }
+
+  const candidate = item as Record<string, unknown>;
+  const value = assertNonEmptyString(candidate.value, "value");
+  const label = assertNonEmptyString(candidate.label, "label");
+  const recipientEmail = assertNonEmptyString(
+    candidate.recipientEmail,
+    "recipientEmail"
+  );
+
+  if (!EMAIL_REGEX.test(recipientEmail)) {
+    throw new Error(
+      `Invalid recipientEmail for HELPDESK_TOPIC_ROUTING entry "${value}".`
+    );
+  }
+
+  let zammadGroup: string | undefined;
+  if (candidate.zammadGroup !== undefined) {
+    zammadGroup = assertNonEmptyString(candidate.zammadGroup, "zammadGroup");
+  }
+
+  return {
+    value,
+    label,
+    recipientEmail,
+    zammadGroup,
+  };
+}
+
+export function parseHelpdeskTopicRoutingFromEnv(
+  rawRoutingConfig = process.env.HELPDESK_TOPIC_ROUTING
+): HelpdeskTopicRouting[] {
+  if (!rawRoutingConfig || rawRoutingConfig.trim().length === 0) {
+    return DEFAULT_HELPDESK_TOPIC_ROUTING;
+  }
+
+  let parsed: unknown;
+  try {
+    parsed = JSON.parse(rawRoutingConfig);
+  } catch {
+    throw new Error(
+      "HELPDESK_TOPIC_ROUTING must be a valid JSON array of topic mappings."
+    );
+  }
+
+  if (!Array.isArray(parsed) || parsed.length === 0) {
+    throw new Error(
+      "HELPDESK_TOPIC_ROUTING must contain at least one topic mapping."
+    );
+  }
+
+  const routing = parsed.map((entry, index) =>
+    parseHelpdeskTopicRoutingEntry(entry, index)
+  );
+
+  const duplicateTopic = routing.find(
+    (topic, index) =>
+      routing.findIndex((candidate) => candidate.value === topic.value) !==
+      index
+  );
+
+  if (duplicateTopic) {
+    throw new Error(
+      `Duplicate topic value "${duplicateTopic.value}" in HELPDESK_TOPIC_ROUTING.`
+    );
+  }
+
+  return routing;
+}
+
+export function getHelpdeskTopicOptions(): HelpdeskTopicOption[] {
+  return parseHelpdeskTopicRoutingFromEnv().map(({ value, label }) => ({
+    value,
+    label,
+  }));
+}
+
+export function getHelpdeskTopicByValue(
+  value: string
+): HelpdeskTopicRouting | undefined {
+  return parseHelpdeskTopicRoutingFromEnv().find(
+    (topic) => topic.value === value
+  );
+}
+
+export function getZammadConfig() {
+  const baseUrl = process.env.HELPDESK_ZAMMAD_URL?.trim().replace(/\/$/, "");
+  const apiToken = process.env.HELPDESK_ZAMMAD_API_TOKEN?.trim();
+  const defaultGroup =
+    process.env.HELPDESK_ZAMMAD_DEFAULT_GROUP?.trim() || "Users";
+  const tlsInsecure =
+    process.env.HELPDESK_ZAMMAD_TLS_INSECURE?.trim().toLowerCase() === "true";
+
+  if (!baseUrl) {
+    throw new Error("Missing HELPDESK_ZAMMAD_URL environment variable.");
+  }
+
+  if (!apiToken) {
+    throw new Error("Missing HELPDESK_ZAMMAD_API_TOKEN environment variable.");
+  }
+
+  return {
+    baseUrl,
+    apiToken,
+    defaultGroup,
+    tlsInsecure,
+  };
+}

--- a/src/app/api/helpdesk/contact/__tests__/route.test.ts
+++ b/src/app/api/helpdesk/contact/__tests__/route.test.ts
@@ -66,6 +66,148 @@ describe("POST /api/helpdesk/contact", () => {
     });
   });
 
+  test("returns 400 if lastName is missing", async () => {
+    const response = await POST(
+      new Request("http://localhost/api/helpdesk/contact", {
+        method: "POST",
+        body: JSON.stringify({
+          firstName: "John",
+          email: "john@example.org",
+          topic: "general",
+          title: "Need support",
+          message: "Help",
+        }),
+      })
+    );
+
+    expect(response.status).toBe(400);
+    await expect(response.json()).resolves.toEqual({
+      error: 'Missing required field "lastName"',
+    });
+  });
+
+  test("returns 400 if email is missing", async () => {
+    const response = await POST(
+      new Request("http://localhost/api/helpdesk/contact", {
+        method: "POST",
+        body: JSON.stringify({
+          firstName: "John",
+          lastName: "Doe",
+          topic: "general",
+          title: "Need support",
+          message: "Help",
+        }),
+      })
+    );
+
+    expect(response.status).toBe(400);
+    await expect(response.json()).resolves.toEqual({
+      error: 'Missing required field "email"',
+    });
+  });
+
+  test("returns 400 if topic is missing", async () => {
+    const response = await POST(
+      new Request("http://localhost/api/helpdesk/contact", {
+        method: "POST",
+        body: JSON.stringify({
+          firstName: "John",
+          lastName: "Doe",
+          email: "john@example.org",
+          title: "Need support",
+          message: "Help",
+        }),
+      })
+    );
+
+    expect(response.status).toBe(400);
+    await expect(response.json()).resolves.toEqual({
+      error: 'Missing required field "topic"',
+    });
+  });
+
+  test("returns 400 if title is missing", async () => {
+    const response = await POST(
+      new Request("http://localhost/api/helpdesk/contact", {
+        method: "POST",
+        body: JSON.stringify({
+          firstName: "John",
+          lastName: "Doe",
+          email: "john@example.org",
+          topic: "general",
+          message: "Help",
+        }),
+      })
+    );
+
+    expect(response.status).toBe(400);
+    await expect(response.json()).resolves.toEqual({
+      error: 'Missing required field "title"',
+    });
+  });
+
+  test("returns 400 if title is too long", async () => {
+    const response = await POST(
+      new Request("http://localhost/api/helpdesk/contact", {
+        method: "POST",
+        body: JSON.stringify({
+          firstName: "John",
+          lastName: "Doe",
+          email: "john@example.org",
+          topic: "general",
+          title: "A".repeat(161),
+          message: "Help",
+        }),
+      })
+    );
+
+    expect(response.status).toBe(400);
+    await expect(response.json()).resolves.toEqual({
+      error: 'Field "title" must not exceed 160 characters',
+    });
+  });
+
+  test("returns 400 if message is missing", async () => {
+    const response = await POST(
+      new Request("http://localhost/api/helpdesk/contact", {
+        method: "POST",
+        body: JSON.stringify({
+          firstName: "John",
+          lastName: "Doe",
+          email: "john@example.org",
+          topic: "general",
+          title: "Need support",
+        }),
+      })
+    );
+
+    expect(response.status).toBe(400);
+    await expect(response.json()).resolves.toEqual({
+      error: 'Missing required field "message"',
+    });
+  });
+
+  test("returns 400 if message is too long", async () => {
+    const response = await POST(
+      new Request("http://localhost/api/helpdesk/contact", {
+        method: "POST",
+        body: JSON.stringify({
+          firstName: "John",
+          lastName: "Doe",
+          email: "john@example.org",
+          topic: "general",
+          title: "Need support",
+          message: "A".repeat(4001),
+        }),
+      })
+    );
+
+    expect(response.status).toBe(400);
+    await expect(response.json()).resolves.toEqual({
+      error: 'Field "message" must not exceed 4000 characters',
+    });
+  });
+
   test("returns 400 if topic is unknown", async () => {
     mockGetHelpdeskTopicByValue.mockReturnValueOnce(undefined);
 
@@ -158,6 +300,35 @@ describe("POST /api/helpdesk/contact", () => {
     expect(response.status).toBe(500);
     await expect(response.json()).resolves.toEqual({
       error: "Zammad unavailable",
+    });
+  });
+
+  test("returns generic 500 message when non-Error is thrown", async () => {
+    mockGetHelpdeskTopicByValue.mockReturnValueOnce({
+      value: "general",
+      label: "General inquiry",
+      recipientEmail: "helpdesk@example.org",
+      zammadGroup: "Users",
+    });
+    mockCreateZammadTicket.mockRejectedValueOnce("boom");
+
+    const response = await POST(
+      new Request("http://localhost/api/helpdesk/contact", {
+        method: "POST",
+        body: JSON.stringify({
+          firstName: "John",
+          lastName: "Doe",
+          email: "john@example.org",
+          topic: "general",
+          title: "Need support",
+          message: "Help",
+        }),
+      })
+    );
+
+    expect(response.status).toBe(500);
+    await expect(response.json()).resolves.toEqual({
+      error: "Unexpected helpdesk dispatch error",
     });
   });
 });

--- a/src/app/api/helpdesk/contact/__tests__/route.test.ts
+++ b/src/app/api/helpdesk/contact/__tests__/route.test.ts
@@ -299,7 +299,7 @@ describe("POST /api/helpdesk/contact", () => {
 
     expect(response.status).toBe(500);
     await expect(response.json()).resolves.toEqual({
-      error: "Zammad unavailable",
+      error: "Your request could not be submitted. Please try again.",
     });
   });
 
@@ -328,7 +328,7 @@ describe("POST /api/helpdesk/contact", () => {
 
     expect(response.status).toBe(500);
     await expect(response.json()).resolves.toEqual({
-      error: "Unexpected helpdesk dispatch error",
+      error: "Your request could not be submitted. Please try again.",
     });
   });
 });

--- a/src/app/api/helpdesk/contact/__tests__/route.test.ts
+++ b/src/app/api/helpdesk/contact/__tests__/route.test.ts
@@ -1,0 +1,163 @@
+// SPDX-FileCopyrightText: 2026 PNED G.I.E.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+import { jest } from "@jest/globals";
+import type { HelpdeskTopicRouting } from "@/app/api/helpdesk/config";
+
+const mockGetHelpdeskTopicByValue =
+  jest.fn<(value: string) => HelpdeskTopicRouting | undefined>();
+const mockCreateZammadTicket =
+  jest.fn<(input: unknown) => Promise<{ ticketId?: number }>>();
+
+jest.mock("@/app/api/helpdesk/config", () => ({
+  getHelpdeskTopicByValue: mockGetHelpdeskTopicByValue,
+}));
+
+jest.mock("@/app/api/helpdesk/zammad", () => ({
+  createZammadTicket: mockCreateZammadTicket,
+}));
+
+import { POST } from "@/app/api/helpdesk/contact/route";
+
+describe("POST /api/helpdesk/contact", () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  test("returns 400 if firstName is missing", async () => {
+    const response = await POST(
+      new Request("http://localhost/api/helpdesk/contact", {
+        method: "POST",
+        body: JSON.stringify({
+          lastName: "Doe",
+          email: "john@example.org",
+          topic: "general",
+          title: "Need support",
+          message: "Help",
+        }),
+      })
+    );
+
+    expect(response.status).toBe(400);
+    await expect(response.json()).resolves.toEqual({
+      error: 'Missing required field "firstName"',
+    });
+  });
+
+  test("returns 400 if email is invalid", async () => {
+    const response = await POST(
+      new Request("http://localhost/api/helpdesk/contact", {
+        method: "POST",
+        body: JSON.stringify({
+          firstName: "John",
+          lastName: "Doe",
+          email: "invalid-email",
+          topic: "general",
+          title: "Need support",
+          message: "Help",
+        }),
+      })
+    );
+
+    expect(response.status).toBe(400);
+    await expect(response.json()).resolves.toEqual({
+      error: 'Field "email" must be a valid email address',
+    });
+  });
+
+  test("returns 400 if topic is unknown", async () => {
+    mockGetHelpdeskTopicByValue.mockReturnValueOnce(undefined);
+
+    const response = await POST(
+      new Request("http://localhost/api/helpdesk/contact", {
+        method: "POST",
+        body: JSON.stringify({
+          firstName: "John",
+          lastName: "Doe",
+          email: "john@example.org",
+          topic: "unknown",
+          title: "Need support",
+          message: "Help",
+        }),
+      })
+    );
+
+    expect(response.status).toBe(400);
+    await expect(response.json()).resolves.toEqual({
+      error: 'Unknown topic "unknown"',
+    });
+  });
+
+  test("creates zammad ticket when payload is valid", async () => {
+    mockGetHelpdeskTopicByValue.mockReturnValueOnce({
+      value: "general",
+      label: "General inquiry",
+      recipientEmail: "helpdesk@example.org",
+      zammadGroup: "Users",
+    });
+    mockCreateZammadTicket.mockResolvedValueOnce({ ticketId: 42 });
+
+    const response = await POST(
+      new Request("http://localhost/api/helpdesk/contact", {
+        method: "POST",
+        body: JSON.stringify({
+          firstName: "John",
+          lastName: "Doe",
+          email: "john@example.org",
+          topic: "general",
+          title: "Need support",
+          message: "Help",
+        }),
+      })
+    );
+
+    expect(mockCreateZammadTicket).toHaveBeenCalledWith({
+      title: "Need support",
+      firstName: "John",
+      lastName: "Doe",
+      email: "john@example.org",
+      message: "Help",
+      topicLabel: "General inquiry",
+      topicValue: "general",
+      recipientEmail: "helpdesk@example.org",
+      group: "Users",
+    });
+    expect(response.status).toBe(200);
+    await expect(response.json()).resolves.toEqual({
+      success: true,
+      ticketId: 42,
+    });
+  });
+
+  test("returns 500 when zammad integration fails", async () => {
+    mockGetHelpdeskTopicByValue.mockReturnValueOnce({
+      value: "general",
+      label: "General inquiry",
+      recipientEmail: "helpdesk@example.org",
+      zammadGroup: "Users",
+    });
+    mockCreateZammadTicket.mockRejectedValueOnce(
+      new Error("Zammad unavailable")
+    );
+
+    const response = await POST(
+      new Request("http://localhost/api/helpdesk/contact", {
+        method: "POST",
+        body: JSON.stringify({
+          firstName: "John",
+          lastName: "Doe",
+          email: "john@example.org",
+          topic: "general",
+          title: "Need support",
+          message: "Help",
+        }),
+      })
+    );
+
+    expect(response.status).toBe(500);
+    await expect(response.json()).resolves.toEqual({
+      error: "Zammad unavailable",
+    });
+  });
+});

--- a/src/app/api/helpdesk/contact/route.ts
+++ b/src/app/api/helpdesk/contact/route.ts
@@ -125,9 +125,6 @@ export async function POST(request: Request) {
     });
   } catch (error) {
     console.error("Helpdesk contact submission failed", error);
-    return Response.json(
-      { error: GENERIC_SUBMISSION_ERROR },
-      { status: 500 }
-    );
+    return Response.json({ error: GENERIC_SUBMISSION_ERROR }, { status: 500 });
   }
 }

--- a/src/app/api/helpdesk/contact/route.ts
+++ b/src/app/api/helpdesk/contact/route.ts
@@ -18,6 +18,8 @@ type ContactRequestBody = {
 const MAX_TITLE_LENGTH = 160;
 const MAX_MESSAGE_LENGTH = 4000;
 const EMAIL_SCHEMA = z.string().email();
+const GENERIC_SUBMISSION_ERROR =
+  "Your request could not be submitted. Please try again.";
 
 export async function POST(request: Request) {
   try {
@@ -122,13 +124,9 @@ export async function POST(request: Request) {
       ticketId: result.ticketId,
     });
   } catch (error) {
+    console.error("Helpdesk contact submission failed", error);
     return Response.json(
-      {
-        error:
-          error instanceof Error
-            ? error.message
-            : "Unexpected helpdesk dispatch error",
-      },
+      { error: GENERIC_SUBMISSION_ERROR },
       { status: 500 }
     );
   }

--- a/src/app/api/helpdesk/contact/route.ts
+++ b/src/app/api/helpdesk/contact/route.ts
@@ -4,6 +4,7 @@
 
 import { getHelpdeskTopicByValue } from "@/app/api/helpdesk/config";
 import { createZammadTicket } from "@/app/api/helpdesk/zammad";
+import { z } from "zod";
 
 type ContactRequestBody = {
   firstName?: string;
@@ -14,9 +15,9 @@ type ContactRequestBody = {
   message?: string;
 };
 
-const EMAIL_REGEX = /^[^\s@]+@[^\s@]+\.[^\s@]+$/;
 const MAX_TITLE_LENGTH = 160;
 const MAX_MESSAGE_LENGTH = 4000;
+const EMAIL_SCHEMA = z.string().email();
 
 export async function POST(request: Request) {
   try {
@@ -50,7 +51,7 @@ export async function POST(request: Request) {
       );
     }
 
-    if (!EMAIL_REGEX.test(email)) {
+    if (!EMAIL_SCHEMA.safeParse(email).success) {
       return Response.json(
         { error: 'Field "email" must be a valid email address' },
         { status: 400 }

--- a/src/app/api/helpdesk/contact/route.ts
+++ b/src/app/api/helpdesk/contact/route.ts
@@ -1,0 +1,134 @@
+// SPDX-FileCopyrightText: 2026 PNED G.I.E.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+import { getHelpdeskTopicByValue } from "@/app/api/helpdesk/config";
+import { createZammadTicket } from "@/app/api/helpdesk/zammad";
+
+type ContactRequestBody = {
+  firstName?: string;
+  lastName?: string;
+  email?: string;
+  topic?: string;
+  title?: string;
+  message?: string;
+};
+
+const EMAIL_REGEX = /^[^\s@]+@[^\s@]+\.[^\s@]+$/;
+const MAX_TITLE_LENGTH = 160;
+const MAX_MESSAGE_LENGTH = 4000;
+
+export async function POST(request: Request) {
+  try {
+    const body = (await request.json()) as ContactRequestBody;
+
+    const firstName = body.firstName?.trim();
+    const lastName = body.lastName?.trim();
+    const email = body.email?.trim();
+    const topic = body.topic?.trim();
+    const title = body.title?.trim();
+    const message = body.message?.trim();
+
+    if (!firstName) {
+      return Response.json(
+        { error: 'Missing required field "firstName"' },
+        { status: 400 }
+      );
+    }
+
+    if (!lastName) {
+      return Response.json(
+        { error: 'Missing required field "lastName"' },
+        { status: 400 }
+      );
+    }
+
+    if (!email) {
+      return Response.json(
+        { error: 'Missing required field "email"' },
+        { status: 400 }
+      );
+    }
+
+    if (!EMAIL_REGEX.test(email)) {
+      return Response.json(
+        { error: 'Field "email" must be a valid email address' },
+        { status: 400 }
+      );
+    }
+
+    if (!topic) {
+      return Response.json(
+        { error: 'Missing required field "topic"' },
+        { status: 400 }
+      );
+    }
+
+    if (!title) {
+      return Response.json(
+        { error: 'Missing required field "title"' },
+        { status: 400 }
+      );
+    }
+
+    if (title.length > MAX_TITLE_LENGTH) {
+      return Response.json(
+        {
+          error: `Field "title" must not exceed ${MAX_TITLE_LENGTH} characters`,
+        },
+        { status: 400 }
+      );
+    }
+
+    if (!message) {
+      return Response.json(
+        { error: 'Missing required field "message"' },
+        { status: 400 }
+      );
+    }
+
+    if (message.length > MAX_MESSAGE_LENGTH) {
+      return Response.json(
+        {
+          error: `Field "message" must not exceed ${MAX_MESSAGE_LENGTH} characters`,
+        },
+        { status: 400 }
+      );
+    }
+
+    const selectedTopic = getHelpdeskTopicByValue(topic);
+    if (!selectedTopic) {
+      return Response.json(
+        { error: `Unknown topic "${topic}"` },
+        { status: 400 }
+      );
+    }
+
+    const result = await createZammadTicket({
+      title,
+      firstName,
+      lastName,
+      email,
+      message,
+      topicLabel: selectedTopic.label,
+      topicValue: selectedTopic.value,
+      recipientEmail: selectedTopic.recipientEmail,
+      group: selectedTopic.zammadGroup,
+    });
+
+    return Response.json({
+      success: true,
+      ticketId: result.ticketId,
+    });
+  } catch (error) {
+    return Response.json(
+      {
+        error:
+          error instanceof Error
+            ? error.message
+            : "Unexpected helpdesk dispatch error",
+      },
+      { status: 500 }
+    );
+  }
+}

--- a/src/app/api/helpdesk/topics/__tests__/route.test.ts
+++ b/src/app/api/helpdesk/topics/__tests__/route.test.ts
@@ -1,0 +1,50 @@
+// SPDX-FileCopyrightText: 2026 PNED G.I.E.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+import { jest } from "@jest/globals";
+
+const mockGetHelpdeskTopicOptions =
+  jest.fn<() => Array<{ value: string; label: string }>>();
+
+jest.mock("@/app/api/helpdesk/config", () => ({
+  getHelpdeskTopicOptions: mockGetHelpdeskTopicOptions,
+}));
+
+import { GET } from "@/app/api/helpdesk/topics/route";
+
+describe("GET /api/helpdesk/topics", () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  test("returns topics from configuration", async () => {
+    mockGetHelpdeskTopicOptions.mockReturnValueOnce([
+      { value: "general", label: "General inquiry" },
+      { value: "technical", label: "Technical issue" },
+    ]);
+
+    const response = await GET();
+
+    expect(response.status).toBe(200);
+    await expect(response.json()).resolves.toEqual({
+      topics: [
+        { value: "general", label: "General inquiry" },
+        { value: "technical", label: "Technical issue" },
+      ],
+    });
+  });
+
+  test("returns 500 when config loading fails", async () => {
+    mockGetHelpdeskTopicOptions.mockImplementationOnce(() => {
+      throw new Error("broken config");
+    });
+
+    const response = await GET();
+
+    expect(response.status).toBe(500);
+    await expect(response.json()).resolves.toEqual({
+      error: "broken config",
+    });
+  });
+});

--- a/src/app/api/helpdesk/topics/__tests__/route.test.ts
+++ b/src/app/api/helpdesk/topics/__tests__/route.test.ts
@@ -47,4 +47,17 @@ describe("GET /api/helpdesk/topics", () => {
       error: "broken config",
     });
   });
+
+  test("stringifies non-Error failures", async () => {
+    mockGetHelpdeskTopicOptions.mockImplementationOnce(() => {
+      throw "broken as string";
+    });
+
+    const response = await GET();
+
+    expect(response.status).toBe(500);
+    await expect(response.json()).resolves.toEqual({
+      error: "broken as string",
+    });
+  });
 });

--- a/src/app/api/helpdesk/topics/route.ts
+++ b/src/app/api/helpdesk/topics/route.ts
@@ -1,0 +1,16 @@
+// SPDX-FileCopyrightText: 2026 PNED G.I.E.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+import { getHelpdeskTopicOptions } from "@/app/api/helpdesk/config";
+
+export async function GET() {
+  try {
+    return Response.json({ topics: getHelpdeskTopicOptions() });
+  } catch (error) {
+    return Response.json(
+      { error: error instanceof Error ? error.message : String(error) },
+      { status: 500 }
+    );
+  }
+}

--- a/src/app/api/helpdesk/zammad.ts
+++ b/src/app/api/helpdesk/zammad.ts
@@ -1,0 +1,269 @@
+// SPDX-FileCopyrightText: 2026 PNED G.I.E.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+import { getZammadConfig } from "@/app/api/helpdesk/config";
+import { Agent } from "undici";
+
+type CreateZammadTicketInput = {
+  title: string;
+  firstName: string;
+  lastName: string;
+  email: string;
+  topicLabel: string;
+  topicValue: string;
+  recipientEmail: string;
+  message: string;
+  group?: string;
+};
+
+type ZammadCreateTicketResponse = {
+  id?: number;
+  customer_id?: number;
+};
+
+type ZammadTicketPayload = {
+  title: string;
+  group: string;
+  customer_id: string;
+  article: {
+    subject: string;
+    body: string;
+    type: "email" | "web";
+    sender: "Agent" | "Customer";
+    internal: boolean;
+    to?: string;
+    reply_to?: string;
+    content_type: "text/plain";
+  };
+};
+
+const INSECURE_TLS_DISPATCHER = new Agent({
+  connect: {
+    rejectUnauthorized: false,
+  },
+});
+
+function formatArticleBody(input: CreateZammadTicketInput): string {
+  return [
+    `First name: ${input.firstName}`,
+    `Last name: ${input.lastName}`,
+    `Email: ${input.email}`,
+    `Topic: ${input.topicLabel} (${input.topicValue})`,
+    `Recipient routing: ${input.recipientEmail}`,
+    "",
+    "Message:",
+    input.message,
+  ].join("\n");
+}
+
+function buildEmailArticlePayload(
+  input: CreateZammadTicketInput,
+  targetGroup: string,
+  senderEmail: string
+): ZammadTicketPayload {
+  return {
+    title: input.title,
+    group: targetGroup,
+    customer_id: `guess:${senderEmail}`,
+    article: {
+      subject: input.title,
+      body: formatArticleBody(input),
+      type: "email",
+      sender: "Agent",
+      internal: false,
+      to: input.recipientEmail,
+      reply_to: senderEmail,
+      content_type: "text/plain",
+    },
+  };
+}
+
+function buildFallbackWebPayload(
+  input: CreateZammadTicketInput,
+  targetGroup: string,
+  senderEmail: string
+): ZammadTicketPayload {
+  return {
+    title: input.title,
+    group: targetGroup,
+    customer_id: `guess:${senderEmail}`,
+    article: {
+      subject: input.title,
+      body: formatArticleBody(input),
+      type: "web",
+      sender: "Customer",
+      internal: false,
+      content_type: "text/plain",
+    },
+  };
+}
+
+async function postZammadTicket(
+  baseUrl: string,
+  apiToken: string,
+  payload: ZammadTicketPayload,
+  tlsInsecure: boolean
+) {
+  let response: Response;
+  try {
+    response = await fetch(`${baseUrl}/api/v1/tickets`, {
+      method: "POST",
+      headers: {
+        Authorization: `Token token=${apiToken}`,
+        "Content-Type": "application/json",
+      },
+      body: JSON.stringify(payload),
+      ...(tlsInsecure && baseUrl.startsWith("https://")
+        ? { dispatcher: INSECURE_TLS_DISPATCHER }
+        : {}),
+    });
+  } catch (error) {
+    const message = error instanceof Error ? error.message : String(error);
+    throw new Error(
+      [
+        `Unable to reach Zammad at ${baseUrl}.`,
+        `Request error: ${message}.`,
+        tlsInsecure
+          ? "TLS verification is disabled via HELPDESK_ZAMMAD_TLS_INSECURE=true."
+          : "If this host uses an internal/self-signed certificate, set HELPDESK_ZAMMAD_TLS_INSECURE=true.",
+      ].join(" ")
+    );
+  }
+
+  const responseBody = await response.text();
+  return { response, responseBody };
+}
+
+async function updateZammadCustomerProfile(
+  baseUrl: string,
+  apiToken: string,
+  tlsInsecure: boolean,
+  customerId: number,
+  firstName: string,
+  lastName: string,
+  email: string
+) {
+  try {
+    await fetch(`${baseUrl}/api/v1/users/${customerId}`, {
+      method: "PUT",
+      headers: {
+        Authorization: `Token token=${apiToken}`,
+        "Content-Type": "application/json",
+      },
+      body: JSON.stringify({
+        firstname: firstName,
+        lastname: lastName,
+        email,
+      }),
+      ...(tlsInsecure && baseUrl.startsWith("https://")
+        ? { dispatcher: INSECURE_TLS_DISPATCHER }
+        : {}),
+    });
+  } catch {
+    // Ticket creation succeeded, so user profile sync failure should not break contact flow.
+  }
+}
+
+function parseTicketCreateResponseBody(
+  responseBody: string
+): ZammadCreateTicketResponse {
+  try {
+    return JSON.parse(responseBody) as ZammadCreateTicketResponse;
+  } catch {
+    throw new Error(
+      `Zammad ticket creation succeeded but response was not valid JSON: ${responseBody}`
+    );
+  }
+}
+
+function isMissingGroupEmailError(
+  status: number,
+  responseBody: string
+): boolean {
+  return (
+    status === 500 && responseBody.includes("No email address found for group")
+  );
+}
+
+export async function createZammadTicket(
+  input: CreateZammadTicketInput
+): Promise<{ ticketId?: number }> {
+  const zammadConfig = getZammadConfig();
+  const targetGroup = input.group || zammadConfig.defaultGroup;
+  const senderEmail = input.email.toLowerCase();
+  const emailPayload = buildEmailArticlePayload(
+    input,
+    targetGroup,
+    senderEmail
+  );
+
+  const firstAttempt = await postZammadTicket(
+    zammadConfig.baseUrl,
+    zammadConfig.apiToken,
+    emailPayload,
+    zammadConfig.tlsInsecure
+  );
+
+  if (
+    !firstAttempt.response.ok &&
+    isMissingGroupEmailError(
+      firstAttempt.response.status,
+      firstAttempt.responseBody
+    )
+  ) {
+    const fallbackPayload = buildFallbackWebPayload(
+      input,
+      targetGroup,
+      senderEmail
+    );
+    const fallbackAttempt = await postZammadTicket(
+      zammadConfig.baseUrl,
+      zammadConfig.apiToken,
+      fallbackPayload,
+      zammadConfig.tlsInsecure
+    );
+
+    if (!fallbackAttempt.response.ok) {
+      throw new Error(
+        `Zammad ticket creation failed with status ${fallbackAttempt.response.status}: ${fallbackAttempt.responseBody}`
+      );
+    }
+
+    const fallbackData = parseTicketCreateResponseBody(
+      fallbackAttempt.responseBody
+    );
+    if (fallbackData.customer_id) {
+      await updateZammadCustomerProfile(
+        zammadConfig.baseUrl,
+        zammadConfig.apiToken,
+        zammadConfig.tlsInsecure,
+        fallbackData.customer_id,
+        input.firstName,
+        input.lastName,
+        senderEmail
+      );
+    }
+    return { ticketId: fallbackData.id };
+  }
+
+  if (!firstAttempt.response.ok) {
+    throw new Error(
+      `Zammad ticket creation failed with status ${firstAttempt.response.status}: ${firstAttempt.responseBody}`
+    );
+  }
+
+  const data = parseTicketCreateResponseBody(firstAttempt.responseBody);
+  if (data.customer_id) {
+    await updateZammadCustomerProfile(
+      zammadConfig.baseUrl,
+      zammadConfig.apiToken,
+      zammadConfig.tlsInsecure,
+      data.customer_id,
+      input.firstName,
+      input.lastName,
+      senderEmail
+    );
+  }
+  return { ticketId: data.id };
+}

--- a/src/components/ContactUsModal.tsx
+++ b/src/components/ContactUsModal.tsx
@@ -39,7 +39,12 @@ const INITIAL_FORM_STATE: ContactFormState = {
   message: "",
 };
 
-const EMAIL_REGEX = /^[^\s@]+@[^\s@]+\.[^\s@]+$/;
+function isValidEmailFormat(value: string): boolean {
+  const emailInput = document.createElement("input");
+  emailInput.type = "email";
+  emailInput.value = value;
+  return emailInput.checkValidity();
+}
 
 export default function ContactUsModal() {
   const [open, setOpen] = useState(false);
@@ -145,7 +150,7 @@ export default function ContactUsModal() {
       return;
     }
 
-    if (!EMAIL_REGEX.test(formState.email.trim())) {
+    if (!isValidEmailFormat(formState.email.trim())) {
       setErrorMessage("Please provide a valid email address.");
       return;
     }

--- a/src/components/ContactUsModal.tsx
+++ b/src/components/ContactUsModal.tsx
@@ -1,0 +1,367 @@
+// SPDX-FileCopyrightText: 2026 PNED G.I.E.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+"use client";
+
+import { useEffect, useMemo, useState } from "react";
+import AppButton from "@/components/Button";
+import { Button as DialogButton } from "@/components/shadcn/button";
+import { Input } from "@/components/shadcn/input";
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogHeader,
+  DialogTitle,
+} from "@/components/shadcn/dialog";
+
+type TopicOption = {
+  value: string;
+  label: string;
+};
+
+type ContactFormState = {
+  firstName: string;
+  lastName: string;
+  email: string;
+  topic: string;
+  title: string;
+  message: string;
+};
+
+const INITIAL_FORM_STATE: ContactFormState = {
+  firstName: "",
+  lastName: "",
+  email: "",
+  topic: "",
+  title: "",
+  message: "",
+};
+
+const EMAIL_REGEX = /^[^\s@]+@[^\s@]+\.[^\s@]+$/;
+
+export default function ContactUsModal() {
+  const [open, setOpen] = useState(false);
+  const [topics, setTopics] = useState<TopicOption[]>([]);
+  const [formState, setFormState] =
+    useState<ContactFormState>(INITIAL_FORM_STATE);
+  const [isLoadingTopics, setIsLoadingTopics] = useState(false);
+  const [isSubmitting, setIsSubmitting] = useState(false);
+  const [errorMessage, setErrorMessage] = useState<string | null>(null);
+  const [successMessage, setSuccessMessage] = useState<string | null>(null);
+
+  const isTopicAvailable = useMemo(() => topics.length > 0, [topics.length]);
+
+  useEffect(() => {
+    if (!open || topics.length > 0 || isLoadingTopics) {
+      return;
+    }
+
+    const loadTopics = async () => {
+      setIsLoadingTopics(true);
+      setErrorMessage(null);
+
+      try {
+        const response = await fetch("/api/helpdesk/topics", {
+          method: "GET",
+        });
+        const responseBody = (await response.json()) as {
+          topics?: TopicOption[];
+          error?: string;
+        };
+
+        if (!response.ok) {
+          throw new Error(
+            responseBody.error || "Unable to load support topic options."
+          );
+        }
+
+        const loadedTopics = responseBody.topics ?? [];
+        setTopics(loadedTopics);
+
+        if (loadedTopics.length > 0) {
+          setFormState((previousState) => ({
+            ...previousState,
+            topic: previousState.topic || loadedTopics[0].value,
+          }));
+        }
+      } catch (error) {
+        setErrorMessage(
+          error instanceof Error
+            ? error.message
+            : "Unable to load support topic options."
+        );
+      } finally {
+        setIsLoadingTopics(false);
+      }
+    };
+
+    loadTopics().catch(() => {
+      setErrorMessage("Unable to load support topic options.");
+      setIsLoadingTopics(false);
+    });
+  }, [isLoadingTopics, open, topics.length]);
+
+  const updateField =
+    (field: keyof ContactFormState) =>
+    (event: React.ChangeEvent<HTMLInputElement | HTMLTextAreaElement>) => {
+      setFormState((previousState) => ({
+        ...previousState,
+        [field]: event.target.value,
+      }));
+      setErrorMessage(null);
+      setSuccessMessage(null);
+    };
+
+  const updateTopic = (event: React.ChangeEvent<HTMLSelectElement>) => {
+    setFormState((previousState) => ({
+      ...previousState,
+      topic: event.target.value,
+    }));
+    setErrorMessage(null);
+    setSuccessMessage(null);
+  };
+
+  const closeDialog = (nextOpenState: boolean) => {
+    setOpen(nextOpenState);
+    if (!nextOpenState) {
+      setErrorMessage(null);
+      setSuccessMessage(null);
+      setIsSubmitting(false);
+    }
+  };
+
+  const handleSubmit = async (event: React.FormEvent<HTMLFormElement>) => {
+    event.preventDefault();
+
+    if (!formState.firstName.trim()) {
+      setErrorMessage("Please provide your first name.");
+      return;
+    }
+
+    if (!formState.lastName.trim()) {
+      setErrorMessage("Please provide your last name.");
+      return;
+    }
+
+    if (!EMAIL_REGEX.test(formState.email.trim())) {
+      setErrorMessage("Please provide a valid email address.");
+      return;
+    }
+
+    if (!formState.topic.trim()) {
+      setErrorMessage("Please select a topic.");
+      return;
+    }
+
+    if (!formState.title.trim()) {
+      setErrorMessage("Please provide a title.");
+      return;
+    }
+
+    if (!formState.message.trim()) {
+      setErrorMessage("Please enter a message.");
+      return;
+    }
+
+    setIsSubmitting(true);
+    setErrorMessage(null);
+    setSuccessMessage(null);
+
+    try {
+      const response = await fetch("/api/helpdesk/contact", {
+        method: "POST",
+        headers: {
+          "Content-Type": "application/json",
+        },
+        body: JSON.stringify({
+          firstName: formState.firstName.trim(),
+          lastName: formState.lastName.trim(),
+          email: formState.email.trim(),
+          topic: formState.topic,
+          title: formState.title.trim(),
+          message: formState.message.trim(),
+        }),
+      });
+
+      const responseBody = (await response.json()) as {
+        error?: string;
+        ticketId?: number;
+      };
+
+      if (!response.ok) {
+        throw new Error(
+          responseBody.error ||
+            "Your request could not be submitted. Please try again."
+        );
+      }
+
+      setSuccessMessage("Your request has been submitted successfully.");
+
+      setFormState((previousState) => ({
+        ...INITIAL_FORM_STATE,
+        topic: previousState.topic,
+      }));
+    } catch (error) {
+      setErrorMessage(
+        error instanceof Error
+          ? error.message
+          : "Your request could not be submitted. Please try again."
+      );
+    } finally {
+      setIsSubmitting(false);
+    }
+  };
+
+  return (
+    <>
+      <AppButton
+        text="Get in touch"
+        type="primary"
+        className="self-start"
+        onClick={(event) => {
+          event.preventDefault();
+          setOpen(true);
+        }}
+      />
+
+      <Dialog open={open} onOpenChange={closeDialog}>
+        <DialogContent className="sm:max-w-xl bg-white max-h-[90vh] overflow-y-auto">
+          <DialogHeader>
+            <DialogTitle>Contact Us</DialogTitle>
+            <DialogDescription>
+              Send your inquiry to the right team by selecting a topic.
+            </DialogDescription>
+          </DialogHeader>
+
+          <form className="space-y-4" onSubmit={handleSubmit}>
+            <div className="space-y-2">
+              <label htmlFor="firstName" className="text-sm font-title">
+                First Name
+              </label>
+              <Input
+                id="firstName"
+                value={formState.firstName}
+                onChange={updateField("firstName")}
+                placeholder="Your first name"
+                required
+              />
+            </div>
+
+            <div className="space-y-2">
+              <label htmlFor="lastName" className="text-sm font-title">
+                Last Name
+              </label>
+              <Input
+                id="lastName"
+                value={formState.lastName}
+                onChange={updateField("lastName")}
+                placeholder="Your last name"
+                required
+              />
+            </div>
+
+            <div className="space-y-2">
+              <label htmlFor="email" className="text-sm font-title">
+                Email
+              </label>
+              <Input
+                id="email"
+                type="email"
+                value={formState.email}
+                onChange={updateField("email")}
+                placeholder="you@example.org"
+                required
+              />
+            </div>
+
+            <div className="space-y-2">
+              <label htmlFor="topic" className="text-sm font-title">
+                Topic
+              </label>
+              <select
+                id="topic"
+                value={formState.topic}
+                onChange={updateTopic}
+                className="border-input bg-background ring-offset-background placeholder:text-muted-foreground flex h-10 w-full rounded-md border px-3 py-2 text-sm focus-visible:outline-hidden disabled:cursor-not-allowed disabled:opacity-50"
+                disabled={isLoadingTopics || !isTopicAvailable}
+                required
+              >
+                {!isTopicAvailable && (
+                  <option value="">
+                    {isLoadingTopics
+                      ? "Loading topics..."
+                      : "No topics available"}
+                  </option>
+                )}
+                {topics.map((topic) => (
+                  <option key={topic.value} value={topic.value}>
+                    {topic.label}
+                  </option>
+                ))}
+              </select>
+            </div>
+
+            <div className="space-y-2">
+              <label htmlFor="title" className="text-sm font-title">
+                Title
+              </label>
+              <Input
+                id="title"
+                value={formState.title}
+                onChange={updateField("title")}
+                placeholder="A short title"
+                maxLength={160}
+                required
+              />
+            </div>
+
+            <div className="space-y-2">
+              <label htmlFor="message" className="text-sm font-title">
+                Message
+              </label>
+              <textarea
+                id="message"
+                value={formState.message}
+                onChange={updateField("message")}
+                placeholder="Describe your request"
+                className="border-input bg-background ring-offset-background placeholder:text-muted-foreground min-h-[140px] w-full rounded-md border px-3 py-2 text-sm focus-visible:outline-hidden disabled:cursor-not-allowed disabled:opacity-50"
+                maxLength={4000}
+                required
+              />
+            </div>
+
+            {errorMessage && (
+              <p className="text-sm text-red-700" role="alert">
+                {errorMessage}
+              </p>
+            )}
+            {successMessage && (
+              <p className="text-sm text-green-700" role="status">
+                {successMessage}
+              </p>
+            )}
+
+            <div className="flex justify-end gap-2">
+              <DialogButton
+                type="button"
+                variant="outline"
+                onClick={() => closeDialog(false)}
+                disabled={isSubmitting}
+              >
+                Cancel
+              </DialogButton>
+              <DialogButton
+                type="submit"
+                disabled={isSubmitting || !isTopicAvailable}
+              >
+                {isSubmitting ? "Submitting..." : "Submit"}
+              </DialogButton>
+            </div>
+          </form>
+        </DialogContent>
+      </Dialog>
+    </>
+  );
+}

--- a/src/config/contentConfig.ts
+++ b/src/config/contentConfig.ts
@@ -23,6 +23,7 @@ interface ContentConfig {
   showBasketAndLogin: boolean;
   addParticipantsEnabled: boolean;
   showAlleleFrequency: boolean;
+  contactUsEnabled: boolean;
   footerLogos?: Array<{ src: string; alt: string }>;
   favicon: string;
   headerLogoUrl: string;
@@ -61,6 +62,8 @@ const contentConfig: ContentConfig = {
   addParticipantsEnabled:
     env("NEXT_PUBLIC_FEATURE_ADD_PARTICIPANTS") !== "false",
   showAlleleFrequency: env("NEXT_PUBLIC_SHOW_ALLELE_FREQUENCY") !== "false",
+  contactUsEnabled:
+    env("NEXT_PUBLIC_FEATURE_CONTACT_US")?.toLowerCase() === "true",
   footerLogos: env("NEXT_PUBLIC_FOOTER_LOGOS")
     ? JSON.parse(env("NEXT_PUBLIC_FOOTER_LOGOS") || "[]")
     : undefined,


### PR DESCRIPTION
- Added a Contact Us modal to the footer for user inquiries.
- Implemented API routes for handling contact requests and fetching helpdesk topics.
- Integrated Zammad ticket creation with error handling and user profile updates.
- Updated environment configuration for helpdesk routing and Zammad settings.
- Added tests for the new contact functionality and helpdesk API routes.
- Updated README with helpdesk setup instructions.

## Summary by Sourcery

Add a configurable helpdesk contact flow that exposes a footer "Contact Us" modal backed by Zammad-integrated API endpoints.

New Features:
- Introduce a footer Contact Us modal that lets users submit inquiries via a structured form.
- Expose helpdesk API endpoints for submitting contact requests and listing available helpdesk topics backed by environment-based routing.
- Integrate Zammad ticket creation for incoming contact requests with graceful handling of missing group email configuration and optional customer profile syncing.

Enhancements:
- Add configurable helpdesk topic routing and Zammad connection settings via environment-driven backend configuration.
- Gate the Contact Us UI via a feature flag in the shared content configuration.

Documentation:
- Document local helpdesk and Zammad setup, including required environment variables for topic routing and Zammad integration.

Tests:
- Add unit and route tests for helpdesk configuration parsing, Zammad ticket integration, and the new contact/topics API endpoints.