### PR TITLE
feat(discovery): add default operators for filters in DdsDiscoveryProvider

### DIFF
--- a/src/app/api/discovery/__tests__/retrieve-filters.test.ts
+++ b/src/app/api/discovery/__tests__/retrieve-filters.test.ts
@@ -48,5 +48,6 @@ describe("Retrieving filters", () => {
     expect(response.length).toEqual(2);
     expect(response[0].key).toBe("publisherName");
     expect(response[1].key).toBe("modified");
+    expect(response[1].operators).toEqual(["=", ">", "<", ">=", "<="]);
   });
 });

--- a/src/app/api/discovery/open-api/discovery.yml
+++ b/src/app/api/discovery/open-api/discovery.yml
@@ -1038,6 +1038,12 @@ components:
           type: array
           items:
             $ref: "#/components/schemas/Operator"
+          default:
+            - "="
+            - ">"
+            - "<"
+            - ">="
+            - "<="
         entries:
           type: array
           items:

--- a/src/app/api/discovery/providers/dds-discovery-provider.ts
+++ b/src/app/api/discovery/providers/dds-discovery-provider.ts
@@ -24,6 +24,8 @@ const mapDdsFilterKeyToApp = (key: string): string =>
 const mapAppFilterKeyToDds = (key: string): string =>
   key === "publisherName" ? "publisher_name" : key;
 
+const RANGE_DEFAULT_OPERATORS = ["=", ">", "<", ">=", "<="] as const;
+
 export class DdsDiscoveryProvider implements DiscoveryProvider {
   readonly key = "dds";
 
@@ -40,6 +42,11 @@ export class DdsDiscoveryProvider implements DiscoveryProvider {
     return (response as DiscoveryFilter[]).map((filter) => ({
       ...filter,
       key: mapDdsFilterKeyToApp(filter.key),
+      operators:
+        filter.operators ??
+        (filter.type === "DATETIME" || filter.type === "NUMBER"
+          ? [...RANGE_DEFAULT_OPERATORS]
+          : undefined),
     }));
   }
 


### PR DESCRIPTION
- Updated the DdsDiscoveryProvider to include default operators for DATETIME and NUMBER filter types.
- Enhanced the OpenAPI definition to specify default operators for filters.
- Added a test case to verify the inclusion of operators in the filter response.

## Summary by Sourcery

Add default filter operators for DDS discovery responses and document them in the OpenAPI schema.

New Features:
- Populate default comparison operators for DATETIME and NUMBER filters in DDS discovery responses when operators are not provided.
- Define default operators for filter operators in the discovery OpenAPI specification so clients can rely on them.

Tests:
- Extend discovery filter retrieval tests to assert that filter operators are included in the response for range-type filters.