### PR TITLE
fix(harvest): use undici fetch with harvest dispatcher on Node 24

### DIFF
--- a/scripts/harvest-http.js
+++ b/scripts/harvest-http.js
@@ -2,7 +2,7 @@
 //
 // SPDX-License-Identifier: Apache-2.0
 
-const { Agent } = require("undici");
+const { Agent, fetch: undiciFetch } = require("undici");
 
 const HARVEST_REQUEST_TIMEOUT_MS = 600000;
 const harvestDispatcher = new Agent({
@@ -71,7 +71,7 @@ function truncateText(value, limit = 400) {
 
 async function requestHarvest(
   { apiUrl, sourceUrl, secret },
-  { fetchImpl = fetch, timeoutMs = HARVEST_REQUEST_TIMEOUT_MS } = {}
+  { fetchImpl = undiciFetch, timeoutMs = HARVEST_REQUEST_TIMEOUT_MS } = {}
 ) {
   const timeoutController = new AbortController();
   const timeout = setTimeout(() => timeoutController.abort(), timeoutMs);

--- a/src/app/api/discovery/harvester/__tests__/oidc-auth.service.test.ts
+++ b/src/app/api/discovery/harvester/__tests__/oidc-auth.service.test.ts
@@ -29,7 +29,6 @@ const applyEnv = (snapshot: EnvSnapshot): void => {
 
 describe("OidcAuthService", () => {
   const originalEnv = readEnv();
-  const originalFetch = global.fetch;
   let fetchMock: jest.MockedFunction<typeof fetch>;
 
   beforeEach(() => {
@@ -38,30 +37,28 @@ describe("OidcAuthService", () => {
     delete process.env.HARVEST_OIDC_CLIENT_SECRET;
     jest.restoreAllMocks();
     fetchMock = jest.fn<typeof fetch>();
-    global.fetch = fetchMock;
   });
 
   afterAll(() => {
     applyEnv(originalEnv);
-    global.fetch = originalFetch;
   });
 
   test("returns empty headers when OIDC is not configured", async () => {
-    const service = new OidcAuthService();
+    const service = new OidcAuthService(fetchMock);
     await expect(service.getAuthorizationHeaderIfConfigured()).resolves.toEqual(
       {}
     );
-    expect(global.fetch).not.toHaveBeenCalled();
+    expect(fetchMock).not.toHaveBeenCalled();
   });
 
   test("throws when OIDC configuration is partial", async () => {
     process.env.HARVEST_OIDC_CLIENT_ID = "client-only";
-    const service = new OidcAuthService();
+    const service = new OidcAuthService(fetchMock);
 
     await expect(service.getAuthorizationHeaderIfConfigured()).rejects.toThrow(
       "Incomplete OIDC configuration for harvesting"
     );
-    expect(global.fetch).not.toHaveBeenCalled();
+    expect(fetchMock).not.toHaveBeenCalled();
   });
 
   test("retrieves token and returns bearer authorization header", async () => {
@@ -74,7 +71,7 @@ describe("OidcAuthService", () => {
       json: async () => ({ access_token: "token-123", expires_in: 3600 }),
     } as Response);
 
-    const service = new OidcAuthService();
+    const service = new OidcAuthService(fetchMock);
     const headers = await service.getAuthorizationHeaderIfConfigured();
 
     expect(fetchMock).toHaveBeenCalledTimes(1);
@@ -100,7 +97,7 @@ describe("OidcAuthService", () => {
       json: async () => ({ access_token: "token-123", expires_in: 3600 }),
     } as Response);
 
-    const service = new OidcAuthService();
+    const service = new OidcAuthService(fetchMock);
     await service.getAuthorizationHeaderIfConfigured();
 
     expect(fetchMock).toHaveBeenCalledWith(
@@ -122,7 +119,7 @@ describe("OidcAuthService", () => {
       json: async () => ({ access_token: "token-123", expires_in: 3600 }),
     } as Response);
 
-    const service = new OidcAuthService();
+    const service = new OidcAuthService(fetchMock);
     const first = await service.getAuthorizationHeaderIfConfigured();
     const second = await service.getAuthorizationHeaderIfConfigured();
 
@@ -149,7 +146,7 @@ describe("OidcAuthService", () => {
         json: async () => ({ access_token: "second-token", expires_in: 60 }),
       } as Response);
 
-    const service = new OidcAuthService();
+    const service = new OidcAuthService(fetchMock);
     await service.getAuthorizationHeaderIfConfigured();
 
     nowSpy.mockReturnValue(2_000_000);
@@ -170,7 +167,7 @@ describe("OidcAuthService", () => {
       statusText: "Unauthorized",
     } as Response);
 
-    const service = new OidcAuthService();
+    const service = new OidcAuthService(fetchMock);
     await expect(service.getAuthorizationHeaderIfConfigured()).rejects.toThrow(
       "Failed to retrieve OIDC access token from https://id.example/token (401 Unauthorized)"
     );
@@ -186,7 +183,7 @@ describe("OidcAuthService", () => {
     (error as Error & { cause?: Error }).cause = cause;
     fetchMock.mockRejectedValueOnce(error);
 
-    const service = new OidcAuthService();
+    const service = new OidcAuthService(fetchMock);
     await expect(service.getAuthorizationHeaderIfConfigured()).rejects.toThrow(
       "Failed to retrieve OIDC access token from https://id.example/token: fetch failed | cause: connect ECONNREFUSED 127.0.0.1:8443"
     );
@@ -199,7 +196,7 @@ describe("OidcAuthService", () => {
 
     fetchMock.mockRejectedValueOnce(new Error("fetch failed"));
 
-    const service = new OidcAuthService();
+    const service = new OidcAuthService(fetchMock);
     await expect(service.getAuthorizationHeaderIfConfigured()).rejects.toThrow(
       "Failed to retrieve OIDC access token from https://id.example/token: fetch failed"
     );

--- a/src/app/api/discovery/harvester/dcat-harvester-service.ts
+++ b/src/app/api/discovery/harvester/dcat-harvester-service.ts
@@ -12,7 +12,10 @@ import {
   formatErrorDetails,
   wrapError,
 } from "@/app/api/discovery/harvester/error-utils";
-import { buildHarvestRequestInit } from "@/app/api/discovery/harvester/fetch-options";
+import {
+  buildHarvestRequestInit,
+  harvestFetch,
+} from "@/app/api/discovery/harvester/fetch-options";
 import { parseRdfXmlToQuads } from "@/app/api/discovery/harvester/rdf-quad-loader";
 import { RdfGraph } from "@/app/api/discovery/harvester/rdf-graph";
 
@@ -24,7 +27,7 @@ type HarvestOptions = {
 export class DcatHarvesterService {
   private readonly fetcher: FetchLike;
 
-  constructor(fetcher: FetchLike = fetch) {
+  constructor(fetcher: FetchLike = harvestFetch) {
     this.fetcher = fetcher;
   }
 

--- a/src/app/api/discovery/harvester/fetch-options.ts
+++ b/src/app/api/discovery/harvester/fetch-options.ts
@@ -2,7 +2,7 @@
 //
 // SPDX-License-Identifier: Apache-2.0
 
-import { Agent, Dispatcher } from "undici";
+import { Agent, Dispatcher, fetch as undiciFetch } from "undici";
 
 const harvestDispatcher = new Agent({
   connect: { rejectUnauthorized: false },
@@ -11,6 +11,13 @@ const harvestDispatcher = new Agent({
 type HarvestRequestInit = RequestInit & {
   dispatcher?: Dispatcher;
 };
+
+export type HarvestFetchLike = (
+  input: string | URL,
+  init?: RequestInit
+) => Promise<Response>;
+
+export const harvestFetch = undiciFetch as unknown as HarvestFetchLike;
 
 export const buildHarvestRequestInit = (
   init: RequestInit = {}

--- a/src/app/api/discovery/harvester/oidc-auth.service.ts
+++ b/src/app/api/discovery/harvester/oidc-auth.service.ts
@@ -6,7 +6,11 @@ import {
   formatErrorDetails,
   wrapError,
 } from "@/app/api/discovery/harvester/error-utils";
-import { buildHarvestRequestInit } from "@/app/api/discovery/harvester/fetch-options";
+import {
+  buildHarvestRequestInit,
+  HarvestFetchLike,
+  harvestFetch,
+} from "@/app/api/discovery/harvester/fetch-options";
 
 type OidcTokenResponse = {
   access_token: string;
@@ -17,6 +21,8 @@ type OidcTokenResponse = {
 export class OidcAuthService {
   private accessToken: string | null = null;
   private tokenExpiryEpochMs: number | null = null;
+
+  constructor(private readonly fetcher: HarvestFetchLike = harvestFetch) {}
 
   private get config() {
     return {
@@ -57,7 +63,7 @@ export class OidcAuthService {
 
     let response: Response;
     try {
-      response = await fetch(
+      response = await this.fetcher(
         tokenUrl,
         buildHarvestRequestInit({
           method: "POST",


### PR DESCRIPTION
## Summary by Sourcery

Use a dedicated Undici-based fetch helper for harvest-related HTTP requests and inject it into harvesting services.

Bug Fixes:
- Ensure harvest HTTP requests consistently use Undici fetch with the harvest dispatcher instead of relying on the global fetch implementation.

Enhancements:
- Inject a configurable fetch implementation into OidcAuthService and default it to the shared harvest fetch helper.
- Update DcatHarvesterService to use the shared harvest fetch helper by default for outbound requests.
- Introduce a typed HarvestFetchLike abstraction and a reusable harvestFetch wrapper around Undici fetch.

Tests:
- Refactor OidcAuthService tests to inject a mocked fetch implementation instead of stubbing the global fetch.