### PR TITLE
fix(harvest): limit tls dispatcher to https requests

### DIFF
--- a/scripts/__tests__/harvest-worker.test.js
+++ b/scripts/__tests__/harvest-worker.test.js
@@ -77,6 +77,7 @@ describe("harvest-worker", () => {
         body: JSON.stringify({ url: "https://example.org/catalogue.rdf" }),
       })
     );
+    expect(fetchImpl.mock.calls[0][1].dispatcher).toBeUndefined();
   });
 
   test("triggerHarvest adds the harvest TLS dispatcher", async () => {

--- a/scripts/harvest-http.js
+++ b/scripts/harvest-http.js
@@ -9,6 +9,10 @@ const harvestDispatcher = new Agent({
   connect: { rejectUnauthorized: false },
 });
 
+function usesHttps(url) {
+  return String(url).trim().toLowerCase().startsWith("https://");
+}
+
 function buildHarvestApiUrl(baseUrl) {
   return `${String(baseUrl).replace(/\/+$/, "")}/api/discovery/harvest`;
 }
@@ -86,7 +90,7 @@ async function requestHarvest(
       },
       body: JSON.stringify({ url: sourceUrl }),
       signal: timeoutController.signal,
-      dispatcher: harvestDispatcher,
+      ...(usesHttps(apiUrl) ? { dispatcher: harvestDispatcher } : {}),
     });
   } catch (error) {
     throw new Error(

--- a/src/app/api/discovery/harvester/dcat-harvester-service.ts
+++ b/src/app/api/discovery/harvester/dcat-harvester-service.ts
@@ -55,7 +55,7 @@ export class DcatHarvesterService {
     try {
       response = await this.fetcher(
         url,
-        buildHarvestRequestInit({
+        buildHarvestRequestInit(url, {
           headers: options.headers,
         })
       );

--- a/src/app/api/discovery/harvester/fetch-options.ts
+++ b/src/app/api/discovery/harvester/fetch-options.ts
@@ -19,9 +19,16 @@ export type HarvestFetchLike = (
 
 export const harvestFetch = undiciFetch as unknown as HarvestFetchLike;
 
+const usesHttps = (input: string | URL): boolean =>
+  String(input).trim().toLowerCase().startsWith("https://");
+
 export const buildHarvestRequestInit = (
+  input: string | URL,
   init: RequestInit = {}
-): HarvestRequestInit => ({
-  ...init,
-  dispatcher: harvestDispatcher,
-});
+): HarvestRequestInit =>
+  usesHttps(input)
+    ? {
+        ...init,
+        dispatcher: harvestDispatcher,
+      }
+    : { ...init };

--- a/src/app/api/discovery/harvester/oidc-auth.service.ts
+++ b/src/app/api/discovery/harvester/oidc-auth.service.ts
@@ -65,7 +65,7 @@ export class OidcAuthService {
     try {
       response = await this.fetcher(
         tokenUrl,
-        buildHarvestRequestInit({
+        buildHarvestRequestInit(tokenUrl, {
           method: "POST",
           headers: {
             "Content-Type": "application/x-www-form-urlencoded",


### PR DESCRIPTION
This PR limits the custom harvest TLS dispatcher to HTTPS requests only.

Why

The harvest worker calls the frontend harvest endpoint over plain HTTP:

 - http://gdi-userportal-frontend:3000/api/discovery/harvest

We were applying the custom undici dispatcher to all requests, including that internal HTTP call. On Node 24 this caused the worker to fail with:

 - UND_ERR_INVALID_ARG
 - invalid onRequestStart method

The custom dispatcher is only needed for harvest-related HTTPS calls where self-signed certificates may be involved, such as:

 - external DCAT catalogue URLs
 - OIDC token endpoint requests

It should not be attached to plain HTTP requests.

Changes

 - apply the harvest TLS dispatcher only when the target URL starts with https://
 - keep self-signed HTTPS support for harvest source and OIDC fetches
 - keep internal worker -> frontend HTTP calls free of the custom dispatcher
 - update harvest worker coverage to assert no dispatcher is sent for HTTP API calls

## Summary by Sourcery

Limit the harvest TLS dispatcher to HTTPS requests so internal HTTP harvest calls are not affected.

Bug Fixes:
- Prevent harvest worker failures on Node 24 by no longer attaching the custom TLS dispatcher to plain HTTP requests.

Tests:
- Extend harvest worker tests to verify that no dispatcher is used for HTTP API calls while preserving dispatcher usage for HTTPS harvest and OIDC requests.