### PR TITLE
feat(discovery): enhance dataset series support in API and UI

### DIFF
--- a/src/app/api/discovery/open-api/discovery.yml
+++ b/src/app/api/discovery/open-api/discovery.yml
@@ -395,6 +395,9 @@ components:
         inSeriesCount:
           type: integer
           title: Dataset series count
+        isSeries:
+          type: boolean
+          title: Whether this result is a dataset series
       required:
         - id
         - title
@@ -429,6 +432,9 @@ components:
         title:
           type: string
           title: Title
+        isSeries:
+          type: boolean
+          title: Whether this record is a dataset series
         description:
           type: string
           title: Description

--- a/src/app/datasets/DatasetCard.tsx
+++ b/src/app/datasets/DatasetCard.tsx
@@ -61,6 +61,7 @@ function DatasetCard({
     const isConformsToEmpty = !conformsTo?.length;
     const shouldFetch =
       dataset.id &&
+      !dataset.isSeries &&
       !hasFetchedRef.current &&
       (isConformsToEmpty ||
         (isExternal && !distributions?.some((d) => d.accessUrl)));
@@ -77,7 +78,13 @@ function DatasetCard({
           hasFetchedRef.current = false;
         });
     }
-  }, [dataset.id, isExternal, distributions, conformsTo?.length]);
+  }, [
+    dataset.id,
+    dataset.isSeries,
+    isExternal,
+    distributions,
+    conformsTo?.length,
+  ]);
 
   const isInBasket = basket.some((ds) => ds.id === dataset.id);
   const externalAccessUrl = getFirstAccessUrl(distributions);
@@ -90,58 +97,59 @@ function DatasetCard({
   const hasIdentifier = !!dataset.identifier;
   const buttonDisabled = isLoading || !hasIdentifier;
 
-  const buttonElement = !displayBasketButton ? undefined : isExternal ? (
-    <div onClick={(e) => e.stopPropagation()}>
-      {externalAccessUrl ? (
-        <ExternalDatasetConfirmationDialog url={externalAccessUrl}>
-          {({ onClick }) => (
-            <button
-              onClick={(e) => {
-                e.preventDefault();
-                e.stopPropagation();
-                onClick(e);
-              }}
-              className="text-xs sm:text-base text-primary hover:text-info underline hover:no-underline font-semibold transition-colors duration-200 cursor-pointer shrink-0 inline-flex items-center gap-1"
-            >
-              <span>Access external dataset</span>
-              <FontAwesomeIcon icon={faArrowRight} className="text-xs" />
-            </button>
-          )}
-        </ExternalDatasetConfirmationDialog>
-      ) : (
-        <button
-          disabled
-          onClick={(e) => {
+  const buttonElement =
+    !displayBasketButton || dataset.isSeries ? undefined : isExternal ? (
+      <div onClick={(e) => e.stopPropagation()}>
+        {externalAccessUrl ? (
+          <ExternalDatasetConfirmationDialog url={externalAccessUrl}>
+            {({ onClick }) => (
+              <button
+                onClick={(e) => {
+                  e.preventDefault();
+                  e.stopPropagation();
+                  onClick(e);
+                }}
+                className="text-xs sm:text-base text-primary hover:text-info underline hover:no-underline font-semibold transition-colors duration-200 cursor-pointer shrink-0 inline-flex items-center gap-1"
+              >
+                <span>Access external dataset</span>
+                <FontAwesomeIcon icon={faArrowRight} className="text-xs" />
+              </button>
+            )}
+          </ExternalDatasetConfirmationDialog>
+        ) : (
+          <button
+            disabled
+            onClick={(e) => {
+              e.preventDefault();
+              e.stopPropagation();
+            }}
+            className="text-xs sm:text-base text-gray-400 cursor-not-allowed inline-flex items-center gap-1"
+          >
+            <span>External link not available</span>
+            <FontAwesomeIcon icon={faArrowRight} className="text-xs" />
+          </button>
+        )}
+      </div>
+    ) : (
+      <button
+        onClick={(e: React.MouseEvent<HTMLButtonElement>) => {
+          if (buttonDisabled) {
             e.preventDefault();
             e.stopPropagation();
-          }}
-          className="text-xs sm:text-base text-gray-400 cursor-not-allowed inline-flex items-center gap-1"
-        >
-          <span>External link not available</span>
-          <FontAwesomeIcon icon={faArrowRight} className="text-xs" />
-        </button>
-      )}
-    </div>
-  ) : (
-    <button
-      onClick={(e: React.MouseEvent<HTMLButtonElement>) => {
-        if (buttonDisabled) {
-          e.preventDefault();
-          e.stopPropagation();
-          return;
-        }
-        toggleDatasetInBasket(e);
-      }}
-      disabled={buttonDisabled}
-      className={`text-xs sm:text-base rounded-md px-4 py-2 font-bold transition-colors duration-200 tracking-wide cursor-pointer shrink-0 ${buttonDisabled ? "opacity-60 cursor-not-allowed" : ""} ${isInBasket ? "bg-warning text-black hover:bg-secondary hover:text-white" : "bg-primary text-white hover:bg-secondary"}`}
-    >
-      <FontAwesomeIcon
-        icon={isInBasket ? faMinusCircle : faPlusCircle}
-        className="mr-2"
-      />
-      <span>{isInBasket ? "Remove from basket" : "Add to basket"}</span>
-    </button>
-  );
+            return;
+          }
+          toggleDatasetInBasket(e);
+        }}
+        disabled={buttonDisabled}
+        className={`text-xs sm:text-base rounded-md px-4 py-2 font-bold transition-colors duration-200 tracking-wide cursor-pointer shrink-0 ${buttonDisabled ? "opacity-60 cursor-not-allowed" : ""} ${isInBasket ? "bg-warning text-black hover:bg-secondary hover:text-white" : "bg-primary text-white hover:bg-secondary"}`}
+      >
+        <FontAwesomeIcon
+          icon={isInBasket ? faMinusCircle : faPlusCircle}
+          className="mr-2"
+        />
+        <span>{isInBasket ? "Remove from basket" : "Add to basket"}</span>
+      </button>
+    );
 
   const subTitles = useMemo(
     () =>
@@ -155,6 +163,7 @@ function DatasetCard({
     () => dataset.keywords?.filter((kw): kw is string => !!kw),
     [dataset.keywords]
   );
+  const entityLabel = dataset.isSeries ? "Dataset series" : undefined;
 
   return (
     <Card
@@ -168,6 +177,7 @@ function DatasetCard({
       button={buttonElement}
       isExternal={isExternal}
       externalLabel={externalLabel}
+      entityLabel={entityLabel}
     />
   );
 }

--- a/src/app/datasets/[id]/DatasetMetadata.tsx
+++ b/src/app/datasets/[id]/DatasetMetadata.tsx
@@ -42,6 +42,7 @@ import {
   DatasetDictionaryEntry,
   DatasetRelationEntry,
   RetrievedDataset,
+  SearchedDataset,
   ValueLabel,
 } from "@/app/api/discovery/open-api/schemas";
 
@@ -124,10 +125,12 @@ const DatasetMetadata = ({
   dataset,
   relationships,
   dictionary,
+  seriesMembers = [],
 }: {
   dataset: ExtendedRetrievedDataset;
   relationships: DatasetRelationEntry[];
   dictionary: DatasetDictionaryEntry[];
+  seriesMembers?: SearchedDataset[];
 }) => {
   const [userTimezone, setUserTimezone] = useState<string | null>(null);
   const temporalCoverage = Array.isArray(dataset.temporalCoverage)
@@ -151,6 +154,192 @@ const DatasetMetadata = ({
 
   if (userTimezone === null) {
     return null;
+  }
+
+  if (dataset.isSeries) {
+    return (
+      <>
+        <div className="flex flex-col sm:flex-row sm:flex-wrap gap-3 font-normal text-gray">
+          {dataset.createdAt && (
+            <span className="flex gap-2 items-center relative group">
+              <FontAwesomeIcon
+                icon={faCalendarAlt}
+                className="align-middle text-primary"
+              />
+              <span className="align-middle">
+                Created on {formatDate(dataset.createdAt)}
+              </span>
+              <Tooltip message="Date when this dataset series was created." />
+            </span>
+          )}
+          {dataset.createdAt && dataset.modifiedAt && (
+            <div className="text-lightaccent hidden sm:inline-block">|</div>
+          )}
+          {dataset.modifiedAt && (
+            <span className="flex gap-2 items-center relative group">
+              <FontAwesomeIcon
+                icon={faSyncAlt}
+                className="align-middle text-primary"
+              />
+              <span className="align-middle">
+                Modified on {formatDate(dataset.modifiedAt)}
+              </span>
+              <Tooltip message="Date when this dataset series was last modified." />
+            </span>
+          )}
+          {dataset.identifier && (
+            <>
+              <div className="text-lightaccent hidden sm:inline-block">|</div>
+              <span className="flex gap-2 items-center relative group">
+                <FontAwesomeIcon
+                  icon={faIdBadge}
+                  className="align-middle text-primary"
+                />
+                <span className="align-middle">
+                  Identifier: {dataset.identifier}
+                </span>
+                <Tooltip message="Unique identifier for this dataset series." />
+              </span>
+            </>
+          )}
+        </div>
+
+        <MetadataSection title="Series Overview" icon={faLayerGroup}>
+          <div className="flex flex-col gap-3 text-sm">
+            <MetadataField
+              label="Update Frequency"
+              icon={faSyncAlt}
+              tooltip="How often this series is updated."
+            >
+              {dataset.frequency?.label || <NotProvided />}
+            </MetadataField>
+            <MetadataField
+              label="Access Rights"
+              icon={faTag}
+              tooltip="Access policy applied to this series."
+            >
+              {dataset.accessRights?.label || <NotProvided />}
+            </MetadataField>
+            <div className="flex flex-wrap gap-2 items-center relative group">
+              <span className="font-medium shrink-0">Conforms To:</span>
+              {dataset.conformsTo && dataset.conformsTo.length > 0 ? (
+                <Chips
+                  chips={dataset.conformsTo.map((item) => item.label)}
+                  className="bg-primary/10 text-primary rounded-full py-1"
+                />
+              ) : (
+                <NotProvided />
+              )}
+              <Tooltip message="Standards followed by this dataset series." />
+            </div>
+            <div className="flex items-center gap-2 flex-wrap relative group">
+              <span className="font-medium shrink-0">URI:</span>
+              {dataset.uri ? (
+                <a
+                  href={dataset.uri}
+                  target="_blank"
+                  rel="noopener noreferrer"
+                  className="text-info hover:text-hover-color hover:underline break-all"
+                >
+                  {dataset.uri}
+                </a>
+              ) : (
+                <NotProvided />
+              )}
+              <Tooltip message="Canonical URI of this dataset series." />
+            </div>
+          </div>
+        </MetadataSection>
+
+        <MetadataSection title="Coverage" icon={faGlobe}>
+          <div className="flex flex-col gap-3 text-sm">
+            <div className="flex flex-wrap gap-2 items-center relative group">
+              <span className="font-medium shrink-0">Spatial Coverage:</span>
+              {dataset.spatialCoverage && dataset.spatialCoverage.length > 0 ? (
+                <Chips
+                  chips={dataset.spatialCoverage.map(
+                    (coverage) =>
+                      coverage.text || coverage.uri?.label || "Unknown"
+                  )}
+                  className="bg-primary/10 text-primary rounded-full py-1"
+                />
+              ) : (
+                <NotProvided />
+              )}
+              <Tooltip message="Geographic area covered by this series." />
+            </div>
+            <MetadataField
+              label="Temporal Coverage"
+              tooltip="Time window covered by this series."
+            >
+              {temporalCoverage &&
+              (temporalCoverage.start || temporalCoverage.end) ? (
+                <>
+                  {temporalCoverage.start
+                    ? formatDate(temporalCoverage.start)
+                    : "N/A"}{" "}
+                  -{" "}
+                  {temporalCoverage.end
+                    ? formatDate(temporalCoverage.end)
+                    : "Present"}
+                </>
+              ) : (
+                <NotProvided />
+              )}
+            </MetadataField>
+          </div>
+        </MetadataSection>
+
+        <MetadataSection title="Legal & Compliance" icon={faGavel}>
+          <div className="flex flex-col gap-3 text-sm">
+            <div className="flex flex-wrap gap-2 items-center relative group">
+              <span className="font-medium shrink-0">
+                Applicable Legislation:
+              </span>
+              {dataset.applicableLegislation &&
+              dataset.applicableLegislation.length > 0 ? (
+                <Chips
+                  chips={dataset.applicableLegislation.map(
+                    (item) => item.label
+                  )}
+                  className="bg-primary/10 text-primary rounded-full py-1"
+                />
+              ) : (
+                <NotProvided />
+              )}
+              <Tooltip message="Legislation applicable to this dataset series." />
+            </div>
+          </div>
+        </MetadataSection>
+
+        <MetadataSection title="Member Datasets" icon={faDatabase}>
+          <div className="flex flex-col gap-3 text-sm">
+            {seriesMembers.length > 0 ? (
+              seriesMembers.map((member) => (
+                <div
+                  key={member.id}
+                  className="border-b border-primary/20 pb-2 last:border-b-0"
+                >
+                  <Link
+                    href={`/datasets/${member.id}`}
+                    className="text-info hover:text-hover-color hover:underline font-medium"
+                  >
+                    {member.title}
+                  </Link>
+                  {member.description && (
+                    <p className="mt-1 text-xs text-gray">
+                      {member.description}
+                    </p>
+                  )}
+                </div>
+              ))
+            ) : (
+              <span className="text-primary">No member datasets found.</span>
+            )}
+          </div>
+        </MetadataSection>
+      </>
+    );
   }
 
   return (

--- a/src/app/datasets/[id]/page.tsx
+++ b/src/app/datasets/[id]/page.tsx
@@ -13,7 +13,8 @@ import { FontAwesomeIcon } from "@fortawesome/react-fontawesome";
 import DatasetMetadata from "./DatasetMetadata";
 import Tooltip from "./Tooltip";
 import { createDatasetSidebarItems } from "./sidebarItems";
-import { retrieveDatasetApi } from "../../api/discovery";
+import { retrieveDatasetApi, searchDatasetsApi } from "../../api/discovery";
+import { SearchedDataset } from "../../api/discovery/open-api/schemas";
 import { UrlParams, UrlSearchParams } from "@/app/params";
 
 type DatasetDetailsPageProps = {
@@ -34,6 +35,34 @@ export default async function Page({
 
   try {
     const dataset = await retrieveDatasetApi(_params.id);
+    let seriesMembers: SearchedDataset[] = [];
+
+    if (dataset.isSeries && dataset.title) {
+      try {
+        const membersResponse = await searchDatasetsApi({
+          facets: [
+            {
+              source: "ckan",
+              type: "FREE_TEXT",
+              key: "vocab_in_series_title",
+              value: dataset.title,
+            },
+          ],
+          rows: 100,
+          start: 0,
+          includeBeacon: false,
+        });
+
+        seriesMembers = (membersResponse.results || []).filter(
+          (member) => member.id !== dataset.id
+        );
+      } catch (seriesMembersError) {
+        console.error(
+          "Failed to load dataset series members",
+          seriesMembersError
+        );
+      }
+    }
 
     const relationships = dataset.datasetRelationships || [];
 
@@ -49,23 +78,33 @@ export default async function Page({
               <PageHeading className="text-black">{dataset.title}</PageHeading>
 
               <ul className="flex gap-x-3 gap-y-2 flex-wrap">
-                {dataset.themes
-                  ?.filter(
-                    (theme): theme is typeof theme & { label: string } =>
-                      !!theme.label
-                  )
-                  .map((theme) => (
-                    <li
-                      key={theme.label}
-                      className="tracking-widest uppercase flex items-center relative group"
-                    >
-                      <Chip
-                        className="flex justify-center items-center w-24 md:w-32 h-12 text-[10px] md:text-xs text-center px-1 md:px-2"
-                        chip={theme.label}
-                      />
-                      <Tooltip message="Theme associated with the dataset." />
-                    </li>
-                  ))}
+                {dataset.isSeries && (
+                  <li className="tracking-widest uppercase flex items-center relative group">
+                    <Chip
+                      className="flex justify-center items-center w-24 md:w-32 h-12 text-[10px] md:text-xs text-center px-1 md:px-2"
+                      chip="Dataset series"
+                    />
+                    <Tooltip message="This page describes a dataset series." />
+                  </li>
+                )}
+                {!dataset.isSeries &&
+                  dataset.themes
+                    ?.filter(
+                      (theme): theme is typeof theme & { label: string } =>
+                        !!theme.label
+                    )
+                    .map((theme) => (
+                      <li
+                        key={theme.label}
+                        className="tracking-widest uppercase flex items-center relative group"
+                      >
+                        <Chip
+                          className="flex justify-center items-center w-24 md:w-32 h-12 text-[10px] md:text-xs text-center px-1 md:px-2"
+                          chip={theme.label}
+                        />
+                        <Tooltip message="Theme associated with the dataset." />
+                      </li>
+                    ))}
               </ul>
             </div>
 
@@ -96,7 +135,7 @@ export default async function Page({
               <div className="flex items-center gap-2 text-sm text-gray-500 italic">
                 <FontAwesomeIcon
                   icon={faCircleInfo}
-                  className="w-4 h-4 flex-shrink-0"
+                  className="w-4 h-4 shrink-0"
                 />
                 <span>Conforms to: Not specified for this dataset</span>
               </div>
@@ -119,6 +158,7 @@ export default async function Page({
                 dataset={dataset}
                 relationships={relationships}
                 dictionary={dictionary}
+                seriesMembers={seriesMembers}
               />
             </div>
           </div>

--- a/src/app/datasets/[id]/sidebarItems.tsx
+++ b/src/app/datasets/[id]/sidebarItems.tsx
@@ -66,7 +66,7 @@ function createDatasetSidebarItems(dataset: RetrievedDataset): SidebarItem[] {
           }}
         />
       ),
-      hideItem: false,
+      hideItem: !!dataset.isSeries,
     },
     {
       label: "Export Metadata in",

--- a/src/components/Card.tsx
+++ b/src/components/Card.tsx
@@ -27,6 +27,7 @@ type CardProps = {
   externalUrl?: string;
   isExternal?: boolean;
   externalLabel?: string;
+  entityLabel?: string;
 };
 
 export default function Card({
@@ -40,6 +41,7 @@ export default function Card({
   externalUrl,
   isExternal: isExternalProp,
   externalLabel,
+  entityLabel,
 }: CardProps) {
   const isExternal = isExternalProp ?? !!externalUrl;
   return (
@@ -55,9 +57,7 @@ export default function Card({
                 <span
                   key={subTitle}
                   className={
-                    index
-                      ? "sm:border-l-[2px] sm:pl-2 sm:border-l-info"
-                      : undefined
+                    index ? "sm:border-l-2 sm:pl-2 sm:border-l-info" : undefined
                   }
                 >
                   {subTitle}
@@ -70,17 +70,26 @@ export default function Card({
             {title}
           </div>
 
-          {isExternal && externalLabel ? (
-            <div className="inline-block w-fit">
-              <span className="text-xs font-semibold px-3 py-1 rounded-full bg-info/10 text-info border border-info/20">
-                {externalLabel}
-              </span>
+          {(entityLabel || (isExternal && externalLabel)) && (
+            <div className="inline-flex w-fit flex-wrap items-center gap-2">
+              {entityLabel && (
+                <span className="text-xs font-semibold px-3 py-1 rounded-full bg-secondary/10 text-secondary border border-secondary/20">
+                  {entityLabel}
+                </span>
+              )}
+              {isExternal && externalLabel && (
+                <span className="text-xs font-semibold px-3 py-1 rounded-full bg-info/10 text-info border border-info/20">
+                  {externalLabel}
+                </span>
+              )}
             </div>
-          ) : isExternal && !externalLabel ? (
+          )}
+
+          {isExternal && !externalLabel ? (
             <div className="flex items-center gap-2 text-xs text-gray-500 italic">
               <FontAwesomeIcon
                 icon={faCircleInfo}
-                className="w-3 h-3 flex-shrink-0"
+                className="w-3 h-3 shrink-0"
               />
               <span>Conforms to: Not specified for this dataset</span>
             </div>

--- a/tests/dataset-detail.spec.ts
+++ b/tests/dataset-detail.spec.ts
@@ -68,6 +68,17 @@ test("Dataset detail renders metadata and distributions", async ({ page }) => {
   await expect(
     page.getByRole("heading", { name: /synthetic cohort series/i })
   ).toBeVisible();
+  await expect(page.getByText(/dataset series/i).first()).toBeVisible();
+  await expect(
+    page.getByRole("heading", { name: /member datasets/i })
+  ).toBeVisible();
+  await expect(
+    page.getByRole("link", { name: /cancer cohort study/i })
+  ).toBeVisible();
+  await expect(
+    page.getByRole("heading", { name: /health information/i })
+  ).toHaveCount(0);
+  await expect(page.getByText(/add to basket/i)).toHaveCount(0);
   await page.goBack();
   await expect(
     page.getByRole("heading", { name: /cancer cohort study/i })

--- a/tests/datasets.spec.ts
+++ b/tests/datasets.spec.ts
@@ -60,6 +60,11 @@ test("Dataset list renders filters and results", async ({ page }) => {
   await expect(
     page.getByRole("link", { name: /cancer cohort study/i })
   ).toBeVisible();
+  const seriesCard = page.getByRole("link", {
+    name: /pan-cancer longitudinal series/i,
+  });
+  await expect(seriesCard).toBeVisible();
+  await expect(seriesCard.getByText(/dataset series/i)).toBeVisible();
   await expect(page.getByText(/1 dataset series/i)).toBeVisible();
   await expect(page.getByText(/externally governed/i)).toBeVisible();
 

--- a/tests/fixtures/mockApi.ts
+++ b/tests/fixtures/mockApi.ts
@@ -40,6 +40,46 @@ const setupMockApiRoutes = async (page: Page) => {
       await route.fallback();
       return;
     }
+
+    const requestBody = route.request().postDataJSON() as
+      | { facets?: Array<{ key?: string; value?: string }> }
+      | undefined;
+    const seriesFacet = requestBody?.facets?.find(
+      (facet) => facet.key === "vocab_in_series_title" && facet.value
+    );
+
+    if (seriesFacet?.value) {
+      const datasetDetails = Object.values(datasetDetailsById) as Array<{
+        id: string;
+        isSeries?: boolean;
+        inSeries?: Array<{ title?: string }>;
+      }>;
+
+      const memberIds = new Set(
+        datasetDetails
+          .filter((dataset) => !dataset.isSeries)
+          .filter((dataset) =>
+            Array.isArray(dataset.inSeries)
+              ? dataset.inSeries.some(
+                  (series) => series?.title === seriesFacet.value
+                )
+              : false
+          )
+          .map((dataset) => dataset.id)
+      );
+
+      const results = mockData.datasetSearchResponse.results.filter((dataset) =>
+        memberIds.has(dataset.id)
+      );
+
+      await fulfillJson(route, {
+        ...mockData.datasetSearchResponse,
+        count: results.length,
+        results,
+      });
+      return;
+    }
+
     await fulfillJson(route, mockData.datasetSearchResponse);
   });
 

--- a/tests/mocks/discovery.json
+++ b/tests/mocks/discovery.json
@@ -275,6 +275,25 @@
           }
         ],
         "keywords": ["pharmacogenomics", "variants"]
+      },
+      {
+        "id": "series-010",
+        "title": "Pan-Cancer Longitudinal Series",
+        "description": "A longitudinal dataset series for pan-cancer studies.",
+        "createdAt": "2023-01-10T09:00:00Z",
+        "modifiedAt": "2024-02-20T10:30:00Z",
+        "identifier": "series-010",
+        "isSeries": true,
+        "distributionsCount": 0,
+        "inSeriesCount": 0,
+        "recordsCount": 0,
+        "themes": [
+          {
+            "value": "oncology",
+            "label": "Oncology"
+          }
+        ],
+        "keywords": ["series", "longitudinal", "pan-cancer"]
       }
     ]
   },
@@ -615,6 +634,91 @@
       ],
       "distributions": []
     },
+    "series-010": {
+      "id": "series-010",
+      "title": "Pan-Cancer Longitudinal Series",
+      "description": "A longitudinal dataset series for pan-cancer studies.",
+      "createdAt": "2023-01-10T09:00:00Z",
+      "modifiedAt": "2024-02-20T10:30:00Z",
+      "identifier": "series-010",
+      "isSeries": true,
+      "themes": [
+        {
+          "value": "oncology",
+          "label": "Oncology"
+        },
+        {
+          "value": "genomics",
+          "label": "Genomics"
+        }
+      ],
+      "keywords": ["series", "longitudinal", "pan-cancer"],
+      "conformsTo": [
+        {
+          "value": "http://example.org/schema/gdi-core",
+          "label": "GDI Core"
+        }
+      ],
+      "languages": [
+        {
+          "value": "en",
+          "label": "English"
+        }
+      ],
+      "publishers": [
+        {
+          "name": "GDI Oncology Institute",
+          "identifier": "publisher-series-010",
+          "email": "series-owner@example.org",
+          "url": "https://example.org/publishers/oncology-institute"
+        }
+      ],
+      "contacts": [
+        {
+          "name": "Series Coordination Desk",
+          "email": "series-desk@example.org",
+          "url": ["https://example.org/contact/series-desk"],
+          "identifier": "contact-series-010"
+        }
+      ],
+      "accessRights": {
+        "value": "restricted",
+        "label": "Restricted"
+      },
+      "dcatType": {
+        "value": "dataset_series",
+        "label": "Dataset series"
+      },
+      "frequency": {
+        "value": "monthly",
+        "label": "Monthly"
+      },
+      "temporalCoverage": [
+        {
+          "start": "2019-01-01T00:00:00Z",
+          "end": "2024-12-31T00:00:00Z"
+        }
+      ],
+      "spatialCoverage": [
+        {
+          "text": "European Union",
+          "uri": {
+            "value": "eu",
+            "label": "European Union"
+          }
+        }
+      ],
+      "applicableLegislation": [
+        {
+          "value": "data-act",
+          "label": "Data Act"
+        }
+      ],
+      "documentation": ["https://example.org/docs/series-010"],
+      "homepage": "https://example.org/series/series-010",
+      "uri": "https://example.org/resource/series-010",
+      "distributions": []
+    },
     "series-001": {
       "id": "series-001",
       "title": "Synthetic Cohort Series",
@@ -622,6 +726,7 @@
       "createdAt": "2023-01-01T00:00:00Z",
       "modifiedAt": "2024-01-15T00:00:00Z",
       "identifier": "series-001",
+      "isSeries": true,
       "publishers": [
         {
           "name": "GDI Oncology Institute"


### PR DESCRIPTION
- Added `isSeries` boolean property to dataset schema in OpenAPI definition.
- Updated DatasetCard component to conditionally render elements based on `isSeries`.
- Enhanced DatasetMetadata to display series-specific information and member datasets.
- Modified page and sidebar items to accommodate dataset series logic.
- Updated tests to verify the new dataset series functionality and visibility in the UI.

## Summary by Sourcery

Add first-class support for dataset series across the discovery API schema and UI, including series-specific detail views and listing labels.

New Features:
- Expose an isSeries flag on searched and retrieved datasets in the discovery OpenAPI schema to identify dataset series.
- Display dataset series as a distinct entity type in dataset cards and detail pages, including a dedicated Series Overview and Member Datasets sections.
- Load and show member datasets for a dataset series by querying the search API with a series title facet.

Enhancements:
- Hide basket actions and external access handling for dataset series cards and detail views, reflecting that series are not directly addable to the basket.
- Adjust dataset detail themes and sidebar sections so that dataset series show a series badge instead of themes and hide the distributions section.
- Extend the shared Card component to support a generic entity label badge alongside existing external dataset badges.

Tests:
- Expand dataset list and detail Playwright tests and mock API responses to cover dataset series labelling, member dataset discovery, and basket visibility behaviour.