### PR TITLE
fix(docker): include undici in frontend runtime image for harvest worker

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -37,6 +37,7 @@ ENV NODE_ENV="production"
 COPY --from=builder /app/public ./public
 COPY --from=builder /app/scripts ./scripts
 COPY --from=builder /app/node_modules/node-cron ./node_modules/node-cron
+COPY --from=builder /app/node_modules/undici ./node_modules/undici
 
 # Ensure no write permissions for executable directories
 COPY --from=builder --chown=1001:1001 /app/.next/standalone ./

--- a/src/components/AuthErrorBanner.tsx
+++ b/src/components/AuthErrorBanner.tsx
@@ -1,0 +1,35 @@
+// SPDX-FileCopyrightText: 2025 PNED G.I.E.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+type AuthErrorBannerProps = {
+  authError?: string;
+};
+
+const authErrorMessages: Record<string, { title: string; message: string }> = {
+  "missing-terms": {
+    title: "Login blocked",
+    message:
+      "You must accept the terms and conditions before you can access the portal.",
+  },
+};
+
+const AuthErrorBanner = ({ authError }: AuthErrorBannerProps) => {
+  if (!authError || !(authError in authErrorMessages)) {
+    return null;
+  }
+
+  const { title, message } = authErrorMessages[authError];
+
+  return (
+    <div
+      className="mx-auto mb-10 w-full max-w-4xl rounded-lg border-l-4 border-l-warning bg-warning/10 p-4 text-left shadow-lg"
+      role="alert"
+    >
+      <h3 className="mb-1 text-lg font-semibold">{title}</h3>
+      <p className="text-sm leading-6 md:text-base">{message}</p>
+    </div>
+  );
+};
+
+export default AuthErrorBanner;


### PR DESCRIPTION
## Summary by Sourcery

Ensure the frontend runtime image includes required HTTP client dependencies and add a reusable banner component for displaying specific authentication errors to users.

New Features:
- Introduce an AuthErrorBanner React component to display user-facing messages for specific authentication failures such as missing terms acceptance.

Build:
- Include the undici Node.js HTTP client library in the frontend production Docker image used by the harvest worker.