### PR TITLE
feat(discovery): allow nullable fields in dataset schema for description and ID

### DIFF
--- a/src/app/api/discovery/open-api/discovery.yml
+++ b/src/app/api/discovery/open-api/discovery.yml
@@ -831,6 +831,7 @@ components:
                   type: string
               description:
                 type: string
+                nullable: true
               endpointDescription:
                 type: string
               endpoint_url:
@@ -844,6 +845,7 @@ components:
               id:
                 type: string
                 title: Data service internal ID
+                nullable: true
               keywords:
                 type: array
                 items:


### PR DESCRIPTION
- Updated OpenAPI definition to make the `description` and `id` fields nullable in the dataset schema, enhancing flexibility in data representation.

## Summary by Sourcery

Allow dataset discovery schema to accept null values for optional metadata fields.

New Features:
- Permit the dataset schema's description field to be null in the discovery OpenAPI definition.
- Permit the dataset schema's id field to be null in the discovery OpenAPI definition.