### PR TITLE
feat(discovery): enhance dataset search response and filtering capabilities

### DIFF
--- a/src/app/api/discovery/__tests__/search-datasets.test.ts
+++ b/src/app/api/discovery/__tests__/search-datasets.test.ts
@@ -85,4 +85,37 @@ describe("Searching datasets", () => {
 
     expect(response).toEqual({ count: 0, results: [] });
   });
+
+  test("maps returned facet keys to app-friendly keys", async () => {
+    const encryptedToken = encrypt("decryptedToken");
+    mockedGetServerSession.mockResolvedValueOnce({
+      access_token: encryptedToken,
+    });
+
+    mockDiscoveryAdapter.onPost("/api/v1/datasets/search").reply(200, {
+      count: 0,
+      results: [],
+      facets: [
+        {
+          source: "ckan",
+          type: "DROPDOWN",
+          key: "publisher_name",
+          label: "Publisher",
+          values: [{ value: "LNDS", label: "LNDS", count: 1 }],
+        },
+      ],
+    });
+
+    const response = await searchDatasetsApi({});
+
+    expect(response.facets).toEqual([
+      {
+        source: "ckan",
+        type: "DROPDOWN",
+        key: "publisherName",
+        label: "Publisher",
+        values: [{ value: "LNDS", label: "LNDS", count: 1 }],
+      },
+    ]);
+  });
 });

--- a/src/app/api/discovery/providers/dds-discovery-provider.ts
+++ b/src/app/api/discovery/providers/dds-discovery-provider.ts
@@ -74,7 +74,15 @@ export class DdsDiscoveryProvider implements DiscoveryProvider {
       } as DatasetSearchQuery,
       { headers }
     );
-    return response as DiscoveryDatasetsSearchResponse;
+    const typedResponse = response as DiscoveryDatasetsSearchResponse;
+
+    return {
+      ...typedResponse,
+      facets: typedResponse.facets?.map((facet) => ({
+        ...facet,
+        key: mapDdsFilterKeyToApp(facet.key),
+      })),
+    };
   }
 
   async retrieveDataset(id: string): Promise<DiscoveryRetrievedDataset> {

--- a/src/app/api/discovery/providers/types.ts
+++ b/src/app/api/discovery/providers/types.ts
@@ -111,6 +111,7 @@ export interface DiscoverySearchedDataset extends DiscoveryDatasetBase {
 export interface DiscoveryDatasetsSearchResponse {
   count?: number;
   results?: DiscoverySearchedDataset[];
+  facets?: DiscoveryFilter[];
   beaconError?: string;
 }
 

--- a/src/app/datasets/FilterList/DropdownFilterContent.tsx
+++ b/src/app/datasets/FilterList/DropdownFilterContent.tsx
@@ -14,7 +14,7 @@ export default function DropdownFilterContent({
   const { activeFilters, addActiveFilter, removeActiveFilter } = useFilters();
 
   const correspondingActiveFilter = activeFilters.find(
-    (f) => f.key === filter.key
+    (f) => f.key === filter.key && f.source === filter.source
   );
 
   const handleCheckboxChange = (

--- a/src/app/datasets/FilterList/index.tsx
+++ b/src/app/datasets/FilterList/index.tsx
@@ -50,7 +50,7 @@ export default function FilterList() {
           </h3>
           <ul className="flex flex-col gap-y-6">
             {catalogueFilters.map((filter) => (
-              <li key={filter.key} className="list-none">
+              <li key={`${filter.source}-${filter.key}`} className="list-none">
                 <FilterItem filter={filter} />
               </li>
             ))}
@@ -70,7 +70,10 @@ export default function FilterList() {
             </p>
             <ul className="flex flex-col gap-y-6">
               {beaconFilters.map((filter) => (
-                <li key={filter.key} className="list-none">
+                <li
+                  key={`${filter.source}-${filter.key}`}
+                  className="list-none"
+                >
                   <FilterItem filter={filter} />
                 </li>
               ))}

--- a/src/providers/datasets/DatasetsProvider.tsx
+++ b/src/providers/datasets/DatasetsProvider.tsx
@@ -101,7 +101,7 @@ export default function DatasetsProvider({
   children,
   searchParams,
 }: DatasetsProviderProps) {
-  const { activeFilters } = useFilters();
+  const { activeFilters, setFilters } = useFilters();
   const [
     { datasets, datasetCount, isLoading, errorCode, beaconError },
     dispatch,
@@ -125,6 +125,7 @@ export default function DatasetsProvider({
 
     try {
       const data = await searchDatasetsApi(options);
+      setFilters(data.facets ?? []);
 
       dispatch({
         type: DatasetsActionType.DATASETS_LOADED,
@@ -143,11 +144,11 @@ export default function DatasetsProvider({
       });
       console.error(error);
     }
-  }, [activeFilters, page, q, sort, beacon]);
+  }, [activeFilters, page, q, sort, beacon, setFilters]);
 
   useEffect(() => {
     fetchDatasets();
-  }, [fetchDatasets, activeFilters, page, q, sort, beacon]);
+  }, [fetchDatasets]);
 
   return (
     <DatasetsContext.Provider

--- a/src/providers/filters/FilterProvider.tsx
+++ b/src/providers/filters/FilterProvider.tsx
@@ -4,9 +4,12 @@
 
 "use client";
 
-import React, { createContext, useContext, useEffect, useReducer } from "react";
-import { AxiosError } from "axios";
-import { retrieveFiltersApi } from "../../app/api/discovery";
+import React, {
+  createContext,
+  useCallback,
+  useContext,
+  useReducer,
+} from "react";
 import { Filter } from "@/app/api/discovery/open-api/schemas";
 import {
   ActiveFilter,
@@ -117,27 +120,11 @@ function FilterProvider({ children }: { children: React.ReactNode }) {
     initialState
   );
 
-  const retrieveFilters = async () => {
-    dispatch({ type: FilterActionType.LOADING });
-
-    try {
-      const filters = await retrieveFiltersApi();
-      dispatch({ type: FilterActionType.FILTERS_RETRIEVED, payload: filters });
-    } catch (error) {
-      const message =
-        error instanceof AxiosError ? error.message : "An error occurred";
-      const statusCode =
-        error instanceof AxiosError ? error.response?.status : 500;
-
-      dispatch({
-        type: FilterActionType.REJECTED,
-        payload: { message, statusCode },
-      });
-    }
-  };
-
-  useEffect(() => {
-    retrieveFilters();
+  const setFilters = useCallback((nextFilters: Filter[]) => {
+    dispatch({
+      type: FilterActionType.FILTERS_RETRIEVED,
+      payload: nextFilters,
+    });
   }, []);
 
   const addActiveFilter = (filter: ActiveFilter) => {
@@ -162,6 +149,7 @@ function FilterProvider({ children }: { children: React.ReactNode }) {
         activeFilters,
         isLoading,
         error,
+        setFilters,
         addActiveFilter,
         removeActiveFilter,
         clearActiveFilters,

--- a/src/providers/filters/FilterProvider.types.ts
+++ b/src/providers/filters/FilterProvider.types.ts
@@ -16,6 +16,7 @@ export type FilterContextState = {
 };
 
 export type FilterContextReturnType = FilterContextState & {
+  setFilters: (filters: Filter[]) => void;
   addActiveFilter: (filter: ActiveFilter) => void;
   removeActiveFilter: (key: string, source: string) => void;
   clearActiveFilters: () => void;

--- a/tests/fixtures/mockApi.ts
+++ b/tests/fixtures/mockApi.ts
@@ -76,11 +76,15 @@ const setupMockApiRoutes = async (page: Page) => {
         ...mockData.datasetSearchResponse,
         count: results.length,
         results,
+        facets: mockData.filters,
       });
       return;
     }
 
-    await fulfillJson(route, mockData.datasetSearchResponse);
+    await fulfillJson(route, {
+      ...mockData.datasetSearchResponse,
+      facets: mockData.filters,
+    });
   });
 
   await page.route(/\/api\/v1\/datasets\/[^/]+$/, async (route) => {

--- a/tests/mocks/mock-api-server.js
+++ b/tests/mocks/mock-api-server.js
@@ -54,7 +54,10 @@ const server = http.createServer((req, res) => {
   }
 
   if (pathname === "/api/v1/datasets/search" && req.method === "POST") {
-    return sendJson(res, 200, mockData.datasetSearchResponse);
+    return sendJson(res, 200, {
+      ...mockData.datasetSearchResponse,
+      facets: mockData.filters,
+    });
   }
 
   const datasetDetailMatch = pathname.match(/^\/api\/v1\/datasets\/([^/]+)$/);


### PR DESCRIPTION
- Added mapping of returned facet keys to app-friendly keys in the dataset search API response.
- Updated the DdsDiscoveryProvider to transform facet keys for consistency.
- Enhanced the FilterList component to use a combination of source and key for unique list item keys.
- Introduced setFilters functionality in the FilterProvider to manage active filters based on dataset search results.
- Updated mock API responses to include facets for testing purposes.

## Summary by Sourcery

Enhance dataset discovery search to surface and consume facet metadata, and align filter handling with the search API.

New Features:
- Expose dataset search facets from the discovery API response to the frontend filter system.
- Allow filters to be set directly from dataset search results via the filters context.

Enhancements:
- Map backend facet keys to app-friendly keys in the discovery provider for consistent filter identifiers.
- Use a combination of facet source and key for unique filter item identity and active-filter matching.
- Simplify datasets fetching effects to depend on a memoised fetch function rather than individual query parameters.

Tests:
- Extend discovery search tests to cover facet key mapping behavior.
- Update mock API servers and fixtures to include facet data in dataset search responses for testing.