### PR TITLE
docs: update developer guide platform notes

### DIFF
--- a/documentation/docs/developer-guide/1-get-started/platform-overview.md
+++ b/documentation/docs/developer-guide/1-get-started/platform-overview.md
@@ -56,7 +56,7 @@ For detailed architecture diagrams and component interactions, see: GDI applicat
 - **CKAN**: Open-source data catalogue system
   - PostgreSQL database for metadata storage
   - Solr for full-text search
-  - Custom GDI extensions for DCAT-AP 3 support
+  - Custom GDI extensions make it possible to support DCAT-AP 3 and HealthDCAT
   - Harvester extensions for collecting external datasets
 
 ### Supporting services

--- a/documentation/docs/developer-guide/1-get-started/repository-structure.md
+++ b/documentation/docs/developer-guide/1-get-started/repository-structure.md
@@ -36,13 +36,13 @@ Java/Quarkus microservices for dataset discovery service (DDS) and access manage
 
 Data catalogue management with custom extensions and harvesters.
 
-| Repository name                         | Structure                                                                                                                    |
-| --------------------------------------- | ---------------------------------------------------------------------------------------------------------------------------- |
-| `gdi-userportal-ckan-docker`            | - `/setup`: Startup scripts and configuration<br/>- `/Dockerfile`: Custom CKAN image build                                   |
-| `gdi-userportal-ckanext-gdi-userportal` | - DCAT-AP 3 schema implementation<br/>- OIDC with PKCE authentication support<br/>- Custom API endpoints for DDS integration |
+| Repository name                                                                                           | Structure                                                                                                                    |
+| --------------------------------------------------------------------------------------------------------- | ---------------------------------------------------------------------------------------------------------------------------- |
+| `gdi-userportal-ckan-docker`                                                                              | - `/setup`: Startup scripts and configuration<br/>- `/Dockerfile`: Custom CKAN image build                                   |
+| `gdi-userportal-ckanext-gdi-userportal`                                                                   | - DCAT-AP 3 schema implementation<br/>- OIDC with PKCE authentication support<br/>- Custom API endpoints for DDS integration |
 | [`gdi-userportal-ckanext-dcat`](https://github.com/GenomicDataInfrastructure/gdi-userportal-ckanext-dcat) | - Fork of the official CKAN DCAT extension<br/>- Maps between the DCAT and CKAN models<br/>- Enables dataset series support  |
-| `gdi-userportal-ckanext-fairdatapoint`  | - Harvests metadata from FAIR Data Point instances                                                                           |
-| `gdi-userportal-ckanext-harvest`        | - Fork of official CKAN harvest extension with GDI customisations                                                            |
+| `gdi-userportal-ckanext-fairdatapoint`                                                                    | - Harvests metadata from FAIR Data Point instances                                                                           |
+| `gdi-userportal-ckanext-harvest`                                                                          | - Fork of official CKAN harvest extension with GDI customisations                                                            |
 
 ## Documentation repository
 
@@ -64,16 +64,16 @@ All repositories follow the same Git workflow:
 
 ## Common tasks and repositories
 
-| Task                     | Repository                                 |
-| ------------------------ | ------------------------------------------ |
-| User interface changes   | `gdi-userportal-frontend`                  |
-| Dataset search logic     | `gdi-userportal-dataset-discovery-service` |
-| Access request workflows | `gdi-userportal-access-management-service` |
+| Task                     | Repository                                                                                                |
+| ------------------------ | --------------------------------------------------------------------------------------------------------- |
+| User interface changes   | `gdi-userportal-frontend`                                                                                 |
+| Dataset search logic     | `gdi-userportal-dataset-discovery-service`                                                                |
+| Access request workflows | `gdi-userportal-access-management-service`                                                                |
 | DCAT and CKAN mapping    | [`gdi-userportal-ckanext-dcat`](https://github.com/GenomicDataInfrastructure/gdi-userportal-ckanext-dcat) |
-| Metadata schema changes  | `gdi-userportal-ckanext-gdi-userportal`    |
-| Harvesting from FDP      | `gdi-userportal-ckanext-fairdatapoint`     |
-| CKAN deployment config   | `gdi-userportal-ckan-docker`               |
-| Documentation            | `gdi-userportal-frontend/documentation`    |
+| Metadata schema changes  | `gdi-userportal-ckanext-gdi-userportal`                                                                   |
+| Harvesting from FDP      | `gdi-userportal-ckanext-fairdatapoint`                                                                    |
+| CKAN deployment config   | `gdi-userportal-ckan-docker`                                                                              |
+| Documentation            | `gdi-userportal-frontend/documentation`                                                                   |
 
 <br/>
 

--- a/documentation/docs/developer-guide/1-get-started/repository-structure.md
+++ b/documentation/docs/developer-guide/1-get-started/repository-structure.md
@@ -40,6 +40,7 @@ Data catalogue management with custom extensions and harvesters.
 | --------------------------------------- | ---------------------------------------------------------------------------------------------------------------------------- |
 | `gdi-userportal-ckan-docker`            | - `/setup`: Startup scripts and configuration<br/>- `/Dockerfile`: Custom CKAN image build                                   |
 | `gdi-userportal-ckanext-gdi-userportal` | - DCAT-AP 3 schema implementation<br/>- OIDC with PKCE authentication support<br/>- Custom API endpoints for DDS integration |
+| [`gdi-userportal-ckanext-dcat`](https://github.com/GenomicDataInfrastructure/gdi-userportal-ckanext-dcat) | - Fork of the official CKAN DCAT extension<br/>- Maps between the DCAT and CKAN models<br/>- Enables dataset series support  |
 | `gdi-userportal-ckanext-fairdatapoint`  | - Harvests metadata from FAIR Data Point instances                                                                           |
 | `gdi-userportal-ckanext-harvest`        | - Fork of official CKAN harvest extension with GDI customisations                                                            |
 
@@ -68,6 +69,7 @@ All repositories follow the same Git workflow:
 | User interface changes   | `gdi-userportal-frontend`                  |
 | Dataset search logic     | `gdi-userportal-dataset-discovery-service` |
 | Access request workflows | `gdi-userportal-access-management-service` |
+| DCAT and CKAN mapping    | [`gdi-userportal-ckanext-dcat`](https://github.com/GenomicDataInfrastructure/gdi-userportal-ckanext-dcat) |
 | Metadata schema changes  | `gdi-userportal-ckanext-gdi-userportal`    |
 | Harvesting from FDP      | `gdi-userportal-ckanext-fairdatapoint`     |
 | CKAN deployment config   | `gdi-userportal-ckan-docker`               |

--- a/documentation/docs/developer-guide/2-set-up-your-environment/2-set-up-backend-services.md
+++ b/documentation/docs/developer-guide/2-set-up-your-environment/2-set-up-backend-services.md
@@ -19,7 +19,7 @@ Set up the Java/Quarkus backend services (Dataset Discovery Service and Access M
 
 - Java Development Kit (JDK) 17 or 21
 - Maven 3.8+
-- Docker (for running PostgreSQL and other dependencies)
+- Docker (optional, for running local integration dependencies)
 - Git
 
 ## Clone the repository
@@ -63,11 +63,6 @@ mvnw.cmd clean install
 Create an `application.properties` file in `src/main/resources/`:
 
 ```properties
-# Database configuration
-quarkus.datasource.jdbc.url=jdbc:postgresql://localhost:5432/gdi
-quarkus.datasource.username=gdi_user
-quarkus.datasource.password=gdi_pass
-
 # CKAN integration (for DDS)
 ckan.api.url=http://localhost:5000/api/3
 
@@ -86,25 +81,11 @@ quarkus.log.level=INFO
 quarkus.log.category."io.github.genomicdatainfrastructure".level=DEBUG
 ```
 
-## Start dependencies with Docker
+## Start integration dependencies
 
-Both services require PostgreSQL. Use Docker Compose:
+DDS and AMS are intermediate services and do not require their own PostgreSQL database connection. For local development, start only the services your target backend integrates with, such as CKAN for DDS, REMS for AMS, and Keycloak for authentication.
 
-```bash
-docker compose up -d postgres
-```
-
-Or run PostgreSQL directly:
-
-```bash
-docker run -d
-  --name gdi-postgres \
-  -e POSTGRES_DB=gdi \
-  -e POSTGRES_USER=gdi_user \
-  -e POSTGRES_PASSWORD=gdi_pass \
-  -p 5432:5432 \
-  postgres:14
-```
+Use the relevant Docker Compose setup from those repositories when you need local instances of these integration services.
 
 ## Run in development mode
 
@@ -194,12 +175,6 @@ The executable JAR is in `target/quarkus-app/`.
 
   ```properties
   quarkus.http.port=8081
-  ```
-
-- **Database connection failed:** Ensure PostgreSQL is running.
-
-  ```bash
-  docker ps | grep postgres
   ```
 
 - **Maven build fails:** Clear Maven cache and rebuild.

--- a/documentation/docs/developer-guide/2-set-up-your-environment/3-set-up-ckan.md
+++ b/documentation/docs/developer-guide/2-set-up-your-environment/3-set-up-ckan.md
@@ -17,10 +17,24 @@ Install CKAN and its extensions for local development and testing.
 
 ## Prerequisites
 
-- Python 3 installed
+- Python 3.10 installed
 - PostgreSQL installed and running
 - Git installed
 - Administrator/sudo access on your machine
+
+## Version alignment
+
+The local setup should match the versions used by the `gdi-userportal-ckan-docker` development image:
+
+| Component      | Version or source                                                                 |
+| -------------- | ---------------------------------------------------------------------------------- |
+| CKAN           | `2.11.4`                                                                           |
+| CKAN base image | `ckan/ckan-dev:2.11.4` for development, `ckan/ckan-base:2.11.4` for production    |
+| Python         | `3.10`                                                                             |
+| PostgreSQL     | `18-alpine`                                                                        |
+| Solr           | `10.0.0-slim`                                                                      |
+| Redis          | `7.4.2`                                                                            |
+| DCAT extension | `GenomicDataInfrastructure/gdi-userportal-ckanext-dcat@v2.4.2`                    |
 
 ## Install CKAN locally
 
@@ -42,9 +56,9 @@ Install CKAN and its extensions for local development and testing.
 2. **Install CKAN as a package into your virtual environment:**
 
    ```commandline
-   pip install -e 'git+https://github.com/ckan/ckan.git@ckan-2.10.5#egg=ckan[requirements]'
+   pip install -e 'git+https://github.com/ckan/ckan.git@ckan-2.11.4#egg=ckan[requirements]'
    # For development purposes, include dev dependencies:
-   pip install -e 'git+https://github.com/ckan/ckan.git@ckan-2.10.5#egg=ckan[requirements,dev]'
+   pip install -e 'git+https://github.com/ckan/ckan.git@ckan-2.11.4#egg=ckan[requirements,dev]'
    ```
 
    :::tip Troubleshooting
@@ -68,7 +82,7 @@ Install CKAN and its extensions for local development and testing.
    Directly from GitHub:
 
    ```commandline
-   pip install -e git+https://github.com/ckan/ckanext-dcat.git@v2.1.0#egg=ckanext-dcat
+   pip install -e git+https://github.com/GenomicDataInfrastructure/gdi-userportal-ckanext-dcat.git@v2.4.2#egg=ckanext-dcat
    ```
 
 4. **Install the dependencies for the CKAN extensions:**
@@ -91,7 +105,7 @@ Install CKAN and its extensions for local development and testing.
 
 ## Configure testing
 
-Your testing strategy depends on your plugin's functionality. CKAN provides helper functions to generate dummy data and clean up databases after tests. For detailed information, review the [official CKAN documentation](https://docs.ckan.org/en/2.10/extensions/testing-extensions.html).
+Your testing strategy depends on your plugin's functionality. CKAN provides helper functions to generate dummy data and clean up databases after tests. For detailed information, review the [official CKAN documentation](https://docs.ckan.org/en/2.11/extensions/testing-extensions.html).
 
 To set up your test environment, configure plugin testing:
 
@@ -170,11 +184,5 @@ Here are some common issues when installing CKAN and how to resolve them:
    ```commandline
    pip install -r <venv directory>/src/ckan/requirements.txt
    pip install -r <venv directory>/src/ckan/dev-requirements.txt
-   pip install -e 'git+https://github.com/ckan/ckan.git@ckan-2.10.5#egg=ckan'
+   pip install -e 'git+https://github.com/ckan/ckan.git@ckan-2.11.4#egg=ckan'
    ```
-
-- **PyYAML compatibility Issues (CKAN v2.9.10).** If you encounter the error `TypeError: load() missing 1 required positional argument: 'Loader'`, downgrade PyYAML:
-
-1. Open `requirements.txt` in your CKAN installation.
-2. Change `pyyaml==5.4.1` or `pyyaml==6.0.1` to `pyyaml==5.3.1`
-3. Reinstall dependencies.

--- a/documentation/docs/developer-guide/2-set-up-your-environment/3-set-up-ckan.md
+++ b/documentation/docs/developer-guide/2-set-up-your-environment/3-set-up-ckan.md
@@ -140,6 +140,16 @@ pytest --ckan-ini=test.ini
 <path to virtual environment>/default/bin/pytest --ckan-ini=test.ini --disable-warnings ./ckanext/fairdatapoint --cov ./ckanext/fairdatapoint -vv
 ```
 
+**When developing an extension in Docker**, start the development setup with Docker Compose, then run tests from inside the `ckan-dev` container:
+
+```bash
+docker compose exec -it ckan-dev bash
+cd /srv/app/src_extensions/ckanext-fairdatapoint
+pytest --ckan-ini=test.ini
+```
+
+Replace `ckanext-fairdatapoint` with the extension you are developing.
+
 **To run individual test files or unit tests within PyCharm**, set the following environment variable in your run configuration:
 
 ```commandline

--- a/documentation/docs/developer-guide/2-set-up-your-environment/3-set-up-ckan.md
+++ b/documentation/docs/developer-guide/2-set-up-your-environment/3-set-up-ckan.md
@@ -26,15 +26,15 @@ Install CKAN and its extensions for local development and testing.
 
 The local setup should match the versions used by the `gdi-userportal-ckan-docker` development image:
 
-| Component      | Version or source                                                                 |
-| -------------- | ---------------------------------------------------------------------------------- |
-| CKAN           | `2.11.4`                                                                           |
-| CKAN base image | `ckan/ckan-dev:2.11.4` for development, `ckan/ckan-base:2.11.4` for production    |
-| Python         | `3.10`                                                                             |
-| PostgreSQL     | `18-alpine`                                                                        |
-| Solr           | `10.0.0-slim`                                                                      |
-| Redis          | `7.4.2`                                                                            |
-| DCAT extension | `GenomicDataInfrastructure/gdi-userportal-ckanext-dcat@v2.4.2`                    |
+| Component       | Version or source                                                              |
+| --------------- | ------------------------------------------------------------------------------ |
+| CKAN            | `2.11.4`                                                                       |
+| CKAN base image | `ckan/ckan-dev:2.11.4` for development, `ckan/ckan-base:2.11.4` for production |
+| Python          | `3.10`                                                                         |
+| PostgreSQL      | `18-alpine`                                                                    |
+| Solr            | `10.0.0-slim`                                                                  |
+| Redis           | `7.4.2`                                                                        |
+| DCAT extension  | `GenomicDataInfrastructure/gdi-userportal-ckanext-dcat@v2.4.2`                 |
 
 ## Install CKAN locally
 

--- a/documentation/docs/developer-guide/3-understand-the-codebase/4-service-apis-reference.md
+++ b/documentation/docs/developer-guide/3-understand-the-codebase/4-service-apis-reference.md
@@ -42,9 +42,8 @@ Explore the APIs of the different services in the GDI platform for dataset manag
 - **Documentation:** https://docs.ckan.org/en/latest/api/ access at `<ckan-base-url>/api/3/action/`
 - **Example:** `http://localhost:5000/api/3/action/` for local development
 - **Endpoints:**
-  - `GET /api/3/action/package_search`: Search datasets
-  - `GET /api/3/action/package_show`: Get dataset details
-  - `POST /api/3/action/package_create`: Create dataset (auth required)
+  - `GET /api/3/action/enhanced_package_search`: Search datasets with GDI User Portal field translations
+  - `GET /api/3/action/enhanced_package_show`: Get dataset details with GDI User Portal field translations
 
 ## Authentication
 

--- a/documentation/docs/developer-guide/4-build-features/3-add-metadata-fields.md
+++ b/documentation/docs/developer-guide/4-build-features/3-add-metadata-fields.md
@@ -135,7 +135,6 @@ To add and configure a searchable field:
    - **Predicate** - The RDF term for the field
    - **Cardinality** - Single or multiple-valued
    - **Range** - The datatype or class
-
    2. **Add the field to the class.** For HealthDCAT-AP fields, use the relevant class under `sempyro.healthdcatap` and add a property definition. Example for the `health_theme` property in `HEALTHDCATAPDataset`:
 
    ```python
@@ -153,10 +152,9 @@ To add and configure a searchable field:
    - **Line 1**: Property name and range. Use `List[]` for multi-valued fields (cardinality > 1). Common range types include `AnyHttpUrl`, `LiteralField`, or classes like `Agent` or `VCard`.
    - **Line 2**: Set `default=None` for optional fields. Omit this line for mandatory fields.
    - **Line 3**: Human-readable description of the field.
-      - **Line 4**: `json_schema_extra` containing the RDF mapping metadata.
-      - **Line 5**: RDF predicate (for example `HEALTHDCATAP.healthTheme`). Common namespaces like `DCTERMS`, `DCAT`, and `HEALTHDCATAP` are imported by default. Define custom predicates with `URIRef("http://example.com/range#property")`.
-      - **Line 6**: RDF type such as `rdfs_literal`, `xsd:string`, or `uri`. Review other properties in the class for guidance.
-
+     - **Line 4**: `json_schema_extra` containing the RDF mapping metadata.
+     - **Line 5**: RDF predicate (for example `HEALTHDCATAP.healthTheme`). Common namespaces like `DCTERMS`, `DCAT`, and `HEALTHDCATAP` are imported by default. Define custom predicates with `URIRef("http://example.com/range#property")`.
+     - **Line 6**: RDF type such as `rdfs_literal`, `xsd:string`, or `uri`. Review other properties in the class for guidance.
    3. **Regenerate schemas.** Regenerate the JSON and YAML schemas. For the `HEALTHDCATAPDataset` class:
 
    ```bash

--- a/documentation/docs/developer-guide/4-build-features/3-add-metadata-fields.md
+++ b/documentation/docs/developer-guide/4-build-features/3-add-metadata-fields.md
@@ -136,27 +136,31 @@ To add and configure a searchable field:
    - **Cardinality** - Single or multiple-valued
    - **Range** - The datatype or class
 
-2. **Add the field to the class.** Go to the relevant class and add a property definition. Example for the `type` property in `HRI_Dataset`:
+   2. **Add the field to the class.** For HealthDCAT-AP fields, use the relevant class under `sempyro.healthdcatap` and add a property definition. Example for the `health_theme` property in `HEALTHDCATAPDataset`:
 
    ```python
-   type: List[AnyHttpUrl] = Field(
+      health_theme: List[AnyHttpUrl] = Field(
        default=None,
-       description="The nature or genre of the resource. HRI recommended",
-       rdf_term=DCTERMS.type,
-       rdf_type="uri")
+         description="A category of the Dataset or tag describing the Dataset.",
+         json_schema_extra={
+            "rdf_term": HEALTHDCATAP.healthTheme,
+            "rdf_type": "uri",
+         },
+      )
    ```
 
    Each field is defined as a class property with the following structure:
    - **Line 1**: Property name and range. Use `List[]` for multi-valued fields (cardinality > 1). Common range types include `AnyHttpUrl`, `LiteralField`, or classes like `Agent` or `VCard`.
    - **Line 2**: Set `default=None` for optional fields. Omit this line for mandatory fields.
    - **Line 3**: Human-readable description of the field.
-   - **Line 4**: RDF predicate (e.g., `DCTERMS.type`). Common namespaces like `DCTERMS` and `DCAT` are imported by default. Define custom predicates with `URIRef("http://example.com/range#property")`.
-   - **Line 5**: RDF type such as `rdfs_literal`, `xsd:string`, or `uri`. Review other properties in the class for guidance.
+      - **Line 4**: `json_schema_extra` containing the RDF mapping metadata.
+      - **Line 5**: RDF predicate (for example `HEALTHDCATAP.healthTheme`). Common namespaces like `DCTERMS`, `DCAT`, and `HEALTHDCATAP` are imported by default. Define custom predicates with `URIRef("http://example.com/range#property")`.
+      - **Line 6**: RDF type such as `rdfs_literal`, `xsd:string`, or `uri`. Review other properties in the class for guidance.
 
-3. **Regenerate schemas.** Regenerate the JSON and YAML schemas. For the `HRIDataset` class:
+   3. **Regenerate schemas.** Regenerate the JSON and YAML schemas. For the `HEALTHDCATAPDataset` class:
 
    ```bash
-   hatch run python sempyro/hri_dcat/hri_dataset
+      hatch run python sempyro/healthdcatap/healthdcatap_dataset.py
    ```
 
 ## FAIR Data Point (FDP)

--- a/documentation/docs/developer-guide/4-build-features/3-add-metadata-fields.md
+++ b/documentation/docs/developer-guide/4-build-features/3-add-metadata-fields.md
@@ -18,41 +18,42 @@ Add, modify, or delete metadata fields across the CKAN ecosystem, including DCAT
 In this guide
 
 > [CKAN DCAT Model](#ckan-dcat-model)  
+> [CKAN scheming schemas](#ckan-scheming-schemas)
 > [Solr search integration](#solr-search-integration)  
 > [SeMPyRO](#sempyro)  
 > [FAIR Data Point (FDP)](#fair-data-point-fdp)  
 > [Discovery Service](#discovery-service)
 
-## CKAN DCAT Model
+## CKAN DCAT model
 
-To add DCAT-AP fields missing from the upstream CKAN DCAT extension:
+Use the GDI-maintained DCAT extension when adding fields that affect DCAT parsing, serialisation, or mapping between DCAT and CKAN:
 
-1. **Fork and clone the repository:**
+1. **Clone the GDI DCAT extension repository:**
 
    ```bash
-   git clone https://github.com/ckan/ckanext-dcat
+   git clone https://github.com/GenomicDataInfrastructure/gdi-userportal-ckanext-dcat.git
    ```
 
-2. **Add the new field to the schema:**
-   - Modify the schema file: `ckanext/dcat/schemas/dcat_ap_full.yaml`
+2. **Add the new field to the relevant DCAT schema.**
+   - For DCAT-AP fields, update files such as `ckanext/dcat/schemas/dcat_ap_full.yaml`.
+   - For HealthDCAT fields, update files such as `ckanext/dcat/schemas/health_dcat_ap.yaml` or `ckanext/dcat/schemas/health_dcat_ap_multilingual.yaml`.
+   - For dataset series fields, review `ckanext/dcat/schemas/dcat_ap_dataset_series.yaml` and `ckanext/dcat/schemas/dcat_ap_in_series.yaml`.
    - Use appropriate field types (e.g., text, repeating subfield, URI).
    - Follow examples from other fields for consistency.
-
-   For more information about scheming, see: [Work with CKAN schemas](/developer-guide/work-with-ckan-schemas).
 
 3. **Extend the existing mapping depending on the DCAT-AP version.** Modify the mapping files located in the directory: `ckanext/dcat/profiles`.
 
    :::tip Example
-   See [PR #302](https://github.com/ckan/ckanext-dcat/pull/302) for a practical example of how to implement mapping for multi-valued fields like `creator` in CKAN DCAT profiles.
+   Review existing multi-valued fields such as `creator` in the GDI DCAT fork for mapping and test patterns.
    :::
 
 4. **Fix the corresponding unit tests.**
 
-5. **Create a pull request to the CKAN DCAT extension repository.** Ensure that you follow the contributing guidelines for CKAN:
+5. **Create a pull request to [`gdi-userportal-ckanext-dcat`](https://github.com/GenomicDataInfrastructure/gdi-userportal-ckanext-dcat).**
    - Include unit tests for the new fields.
    - Ensure compatibility across different DCAT-AP versions.
 
-6. **Update the following repositories after a new release.** Update development and production Dockerfiles in these repositories( order is important):
+6. **Update the following repositories after a new release.** Update development and production Dockerfiles in these repositories (order is important):
    - https://github.com/GenomicDataInfrastructure/gdi-userportal-ckanext-fairdatapoint
    - https://github.com/GenomicDataInfrastructure/gdi-userportal-ckan-docker
 
@@ -63,6 +64,27 @@ To add DCAT-AP fields missing from the upstream CKAN DCAT extension:
 Always take into account the mapping from CKAN → DCAT in addition to DCAT → CKAN.
 
 :::
+
+## CKAN scheming schemas
+
+Use the GDI User Portal CKAN extension when adding fields that should appear in CKAN dataset forms or be stored as CKAN package fields:
+
+1. **Clone the GDI User Portal CKAN extension repository:**
+
+   ```bash
+   git clone https://github.com/GenomicDataInfrastructure/gdi-userportal-ckanext-gdi-userportal.git
+   ```
+
+2. **Update the active scheming schemas.** The Docker setup configures these files through `scheming.dataset_schemas`:
+   - `ckanext/gdi_userportal/scheming/schemas/dataset_multilingual.yaml`
+   - `ckanext/gdi_userportal/scheming/schemas/dataset_series_multilingual.yaml`
+
+3. **Update GDI-specific presets if the field needs custom rendering or validation.**
+   - `ckanext/gdi_userportal/scheming/presets/gdi_presets.yaml`
+
+4. **Check the Docker scheming configuration.** The active configuration is maintained in [`gdi-userportal-ckan-docker`](https://github.com/GenomicDataInfrastructure/gdi-userportal-ckan-docker), in `ckan/docker-entrypoint.d/setup_scheming.sh`.
+
+For field keys and schema syntax, see the [CKAN scheming documentation](https://github.com/ckan/ckanext-scheming/tree/release-3.1.0#field-keys) and [Work with CKAN schemas](/developer-guide/work-with-ckan-schemas).
 
 ## Solr search integration
 

--- a/documentation/docs/developer-guide/4-build-features/5-develop-harvesters/2-test-locally.md
+++ b/documentation/docs/developer-guide/4-build-features/5-develop-harvesters/2-test-locally.md
@@ -15,6 +15,44 @@ SPDX-License-Identifier: CC-BY-4.0
 
 Test DCAT harvesting in CKAN by setting up a local nginx web server. This guide assumes you have CKAN running with the previously configured docker-compose.
 
+## Use hosted test data
+
+You can also test harvesting with the Health-RI harvesting test data repository.
+
+1. Find the CKAN sysadmin credentials in the `.env` file:
+
+   ```bash
+   CKAN_SYSADMIN_NAME
+   CKAN_SYSADMIN_PASSWORD
+   ```
+
+2. Log in to CKAN with those credentials.
+
+3. Create an organisation. CKAN requires an organisation before you can create a harvest source. The name can be any local test name, for example `testorg1`.
+
+4. Create a harvest source for the test data from [`Health-RI/harvesting-test-data`](https://github.com/Health-RI/harvesting-test-data):
+
+   | Field                | Value                                                                                                                                                                                                                                          |
+   | -------------------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+   | **URL**              | `https://raw.githubusercontent.com/Health-RI/harvesting-test-data/c1019281532fb1114bd4eba362e94cc04ae18132/dataset_health.ttl`                                                                                                                |
+   | **Title**            | Any title you can recognise later, for example `harvest_dataset_health`                                                                                                                                                                        |
+   | **Source type**      | `Generic DCAT RDF Harvester`                                                                                                                                                                                                                   |
+   | **Update frequency** | `Manual`                                                                                                                                                                                                                                      |
+   | **Configuration**    | `{ "profile": "fairdatapoint_dcat_ap", "rdf_format": "text/turtle", "force_all": "true" }`                                                                                                                                                    |
+
+   The test data can change during development. Ask the team which version to use if you need reproducible results. The URL above pins an earlier commit.
+
+5. Save the harvest source.
+
+6. Trigger the harvest from the running `ckan-dev` container. Replace `harvest_dataset_health` with the title, name, or harvest source ID you used. If CKAN generated a different URL name, use the last part of the harvest source URL.
+
+   ```bash
+   docker compose exec -it ckan-dev bash
+   ckan --config=/srv/app/ckan.ini harvester run-test harvest_dataset_health
+   ```
+
+   The test data contains non-resolvable URIs, so several `404` errors are expected. If you get `sqlalchemy.exc.PendingRollbackError`, rerun the harvest job and cancel the running job when prompted. This can happen because dataset and dataset series records are created in an order that is not deterministic.
+
 ## Set up nginx web server
 
 Start an nginx container to serve your DCAT files. Replace `~/Development/xnatdcat/` with the folder containing your test data.

--- a/documentation/docs/developer-guide/4-build-features/5-develop-harvesters/2-test-locally.md
+++ b/documentation/docs/developer-guide/4-build-features/5-develop-harvesters/2-test-locally.md
@@ -32,13 +32,13 @@ You can also test harvesting with the Health-RI harvesting test data repository.
 
 4. Create a harvest source for the test data from [`Health-RI/harvesting-test-data`](https://github.com/Health-RI/harvesting-test-data):
 
-   | Field                | Value                                                                                                                                                                                                                                          |
-   | -------------------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-   | **URL**              | `https://raw.githubusercontent.com/Health-RI/harvesting-test-data/c1019281532fb1114bd4eba362e94cc04ae18132/dataset_health.ttl`                                                                                                                |
-   | **Title**            | Any title you can recognise later, for example `harvest_dataset_health`                                                                                                                                                                        |
-   | **Source type**      | `Generic DCAT RDF Harvester`                                                                                                                                                                                                                   |
-   | **Update frequency** | `Manual`                                                                                                                                                                                                                                      |
-   | **Configuration**    | `{ "profile": "fairdatapoint_dcat_ap", "rdf_format": "text/turtle", "force_all": "true" }`                                                                                                                                                    |
+   | Field                | Value                                                                                                                          |
+   | -------------------- | ------------------------------------------------------------------------------------------------------------------------------ |
+   | **URL**              | `https://raw.githubusercontent.com/Health-RI/harvesting-test-data/c1019281532fb1114bd4eba362e94cc04ae18132/dataset_health.ttl` |
+   | **Title**            | Any title you can recognise later, for example `harvest_dataset_health`                                                        |
+   | **Source type**      | `Generic DCAT RDF Harvester`                                                                                                   |
+   | **Update frequency** | `Manual`                                                                                                                       |
+   | **Configuration**    | `{ "profile": "fairdatapoint_dcat_ap", "rdf_format": "text/turtle", "force_all": "true" }`                                     |
 
    The test data can change during development. Ask the team which version to use if you need reproducible results. The URL above pins an earlier commit.
 


### PR DESCRIPTION
## Summary
- Mention that the CKAN extension layer supports HealthDCAT in the platform overview.
- Add `gdi-userportal-ckanext-dcat` to the CKAN repositories and common task mapping, including its role in DCAT/CKAN mapping and dataset series support.
- Update backend service setup guidance to remove PostgreSQL as a DDS/AMS dependency and describe the services as intermediate integrations.
- Add a developer workflow for harvesting the Health-RI `dataset_health.ttl` test data, including configuration, CLI trigger, and expected troubleshooting notes.
- Add Docker-based CKAN extension test commands from inside the `ckan-dev` container.
- Align the CKAN setup page with `gdi-userportal-ckan-docker` pins: CKAN `2.11.4`, Python `3.10`, PostgreSQL `18-alpine`, Solr `10.0.0-slim`, Redis `7.4.2`, and `gdi-userportal-ckanext-dcat@v2.4.2`.
- Update the service API reference to remove `package_create` and document the current `enhanced_package_search` and `enhanced_package_show` CKAN extension actions.
- Update the metadata-field workflow to reference the GDI DCAT fork and the active GDI scheming schema files in `gdi-userportal-ckanext-gdi-userportal`.

## Validation
- `npm run build` in `documentation/`

## Summary by Sourcery

Update developer documentation to align CKAN, DCAT, and backend service guidance with current GDI architecture and repositories.

Documentation:
- Document use of the GDI DCAT fork and scheming schemas for managing DCAT, HealthDCAT, and dataset series metadata fields.
- Align CKAN local setup instructions and testing guidance with the `gdi-userportal-ckan-docker` stack, including version pins and Docker-based extension testing.
- Clarify that DDS and AMS act as integration services without their own PostgreSQL dependency and point developers to external service Docker setups instead.
- Add a Health-RI hosted test data workflow for exercising CKAN DCAT harvesters via CLI.
- Describe the role of `gdi-userportal-ckanext-dcat` in the platform and map common tasks to the appropriate CKAN extension repositories.
- Update the service API reference to focus on GDI-specific CKAN actions `enhanced_package_search` and `enhanced_package_show`.