### PR TITLE
chore(deps): update @playwright/test and related dependencies to version 1.60.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -68,7 +68,7 @@
       },
       "devDependencies": {
         "@eslint/compat": "^2.0.2",
-        "@playwright/test": "^1.56.1",
+        "@playwright/test": "^1.60.0",
         "@tailwindcss/postcss": "^4.0.0",
         "@types/jest": "^30.0.0",
         "@types/node": "^24.10.4",
@@ -4300,11 +4300,13 @@
       }
     },
     "node_modules/@playwright/test": {
-      "version": "1.57.0",
+      "version": "1.60.0",
+      "resolved": "https://registry.npmjs.org/@playwright/test/-/test-1.60.0.tgz",
+      "integrity": "sha512-O71yZIbAh/PxDMNGns37GHBIfrVkEVyn+AXyIa5dOTfb4/xNvRWV+Vv/NMbNCtODB/pO7vLlF2OTmMVLhmr7Ag==",
       "devOptional": true,
       "license": "Apache-2.0",
       "dependencies": {
-        "playwright": "1.57.0"
+        "playwright": "1.60.0"
       },
       "bin": {
         "playwright": "cli.js"
@@ -14616,11 +14618,13 @@
       }
     },
     "node_modules/playwright": {
-      "version": "1.57.0",
+      "version": "1.60.0",
+      "resolved": "https://registry.npmjs.org/playwright/-/playwright-1.60.0.tgz",
+      "integrity": "sha512-hheHdokM8cdqCb0lcE3s+zT4t4W+vvjpGxsZlDnikarzx8tSzMebh3UiFtgqwFwnTnjYQcsyMF8ei2mCO/tpeA==",
       "devOptional": true,
       "license": "Apache-2.0",
       "dependencies": {
-        "playwright-core": "1.57.0"
+        "playwright-core": "1.60.0"
       },
       "bin": {
         "playwright": "cli.js"
@@ -14633,7 +14637,9 @@
       }
     },
     "node_modules/playwright-core": {
-      "version": "1.57.0",
+      "version": "1.60.0",
+      "resolved": "https://registry.npmjs.org/playwright-core/-/playwright-core-1.60.0.tgz",
+      "integrity": "sha512-9bW6zvX/m0lEbgTKJ6YppOKx8H3VOPBMOCFh2irXFOT4BbHgrx5hPjwJYLT40Lu+4qtD36qKc/Hn56StUW57IA==",
       "devOptional": true,
       "license": "Apache-2.0",
       "bin": {

--- a/package.json
+++ b/package.json
@@ -88,7 +88,7 @@
   },
   "devDependencies": {
     "@eslint/compat": "^2.0.2",
-    "@playwright/test": "^1.56.1",
+    "@playwright/test": "^1.60.0",
     "@tailwindcss/postcss": "^4.0.0",
     "@types/jest": "^30.0.0",
     "@types/node": "^24.10.4",


### PR DESCRIPTION
## Summary by Sourcery

Build:
- Bump @playwright/test dev dependency from 1.56.1 to 1.60.0 and refresh lockfile accordingly.