### PR TITLE
feat(datasets): add temporal coverage fields and enhance UI representation

### DIFF
--- a/src/app/api/discovery/open-api/discovery.yml
+++ b/src/app/api/discovery/open-api/discovery.yml
@@ -386,6 +386,14 @@ components:
           type: array
           items:
             $ref: "#/components/schemas/TimeWindow"
+        temporalCoverageStart:
+          type: string
+          format: date-time
+          description: Earliest available temporal coverage start across all periods.
+        temporalCoverageEnd:
+          type: string
+          format: date-time
+          description: Latest available temporal coverage end across all periods.
         recordsCount:
           type: integer
           title: Records count

--- a/src/app/api/helpdesk/zammad.ts
+++ b/src/app/api/helpdesk/zammad.ts
@@ -3,7 +3,6 @@
 // SPDX-License-Identifier: Apache-2.0
 
 import { getZammadConfig } from "@/app/api/helpdesk/config";
-import { Agent } from "undici";
 
 type CreateZammadTicketInput = {
   title: string;
@@ -38,11 +37,27 @@ type ZammadTicketPayload = {
   };
 };
 
-const INSECURE_TLS_DISPATCHER = new Agent({
-  connect: {
-    rejectUnauthorized: false,
-  },
-});
+async function withOptionalInsecureTls<T>(
+  baseUrl: string,
+  tlsInsecure: boolean,
+  run: () => Promise<T>
+): Promise<T> {
+  if (!(tlsInsecure && baseUrl.startsWith("https://"))) {
+    return run();
+  }
+
+  const previousTlsSetting = process.env.NODE_TLS_REJECT_UNAUTHORIZED;
+  process.env.NODE_TLS_REJECT_UNAUTHORIZED = "0";
+  try {
+    return await run();
+  } finally {
+    if (previousTlsSetting === undefined) {
+      delete process.env.NODE_TLS_REJECT_UNAUTHORIZED;
+    } else {
+      process.env.NODE_TLS_REJECT_UNAUTHORIZED = previousTlsSetting;
+    }
+  }
+}
 
 function formatArticleBody(input: CreateZammadTicketInput): string {
   return [
@@ -107,17 +122,16 @@ async function postZammadTicket(
 ) {
   let response: Response;
   try {
-    response = await fetch(`${baseUrl}/api/v1/tickets`, {
-      method: "POST",
-      headers: {
-        Authorization: `Token token=${apiToken}`,
-        "Content-Type": "application/json",
-      },
-      body: JSON.stringify(payload),
-      ...(tlsInsecure && baseUrl.startsWith("https://")
-        ? { dispatcher: INSECURE_TLS_DISPATCHER }
-        : {}),
-    });
+    response = await withOptionalInsecureTls(baseUrl, tlsInsecure, () =>
+      fetch(`${baseUrl}/api/v1/tickets`, {
+        method: "POST",
+        headers: {
+          Authorization: `Token token=${apiToken}`,
+          "Content-Type": "application/json",
+        },
+        body: JSON.stringify(payload),
+      })
+    );
   } catch (error) {
     const message = error instanceof Error ? error.message : String(error);
     throw new Error(
@@ -145,21 +159,20 @@ async function updateZammadCustomerProfile(
   email: string
 ) {
   try {
-    await fetch(`${baseUrl}/api/v1/users/${customerId}`, {
-      method: "PUT",
-      headers: {
-        Authorization: `Token token=${apiToken}`,
-        "Content-Type": "application/json",
-      },
-      body: JSON.stringify({
-        firstname: firstName,
-        lastname: lastName,
-        email,
-      }),
-      ...(tlsInsecure && baseUrl.startsWith("https://")
-        ? { dispatcher: INSECURE_TLS_DISPATCHER }
-        : {}),
-    });
+    await withOptionalInsecureTls(baseUrl, tlsInsecure, () =>
+      fetch(`${baseUrl}/api/v1/users/${customerId}`, {
+        method: "PUT",
+        headers: {
+          Authorization: `Token token=${apiToken}`,
+          "Content-Type": "application/json",
+        },
+        body: JSON.stringify({
+          firstname: firstName,
+          lastname: lastName,
+          email,
+        }),
+      })
+    );
   } catch {
     // Ticket creation succeeded, so user profile sync failure should not break contact flow.
   }

--- a/src/app/datasets/[id]/DatasetMetadata.tsx
+++ b/src/app/datasets/[id]/DatasetMetadata.tsx
@@ -133,15 +133,36 @@ const DatasetMetadata = ({
   seriesMembers?: SearchedDataset[];
 }) => {
   const [userTimezone, setUserTimezone] = useState<string | null>(null);
-  const temporalCoverage = Array.isArray(dataset.temporalCoverage)
-    ? dataset.temporalCoverage[0]
-    : dataset.temporalCoverage;
+  const temporalCoverageCandidate = dataset.temporalCoverage as unknown;
+  const temporalCoverageSource = Array.isArray(temporalCoverageCandidate)
+    ? (temporalCoverageCandidate as Array<{ start?: string; end?: string }>)
+    : temporalCoverageCandidate && typeof temporalCoverageCandidate === "object"
+      ? [temporalCoverageCandidate as { start?: string; end?: string }]
+      : [];
+  const temporalCoverage = temporalCoverageSource.filter(
+    (coverage) => coverage.start || coverage.end
+  );
+  const hasTemporalCoverage = temporalCoverage.length > 0;
   const analytics =
     dataset.analytics
       ?.map((entry) =>
         typeof entry === "string" ? entry : entry.title || entry.description
       )
       .filter((entry): entry is string => Boolean(entry)) ?? [];
+  const renderTemporalCoverage = () => {
+    if (!hasTemporalCoverage) {
+      return <NotProvided />;
+    }
+
+    const temporalCoverageLabel = temporalCoverage
+      .map(
+        (coverage) =>
+          `${coverage.start ? formatDate(coverage.start) : "N/A"} — ${coverage.end ? formatDate(coverage.end) : "Present"}`
+      )
+      .join(", ");
+
+    return <span>{temporalCoverageLabel}</span>;
+  };
 
   useEffect(() => {
     try {
@@ -220,18 +241,6 @@ const DatasetMetadata = ({
             >
               {dataset.accessRights?.label || <NotProvided />}
             </MetadataField>
-            <div className="flex flex-wrap gap-2 items-center relative group">
-              <span className="font-medium shrink-0">Conforms To:</span>
-              {dataset.conformsTo && dataset.conformsTo.length > 0 ? (
-                <Chips
-                  chips={dataset.conformsTo.map((item) => item.label)}
-                  className="bg-primary/10 text-primary rounded-full py-1"
-                />
-              ) : (
-                <NotProvided />
-              )}
-              <Tooltip message="Standards followed by this dataset series." />
-            </div>
             <div className="flex items-center gap-2 flex-wrap relative group">
               <span className="font-medium shrink-0">URI:</span>
               {dataset.uri ? (
@@ -272,20 +281,7 @@ const DatasetMetadata = ({
               label="Temporal Coverage"
               tooltip="Time window covered by this series."
             >
-              {temporalCoverage &&
-              (temporalCoverage.start || temporalCoverage.end) ? (
-                <>
-                  {temporalCoverage.start
-                    ? formatDate(temporalCoverage.start)
-                    : "N/A"}{" "}
-                  -{" "}
-                  {temporalCoverage.end
-                    ? formatDate(temporalCoverage.end)
-                    : "Present"}
-                </>
-              ) : (
-                <NotProvided />
-              )}
+              {renderTemporalCoverage()}
             </MetadataField>
           </div>
         </MetadataSection>
@@ -660,8 +656,7 @@ const DatasetMetadata = ({
 
       {(isHealthDcatApCompatible(dataset) ||
         (dataset.spatialCoverage && dataset.spatialCoverage.length > 0) ||
-        (temporalCoverage &&
-          (temporalCoverage.start || temporalCoverage.end)) ||
+        hasTemporalCoverage ||
         dataset.temporalResolution ||
         dataset.spatialResolutionInMeters !== undefined) && (
         <MetadataSection title="Coverage" icon={faGlobe}>
@@ -685,20 +680,7 @@ const DatasetMetadata = ({
               label="Temporal Coverage"
               tooltip="Time period covered by the data in this dataset."
             >
-              {temporalCoverage &&
-              (temporalCoverage.start || temporalCoverage.end) ? (
-                <>
-                  {temporalCoverage.start
-                    ? formatDate(temporalCoverage.start)
-                    : "N/A"}{" "}
-                  -{" "}
-                  {temporalCoverage.end
-                    ? formatDate(temporalCoverage.end)
-                    : "Present"}
-                </>
-              ) : (
-                <NotProvided />
-              )}
+              {renderTemporalCoverage()}
             </MetadataField>
             <MetadataField
               label="Temporal Resolution"

--- a/src/app/datasets/[id]/page.tsx
+++ b/src/app/datasets/[id]/page.tsx
@@ -67,14 +67,18 @@ export default async function Page({
     const relationships = dataset.datasetRelationships || [];
 
     const dictionary = dataset.dataDictionary || [];
+    const headingClasses = [
+      "flex flex-col gap-y-5 gap-x-3 justify-between",
+      dataset.isSeries || (dataset.themes?.length && dataset.themes.length < 2)
+        ? "md:flex-row md:items-start md:gap-y-0"
+        : "",
+    ].join(" ");
 
     return (
       <PageContainer searchParams={_searchParams}>
         <div className="flex flex-col items-start justify-start lg:flex-row">
           <div className="flex w-full flex-col gap-5 lg:w-2/3 lg:px-5">
-            <div
-              className={`flex flex-col ${dataset.themes?.length && dataset.themes.length < 2 && "md:flex-row md:gap-y-0 items-start"} gap-y-5 gap-x-3 justify-between`}
-            >
+            <div className={headingClasses}>
               <PageHeading className="text-black">{dataset.title}</PageHeading>
 
               <ul className="flex gap-x-3 gap-y-2 flex-wrap">

--- a/src/app/datasets/__tests__/datasetCardItems.test.ts
+++ b/src/app/datasets/__tests__/datasetCardItems.test.ts
@@ -33,18 +33,21 @@ describe("datasetCardItems", () => {
       ],
       createdAt: "2024-03-01T00:00:00.000Z",
       modifiedAt: "",
+      temporalCoverageStart: "2020-01-01T00:00:00.000Z",
+      temporalCoverageEnd: "2023-12-31T00:00:00.000Z",
       recordsCount: 21,
       inSeriesCount: 1,
     };
 
     const items = createDatasetCardItems(dataset);
-    expect(items.length).toBe(6);
+    expect(items.length).toBe(7);
     expect(items[0].text).toBe("Created on 1 March 2024");
     expect(items[1].text).toBe("");
-    expect(items[2].text).toBe("Published by publisher1");
-    expect(items[3].text).toBe("1 Distribution");
-    expect(items[4].text).toBe("1 Dataset series");
-    expect(items[5].text).toBe("21 Records");
+    expect(items[2].text).toBe("1 January 2020 — 31 December 2023");
+    expect(items[3].text).toBe("Published by publisher1");
+    expect(items[4].text).toBe("1 Distribution");
+    expect(items[5].text).toBe("1 Dataset series");
+    expect(items[6].text).toBe("21 Records");
   });
 
   it("should handle missing optional fields without crashing", () => {
@@ -62,8 +65,36 @@ describe("datasetCardItems", () => {
     expect(items[0].text).toBe("");
     expect(items[1].text).toBe("");
     expect(items[2].text).toBe("");
-    expect(items[3].text).toBe("2 Distributions");
-    expect(items[4].text).toBe("2 Dataset series");
-    expect(items[5].text).toBe("1 Record");
+    expect(items[3].text).toBe("");
+    expect(items[4].text).toBe("2 Distributions");
+    expect(items[5].text).toBe("2 Dataset series");
+    expect(items[6].text).toBe("1 Record");
+  });
+
+  it("should show temporal coverage from backend summary fields", () => {
+    const dataset: SearchedDataset = {
+      id: "3",
+      title: "",
+      description: "",
+      publishers: [],
+      temporalCoverageStart: "2020-06-01T00:00:00.000Z",
+      temporalCoverageEnd: "2025-02-01T00:00:00.000Z",
+    };
+
+    const items = createDatasetCardItems(dataset);
+    expect(items[2].text).toBe("1 June 2020 — 1 February 2025");
+  });
+
+  it("should handle open ended temporal coverage", () => {
+    const dataset: SearchedDataset = {
+      id: "4",
+      title: "",
+      description: "",
+      publishers: [],
+      temporalCoverageStart: "2021-07-01T00:00:00.000Z",
+    };
+
+    const items = createDatasetCardItems(dataset);
+    expect(items[2].text).toBe("1 July 2021 — Present");
   });
 });

--- a/src/app/datasets/datasetCardItems.ts
+++ b/src/app/datasets/datasetCardItems.ts
@@ -7,6 +7,7 @@ import { formatDate } from "@/utils/formatDate";
 import {
   faBookBookmark,
   faCalendarAlt,
+  faClock,
   faFile,
   faLayerGroup,
   faSyncAlt,
@@ -18,6 +19,9 @@ export function createDatasetCardItems(dataset: SearchedDataset): CardItem[] {
   const publisherNames = dataset.publishers
     ?.map((publisher) => publisher.name)
     .filter((name): name is string => Boolean(name));
+  const hasTemporalCoverageSummary = Boolean(
+    dataset.temporalCoverageStart || dataset.temporalCoverageEnd
+  );
 
   return [
     {
@@ -32,6 +36,13 @@ export function createDatasetCardItems(dataset: SearchedDataset): CardItem[] {
           `Modified on ${formatDate(dataset.modifiedAt)}`) ||
         "",
       icon: faSyncAlt,
+    },
+    {
+      text:
+        (hasTemporalCoverageSummary &&
+          `${dataset.temporalCoverageStart ? formatDate(dataset.temporalCoverageStart) : "N/A"} — ${dataset.temporalCoverageEnd ? formatDate(dataset.temporalCoverageEnd) : "Present"}`) ||
+        "",
+      icon: faClock,
     },
     {
       text:

--- a/src/app/requests/entitlements/__tests__/entitlementCardItems.test.ts
+++ b/src/app/requests/entitlements/__tests__/entitlementCardItems.test.ts
@@ -37,14 +37,15 @@ describe("entitlementCardItems", () => {
 
     const items = createEntitlementCardItems(dataset, "2024-06-23", "");
 
-    expect(items.length).toBe(8);
+    expect(items.length).toBe(9);
     expect(items[0].text).toBe("Created on 1 March 2024");
     expect(items[1].text).toBe("");
-    expect(items[2].text).toBe("Published by publisher1");
-    expect(items[3].text).toBe("2 Distributions");
-    expect(items[4].text).toBe("");
+    expect(items[2].text).toBe("");
+    expect(items[3].text).toBe("Published by publisher1");
+    expect(items[4].text).toBe("2 Distributions");
     expect(items[5].text).toBe("");
-    expect(items[6].text).toBe("Start: 23 June 2024");
-    expect(items[7].text).toBe("End: N/A");
+    expect(items[6].text).toBe("");
+    expect(items[7].text).toBe("Start: 23 June 2024");
+    expect(items[8].text).toBe("End: N/A");
   });
 });

--- a/src/components/Card.tsx
+++ b/src/components/Card.tsx
@@ -5,6 +5,7 @@
 import {
   IconDefinition,
   faCircleInfo,
+  faLayerGroup,
 } from "@fortawesome/free-solid-svg-icons";
 import { FontAwesomeIcon } from "@fortawesome/react-fontawesome";
 import Link from "next/link";
@@ -50,7 +51,7 @@ export default function Card({
       className="flex flex-col w-full shadow-bb rounded-lg pl-4 pr-4.5 group relative"
     >
       <div className="flex flex-col lg:flex-row gap-x-2 gap-y-4">
-        <div className="flex flex-col gap-y-2 shrink w-full lg:w-[90%] lg:pr-4">
+        <div className="flex flex-col gap-y-2 shrink w-full">
           {subTitles.length > 0 && (
             <div className="flex flex-wrap gap-2 font-normal text-xs sm:text-sm leading-[12px] uppercase pb-2">
               {subTitles.map((subTitle, index) => (
@@ -66,22 +67,23 @@ export default function Card({
             </div>
           )}
 
-          <div className="font-bold text-[20px] group-hover:text-info group-hover:underline">
-            {title}
+          <div className="flex items-start justify-between gap-3">
+            <div className="font-bold text-[20px] group-hover:text-info group-hover:underline">
+              {title}
+            </div>
+            {entityLabel && (
+              <span className="inline-flex items-center gap-1.5 text-xs font-semibold px-3 py-1 rounded-full bg-info/10 text-info border border-info/20 shrink-0">
+                <FontAwesomeIcon icon={faLayerGroup} className="w-3 h-3" />
+                {entityLabel}
+              </span>
+            )}
           </div>
 
-          {(entityLabel || (isExternal && externalLabel)) && (
+          {isExternal && externalLabel && (
             <div className="inline-flex w-fit flex-wrap items-center gap-2">
-              {entityLabel && (
-                <span className="text-xs font-semibold px-3 py-1 rounded-full bg-secondary/10 text-secondary border border-secondary/20">
-                  {entityLabel}
-                </span>
-              )}
-              {isExternal && externalLabel && (
-                <span className="text-xs font-semibold px-3 py-1 rounded-full bg-info/10 text-info border border-info/20">
-                  {externalLabel}
-                </span>
-              )}
+              <span className="text-xs font-semibold px-3 py-1 rounded-full bg-info/10 text-info border border-info/20">
+                {externalLabel}
+              </span>
             </div>
           )}
 


### PR DESCRIPTION
- Introduced `temporalCoverageStart` and `temporalCoverageEnd` fields in dataset schema.
- Updated DatasetCard and DatasetMetadata components to display temporal coverage information.
- Enhanced dataset tests to validate temporal coverage handling and UI rendering.
- Refactored API calls to support optional insecure TLS settings for Zammad integration.

## Summary by Sourcery

Add temporal coverage summary fields for datasets and surface them in cards and metadata views, while improving Zammad TLS handling and card layout.

New Features:
- Expose temporalCoverageStart and temporalCoverageEnd fields in the discovery API and dataset search model for summarised temporal coverage.
- Display temporal coverage ranges on dataset cards and in dataset metadata sections, including support for open-ended periods.
- Show dataset entity labels alongside titles in cards with updated styling.

Bug Fixes:
- Ensure Zammad integration can optionally use insecure TLS by temporarily relaxing NODE_TLS_REJECT_UNAUTHORIZED during API calls instead of relying on a custom dispatcher.

Enhancements:
- Refine temporal coverage handling in DatasetMetadata to support multiple coverage windows and robust fallback when coverage is absent.
- Adjust dataset and entitlement card layouts to accommodate the new temporal coverage item and updated badge positioning.
- Simplify dataset page heading layout logic for series and themed datasets.

Tests:
- Extend dataset card item tests to cover temporal coverage display, including open-ended coverage and updated ordering.
- Update entitlement card item tests to reflect the additional card item slot for temporal coverage.