### PR TITLE
Feat/harvester mode

### DIFF
--- a/scripts/__tests__/harvest-worker.test.js
+++ b/scripts/__tests__/harvest-worker.test.js
@@ -24,7 +24,17 @@ describe("harvest-worker", () => {
       sourceUrl: "https://example.org/catalogue.rdf",
       apiUrl: HARVEST_ENDPOINT,
       secret: "top-secret",
+      mode: "replace",
     });
+  });
+
+  test("resolveWorkerConfig supports append mode", () => {
+    const config = resolveWorkerConfig(["--once", "--append"], {
+      HARVEST_SOURCE_URL: "https://example.org/catalogue.rdf",
+      HARVEST_INTERNAL_SECRET: "top-secret",
+    });
+
+    expect(config.mode).toBe("append");
   });
 
   test("resolveWorkerConfig uses HARVEST_BASE_URL when provided", () => {
@@ -61,6 +71,7 @@ describe("harvest-worker", () => {
           apiUrl: HARVEST_ENDPOINT,
           sourceUrl: "https://example.org/catalogue.rdf",
           secret: "top-secret",
+          mode: "append",
         },
         { fetchImpl }
       )
@@ -74,7 +85,10 @@ describe("harvest-worker", () => {
           "Content-Type": "application/json",
           "x-harvest-secret": "top-secret",
         }),
-        body: JSON.stringify({ url: "https://example.org/catalogue.rdf" }),
+        body: JSON.stringify({
+          url: "https://example.org/catalogue.rdf",
+          mode: "append",
+        }),
       })
     );
     expect(fetchImpl.mock.calls[0][1].dispatcher).toBeUndefined();

--- a/scripts/harvest-http.js
+++ b/scripts/harvest-http.js
@@ -74,7 +74,7 @@ function truncateText(value, limit = 400) {
 }
 
 async function requestHarvest(
-  { apiUrl, sourceUrl, secret },
+  { apiUrl, sourceUrl, secret, mode },
   { fetchImpl = undiciFetch, timeoutMs = HARVEST_REQUEST_TIMEOUT_MS } = {}
 ) {
   const timeoutController = new AbortController();
@@ -88,7 +88,10 @@ async function requestHarvest(
         "Content-Type": "application/json",
         "x-harvest-secret": secret,
       },
-      body: JSON.stringify({ url: sourceUrl }),
+      body: JSON.stringify({
+        url: sourceUrl,
+        ...(mode ? { mode } : {}),
+      }),
       signal: timeoutController.signal,
       ...(usesHttps(apiUrl) ? { dispatcher: harvestDispatcher } : {}),
     });

--- a/scripts/harvest-worker.js
+++ b/scripts/harvest-worker.js
@@ -8,7 +8,7 @@ const { buildHarvestApiUrl, requestHarvest } = require("./harvest-http");
 const DEFAULT_HARVEST_BASE_URL = "http://gdi-userportal-frontend:3000";
 
 function parseArgs(argv) {
-  const args = { once: false };
+  const args = { once: false, mode: "" };
 
   for (let i = 0; i < argv.length; i += 1) {
     const token = argv[i];
@@ -21,6 +21,11 @@ function parseArgs(argv) {
     } else if (token === "--secret") {
       args.secret = argv[i + 1] || "";
       i += 1;
+    } else if (token === "--mode") {
+      args.mode = argv[i + 1] || "";
+      i += 1;
+    } else if (token === "--append") {
+      args.mode = "append";
     } else if (token === "--once") {
       args.once = true;
     } else if (token === "--help" || token === "-h") {
@@ -43,9 +48,11 @@ function printUsage() {
       "  HARVEST_BASE_URL             Base URL for the frontend app (default: http://gdi-userportal-frontend:3000)",
       "  HARVEST_INTERNAL_SECRET      Shared secret sent as x-harvest-secret",
       "  HARVEST_SCHEDULE             Cron expression for recurring runs",
+      '  HARVEST_MODE                 Import mode: "replace" or "append" (default: replace)',
       "",
       "Flags:",
       "  --once                Run a single harvest and exit",
+      "  --append              Append harvested datasets without clearing the local index",
     ].join("\n")
   );
 }
@@ -65,6 +72,7 @@ function resolveWorkerConfig(argv = process.argv.slice(2), env = process.env) {
     args.secret || env.HARVEST_INTERNAL_SECRET || ""
   ).trim();
   const schedule = String(args.schedule || env.HARVEST_SCHEDULE || "").trim();
+  const mode = String(args.mode || env.HARVEST_MODE || "replace").trim();
 
   if (!sourceUrl) {
     throw new Error(
@@ -76,6 +84,10 @@ function resolveWorkerConfig(argv = process.argv.slice(2), env = process.env) {
     throw new Error(
       "Missing harvest shared secret. Provide HARVEST_INTERNAL_SECRET or pass --secret."
     );
+  }
+
+  if (!["replace", "append"].includes(mode)) {
+    throw new Error('Invalid harvest mode. Use "replace" or "append".');
   }
 
   if (!once) {
@@ -96,6 +108,7 @@ function resolveWorkerConfig(argv = process.argv.slice(2), env = process.env) {
     apiUrl: buildHarvestApiUrl(baseUrl),
     secret,
     schedule,
+    mode,
   };
 }
 

--- a/scripts/run-harvester.js
+++ b/scripts/run-harvester.js
@@ -5,7 +5,7 @@
 const { buildHarvestApiUrl, requestHarvest } = require("./harvest-http");
 
 function parseArgs(argv) {
-  const args = { url: "" };
+  const args = { url: "", mode: "" };
 
   for (let i = 0; i < argv.length; i += 1) {
     const token = argv[i];
@@ -15,6 +15,11 @@ function parseArgs(argv) {
     } else if (token === "--secret") {
       args.secret = argv[i + 1] || "";
       i += 1;
+    } else if (token === "--mode") {
+      args.mode = argv[i + 1] || "";
+      i += 1;
+    } else if (token === "--append") {
+      args.mode = "append";
     } else if (token === "--help" || token === "-h") {
       args.help = true;
     }
@@ -29,6 +34,11 @@ function printUsage() {
       "Usage:",
       "  npm run harvest:dcat -- --url <catalogue-rdf-url>",
       "  npm run harvest:dcat -- --url <catalogue-rdf-url> --secret <shared-secret>",
+      "  npm run harvest:dcat -- --url <catalogue-rdf-url> --append",
+      "",
+      "Options:",
+      '  --mode <replace|append>   Import mode. Defaults to "replace", which clears the local index first.',
+      "  --append                  Shortcut for --mode append.",
       "",
       "Example:",
       "  npm run harvest:dcat -- \\",
@@ -45,6 +55,9 @@ async function main() {
   const secret = String(
     args.secret || process.env.HARVEST_INTERNAL_SECRET || ""
   ).trim();
+  const mode = String(
+    args.mode || process.env.HARVEST_MODE || "replace"
+  ).trim();
 
   if (args.help || !args.url) {
     printUsage();
@@ -57,11 +70,16 @@ async function main() {
     );
   }
 
+  if (!["replace", "append"].includes(mode)) {
+    throw new Error('Invalid harvest mode. Use "replace" or "append".');
+  }
+
   try {
     const count = await requestHarvest({
       apiUrl: endpoint,
       sourceUrl: args.url,
       secret,
+      mode,
     });
 
     console.log(

--- a/src/app/api/discovery/harvest/__tests__/route.test.ts
+++ b/src/app/api/discovery/harvest/__tests__/route.test.ts
@@ -5,7 +5,7 @@
 import { jest } from "@jest/globals";
 
 const mockHarvestLocalIndexFromDcatUrlApi =
-  jest.fn<(url: string) => Promise<number>>();
+  jest.fn<(url: string, options?: { mode?: string }) => Promise<number>>();
 
 jest.mock("@/app/api/discovery/local-index", () => ({
   harvestLocalIndexFromDcatUrlApi: mockHarvestLocalIndexFromDcatUrlApi,
@@ -90,10 +90,59 @@ describe("POST /api/discovery/harvest", () => {
     );
 
     expect(mockHarvestLocalIndexFromDcatUrlApi).toHaveBeenCalledWith(
-      "https://example.org/catalogue.rdf"
+      "https://example.org/catalogue.rdf",
+      { mode: "replace" }
     );
     expect(response.status).toBe(200);
     await expect(response.json()).resolves.toEqual({ count: 12 });
+  });
+
+  test("passes append mode to the harvester", async () => {
+    process.env.HARVEST_INTERNAL_SECRET = "top-secret";
+    mockHarvestLocalIndexFromDcatUrlApi.mockResolvedValueOnce(4);
+
+    const response = await POST(
+      new Request("http://localhost/api/discovery/harvest", {
+        method: "POST",
+        headers: {
+          "x-harvest-secret": "top-secret",
+        },
+        body: JSON.stringify({
+          url: "https://example.org/catalogue.rdf",
+          mode: "append",
+        }),
+      })
+    );
+
+    expect(mockHarvestLocalIndexFromDcatUrlApi).toHaveBeenCalledWith(
+      "https://example.org/catalogue.rdf",
+      { mode: "append" }
+    );
+    expect(response.status).toBe(200);
+    await expect(response.json()).resolves.toEqual({ count: 4 });
+  });
+
+  test("returns 400 when mode is invalid", async () => {
+    process.env.HARVEST_INTERNAL_SECRET = "top-secret";
+
+    const response = await POST(
+      new Request("http://localhost/api/discovery/harvest", {
+        method: "POST",
+        headers: {
+          "x-harvest-secret": "top-secret",
+        },
+        body: JSON.stringify({
+          url: "https://example.org/catalogue.rdf",
+          mode: "merge",
+        }),
+      })
+    );
+
+    expect(response.status).toBe(400);
+    await expect(response.json()).resolves.toEqual({
+      error: 'Invalid field "mode". Expected "replace" or "append".',
+    });
+    expect(mockHarvestLocalIndexFromDcatUrlApi).not.toHaveBeenCalled();
   });
 
   test("returns 500 with error message when harvest throws", async () => {

--- a/src/app/api/discovery/harvest/route.ts
+++ b/src/app/api/discovery/harvest/route.ts
@@ -4,6 +4,9 @@
 
 import { timingSafeEqual } from "node:crypto";
 import { harvestLocalIndexFromDcatUrlApi } from "@/app/api/discovery/local-index";
+import type { HarvestLocalIndexMode } from "@/app/api/discovery/local-index";
+
+const HARVEST_MODES = new Set<HarvestLocalIndexMode>(["replace", "append"]);
 
 const getProvidedSecret = (request: Request): string => {
   const headerSecret = request.headers.get("x-harvest-secret")?.trim();
@@ -52,8 +55,12 @@ export async function POST(request: Request) {
   }
 
   try {
-    const body = (await request.json()) as { url?: string };
+    const body = (await request.json()) as {
+      url?: string;
+      mode?: HarvestLocalIndexMode;
+    };
     const url = body?.url?.trim();
+    const mode = body?.mode ?? "replace";
 
     if (!url) {
       return Response.json(
@@ -62,7 +69,14 @@ export async function POST(request: Request) {
       );
     }
 
-    const count = await harvestLocalIndexFromDcatUrlApi(url);
+    if (!HARVEST_MODES.has(mode)) {
+      return Response.json(
+        { error: 'Invalid field "mode". Expected "replace" or "append".' },
+        { status: 400 }
+      );
+    }
+
+    const count = await harvestLocalIndexFromDcatUrlApi(url, { mode });
     return Response.json({ count });
   } catch (error) {
     return Response.json(

--- a/src/app/api/discovery/local-index.ts
+++ b/src/app/api/discovery/local-index.ts
@@ -16,6 +16,12 @@ import { dcatHarvesterService } from "@/app/api/discovery/harvester/dcat-harvest
 import { wrapError } from "@/app/api/discovery/harvester/error-utils";
 import { oidcAuthService } from "@/app/api/discovery/harvester/oidc-auth.service";
 
+export type HarvestLocalIndexMode = "replace" | "append";
+
+export type HarvestLocalIndexOptions = {
+  mode?: HarvestLocalIndexMode;
+};
+
 export const upsertLocalIndexDatasetsApi = async (
   datasets: LocalDiscoveryDataset[]
 ): Promise<void> => {
@@ -64,8 +70,11 @@ export const seedLocalIndexFromDdsApi = async (
 };
 
 export const harvestLocalIndexFromDcatUrlApi = async (
-  catalogueRdfUrl: string
+  catalogueRdfUrl: string,
+  options: HarvestLocalIndexOptions = {}
 ): Promise<number> => {
+  const mode = options.mode ?? "replace";
+
   let authHeaders: Record<string, string>;
   try {
     authHeaders = await oidcAuthService.getAuthorizationHeaderIfConfigured();
@@ -88,13 +97,15 @@ export const harvestLocalIndexFromDcatUrlApi = async (
     );
   }
 
-  try {
-    await clearLocalDiscoveryDatasets();
-  } catch (error) {
-    throw wrapError(
-      `Failed to clear the local discovery index before importing ${catalogueRdfUrl}: ${error instanceof Error ? error.message : String(error)}`,
-      error
-    );
+  if (mode === "replace") {
+    try {
+      await clearLocalDiscoveryDatasets();
+    } catch (error) {
+      throw wrapError(
+        `Failed to clear the local discovery index before importing ${catalogueRdfUrl}: ${error instanceof Error ? error.message : String(error)}`,
+        error
+      );
+    }
   }
 
   try {


### PR DESCRIPTION
Add support for an "append" import mode to the discovery harvest API and adjust local indexing behavior accordingly. When mode=append the harvester will add incoming datasets without clearing the existing local index; the default behavior remains replace (clear-and-reindex). Update local-index logic to honor mode semantics and expand route tests to cover append cases and response counts.

```
# append mode (don't clear local index)
npm run harvest:dcat -- --url "https://example.org/catalogue.rdf" --secret "top-secret" --append

# replace mode (clear local index first)
npm run harvest:dcat -- --url "https://example.org/catalogue.rdf" --secret "top-secret" --mode replace

```

## Summary by Sourcery

Add support for configurable harvest modes in the discovery harvest pipeline and wire them through the API, worker, and CLI tooling.

New Features:
- Introduce an optional harvest mode parameter (replace or append) for DCAT-based local index imports, defaulting to replace.
- Add CLI and worker support for selecting harvest mode via --mode/--append flags and HARVEST_MODE environment variable.

Enhancements:
- Update local index harvesting logic to conditionally clear the local index only when running in replace mode.
- Validate harvest mode values both in the HTTP API and worker configuration, returning clear errors on invalid modes.

Tests:
- Extend API, worker, and HTTP client tests to cover append mode behavior, mode propagation, and invalid mode handling.