### PR TITLE
chore: enable ORT job in GitHub Actions workflow and adjust job dependencies

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -24,23 +24,23 @@ env:
 permissions: {}
 
 jobs:
-  # TEMPORARY: ORT job is disabled for this workflow.
-  # ort:
-  #   runs-on: ubuntu-latest
-  #   permissions:
-  #     contents: read
-  #   steps:
-  #     - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
-  #       with:
-  #         persist-credentials: false
-  #     - uses: oss-review-toolkit/ort-ci-github-action@1805edcf1f4f55f35ae6e4d2d9795ccfb29b6021 # v1
-  #       with:
-  #         allow-dynamic-versions: "true"
-  #         fail-on: "issues"
-  #         run: "cache-dependencies,cache-scan-results,labels,analyzer,evaluator,advisor,reporter,upload-results"
+  ort:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          persist-credentials: false
+      - uses: oss-review-toolkit/ort-ci-github-action@1805edcf1f4f55f35ae6e4d2d9795ccfb29b6021 # v1
+        with:
+          allow-dynamic-versions: "true"
+          fail-on: "issues"
+          run: "cache-dependencies,cache-scan-results,labels,analyzer,evaluator,advisor,reporter,upload-results"
 
   e2e-tests:
     runs-on: ubuntu-latest
+    needs: ort
     permissions:
       contents: read
     env:
@@ -69,7 +69,7 @@ jobs:
 
   versioning:
     runs-on: ubuntu-latest
-    needs: [e2e-tests]
+    needs: [ort, e2e-tests]
     permissions:
       contents: write
     outputs:


### PR DESCRIPTION
- Enabled the ORT job in the GitHub Actions workflow for dependency scanning.
- Updated job dependencies to ensure the e2e-tests job runs after the ort job.

## Summary by Sourcery

Enable the ORT dependency scanning job in the release GitHub Actions workflow and wire it into the job dependency chain.

Build:
- Enable the ORT job in the release GitHub Actions workflow and configure its steps for dependency scanning.
- Update e2e-tests and versioning job dependencies so e2e-tests depends on ORT and versioning depends on both ORT and e2e-tests.