### PR TITLE
feat: add summary feature to GVariantsTable and AlleleFrequencyPage

### DIFF
--- a/src/app/allele-frequency/GVariantsTable.tsx
+++ b/src/app/allele-frequency/GVariantsTable.tsx
@@ -7,8 +7,8 @@ import {
   GVariantsSearchResponse,
   SearchedDataset,
 } from "@/app/api/discovery/open-api/schemas";
-import { COUNTRY_OPTIONS } from "@/app/api/discovery/additional-types";
 import VariantAddToBasketButton from "./components/VariantAddToBasketButton";
+import { GVariantsTableUtils } from "@/utils/GVariantsTableUtils";
 import { findDatasetByIdentifier } from "@/utils/datasetEntitlements";
 import React, { useEffect, useMemo, useState } from "react";
 
@@ -18,35 +18,13 @@ type GVariantsTableProps = {
   showSummary?: boolean;
 };
 
-type DatasetGroup = {
-  totalVariant?: GVariantsSearchResponse;
-  variants: GVariantsSearchResponse[];
-};
-
-type BeaconGroup = {
-  datasets: Record<string, DatasetGroup>;
-};
-
 type DatasetActionInfo = {
   dataset: SearchedDataset | null;
   isExternal: boolean;
   externalAccessUrl?: string;
 };
 
-const NOT_AVAILABLE = "not available";
-const COUNTRY_BY_CODE = new Map<string, string>(
-  COUNTRY_OPTIONS.map((c) => [c.value, c.label])
-);
-
-const getDisplayText = (value?: string) => value?.trim() || NOT_AVAILABLE;
-const getBeaconCountryLabel = (beaconId: string) => {
-  const parts = beaconId
-    .toUpperCase()
-    .split(/[^A-Z0-9]+/)
-    .filter(Boolean);
-  const matchedCode = parts.find((part) => COUNTRY_BY_CODE.has(part));
-  return matchedCode ? COUNTRY_BY_CODE.get(matchedCode) : undefined;
-};
+const NOT_AVAILABLE = GVariantsTableUtils.NOT_AVAILABLE;
 
 const renderCell = (value: unknown) =>
   value != null && (typeof value === "string" || typeof value === "number") ? (
@@ -54,22 +32,6 @@ const renderCell = (value: unknown) =>
   ) : (
     <span className="text-xs text-gray-400">not available</span>
   );
-
-const isNumber = (value: unknown): value is number =>
-  typeof value === "number" && Number.isFinite(value);
-
-const formatPopulationSummary = (populations: string[]) => {
-  if (populations.length === 0) {
-    return NOT_AVAILABLE;
-  }
-  if (populations.length === 1) {
-    return populations[0];
-  }
-
-  const preview = populations.slice(0, 2).join(", ");
-  const remaining = populations.length - 2;
-  return remaining > 0 ? `${preview}, +${remaining} more` : preview;
-};
 
 export default function GVariantsTable({
   results,
@@ -81,86 +43,17 @@ export default function GVariantsTable({
   >({});
 
   const sortedResults = useMemo(
-    () =>
-      [...results].sort((a, b) => {
-        const beaconComparison = getDisplayText(a.beacon).localeCompare(
-          getDisplayText(b.beacon),
-          undefined,
-          {
-            sensitivity: "base",
-            numeric: true,
-          }
-        );
-        if (beaconComparison !== 0) {
-          return beaconComparison;
-        }
-
-        const datasetComparison = getDisplayText(a.datasetId).localeCompare(
-          getDisplayText(b.datasetId),
-          undefined,
-          {
-            sensitivity: "base",
-            numeric: true,
-          }
-        );
-        if (datasetComparison !== 0) {
-          return datasetComparison;
-        }
-
-        return getDisplayText(a.population).localeCompare(
-          getDisplayText(b.population),
-          undefined,
-          {
-            sensitivity: "base",
-            numeric: true,
-          }
-        );
-      }),
+    () => GVariantsTableUtils.sortResults(results),
     [results]
   );
 
   const groupedByBeacon = useMemo(
-    () =>
-      sortedResults.reduce(
-        (acc, variant) => {
-          const datasetId = getDisplayText(variant.datasetId);
-          const beaconId = getDisplayText(variant.beacon);
-
-          if (!acc[beaconId]) {
-            acc[beaconId] = {
-              datasets: {},
-            };
-          }
-
-          if (!acc[beaconId].datasets[datasetId]) {
-            acc[beaconId].datasets[datasetId] = {
-              variants: [],
-            };
-          }
-
-          const population = getDisplayText(variant.population).toLowerCase();
-          if (population === "total") {
-            // Prefer server-provided totals row over client-side aggregation.
-            acc[beaconId].datasets[datasetId].totalVariant ??= variant;
-            return acc;
-          }
-
-          acc[beaconId].datasets[datasetId].variants.push(variant);
-          return acc;
-        },
-        {} as Record<string, BeaconGroup>
-      ),
+    () => GVariantsTableUtils.groupByBeacon(sortedResults),
     [sortedResults]
   );
 
   const beaconIds = useMemo(
-    () =>
-      Object.keys(groupedByBeacon).sort((a, b) =>
-        a.localeCompare(b, undefined, {
-          sensitivity: "base",
-          numeric: true,
-        })
-      ),
+    () => GVariantsTableUtils.getSortedBeaconIds(groupedByBeacon),
     [groupedByBeacon]
   );
 
@@ -169,60 +62,21 @@ export default function GVariantsTable({
       Object.fromEntries(
         Object.entries(datasetActions).map(([datasetId, actionInfo]) => [
           datasetId,
-          getDisplayText(actionInfo?.dataset?.datasetType),
+          GVariantsTableUtils.getDisplayText(actionInfo?.dataset?.datasetType),
         ])
       ),
     [datasetActions]
   );
 
-  const rowsForSummary = useMemo(() => {
-    const nonTotalRows = sortedResults.filter(
-      (variant) => getDisplayText(variant.population).toLowerCase() !== "total"
-    );
-    return nonTotalRows.length > 0 ? nonTotalRows : sortedResults;
-  }, [sortedResults]);
+  const rowsForSummary = useMemo(
+    () => GVariantsTableUtils.getRowsForSummary(sortedResults),
+    [sortedResults]
+  );
 
-  const summaryData = useMemo(() => {
-    if (rowsForSummary.length === 0) {
-      return null;
-    }
-
-    const populations = Array.from(
-      new Set(
-        rowsForSummary
-          .map((variant) => variant.population?.trim())
-          .filter((population): population is string => !!population)
-      )
-    ).sort((a, b) =>
-      a.localeCompare(b, undefined, { sensitivity: "base", numeric: true })
-    );
-
-    let alleleCount = 0;
-    let alleleNumber = 0;
-    let hasAlleleCount = false;
-    let hasAlleleNumber = false;
-
-    rowsForSummary.forEach((variant) => {
-      if (isNumber(variant.alleleCount)) {
-        alleleCount += variant.alleleCount;
-        hasAlleleCount = true;
-      }
-      if (isNumber(variant.alleleNumber)) {
-        alleleNumber += variant.alleleNumber;
-        hasAlleleNumber = true;
-      }
-    });
-
-    return {
-      population: formatPopulationSummary(populations),
-      alleleCount: hasAlleleCount ? alleleCount : null,
-      alleleNumber: hasAlleleNumber ? alleleNumber : null,
-      frequency:
-        hasAlleleCount && hasAlleleNumber && alleleNumber > 0
-          ? alleleCount / alleleNumber
-          : null,
-    };
-  }, [rowsForSummary]);
+  const summaryData = useMemo(
+    () => GVariantsTableUtils.buildSummaryData(rowsForSummary),
+    [rowsForSummary]
+  );
 
   const datasetGroupKeys = useMemo(
     () =>
@@ -372,7 +226,8 @@ export default function GVariantsTable({
             </thead>
             <tbody>
               {beaconIds.map((beaconId) => {
-                const beaconCountryLabel = getBeaconCountryLabel(beaconId);
+                const beaconCountryLabel =
+                  GVariantsTableUtils.getBeaconCountryLabel(beaconId);
                 const datasetIds = Object.keys(
                   groupedByBeacon[beaconId].datasets
                 ).sort((a, b) =>

--- a/src/app/allele-frequency/GVariantsTable.tsx
+++ b/src/app/allele-frequency/GVariantsTable.tsx
@@ -15,6 +15,7 @@ import React, { useEffect, useMemo, useState } from "react";
 type GVariantsTableProps = {
   results: GVariantsSearchResponse[];
   datasetActions: Record<string, DatasetActionInfo>;
+  showSummary?: boolean;
 };
 
 type DatasetGroup = {
@@ -54,9 +55,26 @@ const renderCell = (value: unknown) =>
     <span className="text-xs text-gray-400">not available</span>
   );
 
+const isNumber = (value: unknown): value is number =>
+  typeof value === "number" && Number.isFinite(value);
+
+const formatPopulationSummary = (populations: string[]) => {
+  if (populations.length === 0) {
+    return NOT_AVAILABLE;
+  }
+  if (populations.length === 1) {
+    return populations[0];
+  }
+
+  const preview = populations.slice(0, 2).join(", ");
+  const remaining = populations.length - 2;
+  return remaining > 0 ? `${preview}, +${remaining} more` : preview;
+};
+
 export default function GVariantsTable({
   results,
   datasetActions,
+  showSummary = false,
 }: GVariantsTableProps) {
   const [expandedDatasets, setExpandedDatasets] = useState<
     Record<string, boolean>
@@ -157,6 +175,55 @@ export default function GVariantsTable({
     [datasetActions]
   );
 
+  const rowsForSummary = useMemo(() => {
+    const nonTotalRows = sortedResults.filter(
+      (variant) => getDisplayText(variant.population).toLowerCase() !== "total"
+    );
+    return nonTotalRows.length > 0 ? nonTotalRows : sortedResults;
+  }, [sortedResults]);
+
+  const summaryData = useMemo(() => {
+    if (rowsForSummary.length === 0) {
+      return null;
+    }
+
+    const populations = Array.from(
+      new Set(
+        rowsForSummary
+          .map((variant) => variant.population?.trim())
+          .filter((population): population is string => !!population)
+      )
+    ).sort((a, b) =>
+      a.localeCompare(b, undefined, { sensitivity: "base", numeric: true })
+    );
+
+    let alleleCount = 0;
+    let alleleNumber = 0;
+    let hasAlleleCount = false;
+    let hasAlleleNumber = false;
+
+    rowsForSummary.forEach((variant) => {
+      if (isNumber(variant.alleleCount)) {
+        alleleCount += variant.alleleCount;
+        hasAlleleCount = true;
+      }
+      if (isNumber(variant.alleleNumber)) {
+        alleleNumber += variant.alleleNumber;
+        hasAlleleNumber = true;
+      }
+    });
+
+    return {
+      population: formatPopulationSummary(populations),
+      alleleCount: hasAlleleCount ? alleleCount : null,
+      alleleNumber: hasAlleleNumber ? alleleNumber : null,
+      frequency:
+        hasAlleleCount && hasAlleleNumber && alleleNumber > 0
+          ? alleleCount / alleleNumber
+          : null,
+    };
+  }, [rowsForSummary]);
+
   const datasetGroupKeys = useMemo(
     () =>
       beaconIds.flatMap((beaconId) =>
@@ -206,187 +273,256 @@ export default function GVariantsTable({
   };
 
   return (
-    <div className="overflow-x-auto">
-      <table className="min-w-[1100px] lg:min-w-full border border-surface shadow-lg rounded-xl overflow-hidden table-fixed text-xs sm:text-sm">
-        <thead>
-          <tr className="bg-primary text-surface">
-            <th className="px-3 py-2 text-left whitespace-nowrap">Dataset</th>
-            <th className="px-3 py-2 text-left whitespace-nowrap">
-              Dataset Type
-            </th>
-            <th className="px-3 py-2 text-left whitespace-nowrap">
-              Population
-            </th>
-            <th className="px-3 py-2 text-left whitespace-nowrap">
-              Allele Count
-            </th>
-            <th className="px-3 py-2 text-left whitespace-nowrap">
-              Allele Number
-            </th>
-            <th className="px-3 py-2 text-left whitespace-nowrap">
-              Homozygous
-            </th>
-            <th className="px-3 py-2 text-left whitespace-nowrap">
-              Heterozygous
-            </th>
-            <th className="px-3 py-2 text-left whitespace-nowrap">
-              Hemizygous
-            </th>
-            <th className="px-3 py-2 text-left whitespace-nowrap">Frequency</th>
-            <th className="px-3 py-2 text-left w-[220px] whitespace-nowrap">
-              Actions
-            </th>
-          </tr>
-        </thead>
-        <tbody>
-          {beaconIds.map((beaconId) => {
-            const beaconCountryLabel = getBeaconCountryLabel(beaconId);
-            const datasetIds = Object.keys(
-              groupedByBeacon[beaconId].datasets
-            ).sort((a, b) =>
-              a.localeCompare(b, undefined, {
-                sensitivity: "base",
-                numeric: true,
-              })
-            );
-
-            return (
-              <React.Fragment key={beaconId}>
-                <tr className="bg-[#70154C14] border border-secondary">
-                  <td
-                    colSpan={10}
-                    className="px-3 py-2 text-base sm:text-lg font-bold"
-                  >
-                    Beacon: {beaconId}
-                    {beaconCountryLabel ? ` (${beaconCountryLabel})` : ""}
+    <div className="space-y-6">
+      {showSummary && summaryData && beaconIds.length > 1 && (
+        <div>
+          <h3 className="text-base sm:text-lg font-semibold mb-2">
+            Summary for current filter
+          </h3>
+          <div className="overflow-x-auto">
+            <table className="min-w-[1100px] lg:min-w-full border border-surface shadow-lg rounded-xl overflow-hidden table-fixed text-xs sm:text-sm">
+              <thead>
+                <tr className="bg-primary text-surface">
+                  <th className="px-3 py-2 text-left whitespace-nowrap">
+                    Scope
+                  </th>
+                  <th className="px-3 py-2 text-left whitespace-nowrap">
+                    Population
+                  </th>
+                  <th className="px-3 py-2 text-left whitespace-nowrap">
+                    Allele Count
+                  </th>
+                  <th className="px-3 py-2 text-left whitespace-nowrap">
+                    Allele Number
+                  </th>
+                  <th className="px-3 py-2 text-left whitespace-nowrap">
+                    Frequency
+                  </th>
+                </tr>
+              </thead>
+              <tbody>
+                <tr className="bg-surface border border-secondary">
+                  <td className="px-3 py-2 whitespace-nowrap">
+                    All visible matching datasets
+                  </td>
+                  <td className="px-3 py-2 whitespace-nowrap">
+                    {summaryData.population}
+                  </td>
+                  <td className="px-3 py-2 whitespace-nowrap">
+                    {summaryData.alleleCount != null
+                      ? summaryData.alleleCount.toLocaleString()
+                      : renderCell(undefined)}
+                  </td>
+                  <td className="px-3 py-2 whitespace-nowrap">
+                    {summaryData.alleleNumber != null
+                      ? summaryData.alleleNumber.toLocaleString()
+                      : renderCell(undefined)}
+                  </td>
+                  <td className="px-3 py-2 whitespace-nowrap">
+                    {summaryData.frequency != null
+                      ? summaryData.frequency.toFixed(4)
+                      : renderCell(undefined)}
                   </td>
                 </tr>
-                {datasetIds.map((datasetId) => {
-                  const groupKey = `${beaconId}::${datasetId}`;
-                  const datasetGroup =
-                    groupedByBeacon[beaconId].datasets[datasetId];
-                  const isExpanded = expandedDatasets[groupKey];
-                  const actionInfo = datasetActions[datasetId];
-                  const datasetType =
-                    datasetTypeByDatasetId[datasetId] ?? NOT_AVAILABLE;
-                  const totals =
-                    datasetGroup.totalVariant ??
-                    (datasetGroup.variants.length === 1
-                      ? datasetGroup.variants[0]
-                      : undefined);
-                  const rowsToRender =
-                    datasetGroup.variants.length > 0
-                      ? datasetGroup.variants
-                      : datasetGroup.totalVariant
-                        ? [datasetGroup.totalVariant]
-                        : [];
+              </tbody>
+            </table>
+          </div>
+        </div>
+      )}
 
-                  return (
-                    <React.Fragment key={groupKey}>
-                      <tr className="bg-surface border border-secondary">
-                        <td className="px-3 py-2 whitespace-nowrap">
-                          <button
-                            onClick={() => toggleDatasetExpansion(groupKey)}
-                            className="mr-2 font-semibold"
-                            aria-label={`Toggle dataset group ${datasetId}`}
-                          >
-                            {isExpanded ? "▼" : "▶"}
-                          </button>
-                          <button
-                            onClick={() => handleDatasetClick(datasetId)}
-                            disabled={datasetId === NOT_AVAILABLE}
-                            className={`underline transition-colors break-all ${
-                              datasetId !== NOT_AVAILABLE
-                                ? "text-primary hover:text-secondary hover:no-underline cursor-pointer"
-                                : "text-gray-400 cursor-not-allowed opacity-50"
-                            }`}
-                          >
-                            {datasetId}
-                          </button>
-                        </td>
-                        <td className="px-3 py-2 whitespace-nowrap">
-                          {datasetType}
-                        </td>
-                        <td className="px-3 py-2 whitespace-nowrap" />
-                        <td className="px-3 py-2 whitespace-nowrap">
-                          {renderCell(totals?.alleleCount)}
-                        </td>
-                        <td className="px-3 py-2 whitespace-nowrap">
-                          {renderCell(totals?.alleleNumber)}
-                        </td>
-                        <td className="px-3 py-2 whitespace-nowrap">
-                          {renderCell(totals?.alleleCountHomozygous)}
-                        </td>
-                        <td className="px-3 py-2 whitespace-nowrap">
-                          {renderCell(totals?.alleleCountHeterozygous)}
-                        </td>
-                        <td className="px-3 py-2 whitespace-nowrap">
-                          {renderCell(totals?.alleleCountHemizygous)}
-                        </td>
-                        <td className="px-3 py-2 whitespace-nowrap">
-                          {typeof totals?.alleleFrequency === "number"
-                            ? totals.alleleFrequency.toFixed(4)
-                            : renderCell(undefined)}
-                        </td>
-                        <td className="px-3 py-2 w-[220px] whitespace-nowrap">
-                          <div className="w-[220px]">
-                            <VariantAddToBasketButton
-                              datasetId={
-                                datasetId === NOT_AVAILABLE ? "" : datasetId
-                              }
-                              dataset={actionInfo?.dataset ?? null}
-                              isExternal={actionInfo?.isExternal ?? false}
-                              externalAccessUrl={actionInfo?.externalAccessUrl}
-                              disabled={
-                                datasetId === NOT_AVAILABLE ||
-                                (datasetId !== NOT_AVAILABLE && !actionInfo)
-                              }
-                            />
-                          </div>
-                        </td>
-                      </tr>
-                      {isExpanded &&
-                        rowsToRender.map((variant, index) => (
-                          <tr
-                            key={`${groupKey}-${index}`}
-                            className="border-t border-surface bg-[#70154C14]"
-                          >
+      <div>
+        <h3 className="text-base sm:text-lg font-semibold mb-2">
+          Detailed results
+        </h3>
+        <div className="overflow-x-auto">
+          <table className="min-w-[1100px] lg:min-w-full border border-surface shadow-lg rounded-xl overflow-hidden table-fixed text-xs sm:text-sm">
+            <thead>
+              <tr className="bg-primary text-surface">
+                <th className="px-3 py-2 text-left whitespace-nowrap">
+                  Dataset
+                </th>
+                <th className="px-3 py-2 text-left whitespace-nowrap">
+                  Dataset Type
+                </th>
+                <th className="px-3 py-2 text-left whitespace-nowrap">
+                  Population
+                </th>
+                <th className="px-3 py-2 text-left whitespace-nowrap">
+                  Allele Count
+                </th>
+                <th className="px-3 py-2 text-left whitespace-nowrap">
+                  Allele Number
+                </th>
+                <th className="px-3 py-2 text-left whitespace-nowrap">
+                  Homozygous
+                </th>
+                <th className="px-3 py-2 text-left whitespace-nowrap">
+                  Heterozygous
+                </th>
+                <th className="px-3 py-2 text-left whitespace-nowrap">
+                  Hemizygous
+                </th>
+                <th className="px-3 py-2 text-left whitespace-nowrap">
+                  Frequency
+                </th>
+                <th className="px-3 py-2 text-left w-[220px] whitespace-nowrap">
+                  Actions
+                </th>
+              </tr>
+            </thead>
+            <tbody>
+              {beaconIds.map((beaconId) => {
+                const beaconCountryLabel = getBeaconCountryLabel(beaconId);
+                const datasetIds = Object.keys(
+                  groupedByBeacon[beaconId].datasets
+                ).sort((a, b) =>
+                  a.localeCompare(b, undefined, {
+                    sensitivity: "base",
+                    numeric: true,
+                  })
+                );
+
+                return (
+                  <React.Fragment key={beaconId}>
+                    <tr className="bg-[#70154C14] border border-secondary">
+                      <td
+                        colSpan={10}
+                        className="px-3 py-2 text-base sm:text-lg font-bold"
+                      >
+                        Beacon: {beaconId}
+                        {beaconCountryLabel ? ` (${beaconCountryLabel})` : ""}
+                      </td>
+                    </tr>
+                    {datasetIds.map((datasetId) => {
+                      const groupKey = `${beaconId}::${datasetId}`;
+                      const datasetGroup =
+                        groupedByBeacon[beaconId].datasets[datasetId];
+                      const isExpanded = expandedDatasets[groupKey];
+                      const actionInfo = datasetActions[datasetId];
+                      const datasetType =
+                        datasetTypeByDatasetId[datasetId] ?? NOT_AVAILABLE;
+                      const totals =
+                        datasetGroup.totalVariant ??
+                        (datasetGroup.variants.length === 1
+                          ? datasetGroup.variants[0]
+                          : undefined);
+                      const rowsToRender =
+                        datasetGroup.variants.length > 0
+                          ? datasetGroup.variants
+                          : datasetGroup.totalVariant
+                            ? [datasetGroup.totalVariant]
+                            : [];
+
+                      return (
+                        <React.Fragment key={groupKey}>
+                          <tr className="bg-surface border border-secondary">
+                            <td className="px-3 py-2 whitespace-nowrap">
+                              <button
+                                onClick={() => toggleDatasetExpansion(groupKey)}
+                                className="mr-2 font-semibold"
+                                aria-label={`Toggle dataset group ${datasetId}`}
+                              >
+                                {isExpanded ? "▼" : "▶"}
+                              </button>
+                              <button
+                                onClick={() => handleDatasetClick(datasetId)}
+                                disabled={datasetId === NOT_AVAILABLE}
+                                className={`underline transition-colors break-all ${
+                                  datasetId !== NOT_AVAILABLE
+                                    ? "text-primary hover:text-secondary hover:no-underline cursor-pointer"
+                                    : "text-gray-400 cursor-not-allowed opacity-50"
+                                }`}
+                              >
+                                {datasetId}
+                              </button>
+                            </td>
+                            <td className="px-3 py-2 whitespace-nowrap">
+                              {datasetType}
+                            </td>
                             <td className="px-3 py-2 whitespace-nowrap" />
-                            <td className="px-3 py-2 whitespace-nowrap" />
                             <td className="px-3 py-2 whitespace-nowrap">
-                              {variant.population || "-"}
+                              {renderCell(totals?.alleleCount)}
                             </td>
                             <td className="px-3 py-2 whitespace-nowrap">
-                              {renderCell(variant.alleleCount)}
+                              {renderCell(totals?.alleleNumber)}
                             </td>
                             <td className="px-3 py-2 whitespace-nowrap">
-                              {renderCell(variant.alleleNumber)}
+                              {renderCell(totals?.alleleCountHomozygous)}
                             </td>
                             <td className="px-3 py-2 whitespace-nowrap">
-                              {renderCell(variant.alleleCountHomozygous)}
+                              {renderCell(totals?.alleleCountHeterozygous)}
                             </td>
                             <td className="px-3 py-2 whitespace-nowrap">
-                              {renderCell(variant.alleleCountHeterozygous)}
+                              {renderCell(totals?.alleleCountHemizygous)}
                             </td>
                             <td className="px-3 py-2 whitespace-nowrap">
-                              {renderCell(variant.alleleCountHemizygous)}
-                            </td>
-                            <td className="px-3 py-2 whitespace-nowrap">
-                              {variant.alleleFrequency != null
-                                ? variant.alleleFrequency.toFixed(4)
+                              {typeof totals?.alleleFrequency === "number"
+                                ? totals.alleleFrequency.toFixed(4)
                                 : renderCell(undefined)}
                             </td>
-                            <td className="px-3 py-2 w-[220px] whitespace-nowrap" />
+                            <td className="px-3 py-2 w-[220px] whitespace-nowrap">
+                              <div className="w-[220px]">
+                                <VariantAddToBasketButton
+                                  datasetId={
+                                    datasetId === NOT_AVAILABLE ? "" : datasetId
+                                  }
+                                  dataset={actionInfo?.dataset ?? null}
+                                  isExternal={actionInfo?.isExternal ?? false}
+                                  externalAccessUrl={
+                                    actionInfo?.externalAccessUrl
+                                  }
+                                  disabled={
+                                    datasetId === NOT_AVAILABLE ||
+                                    (datasetId !== NOT_AVAILABLE && !actionInfo)
+                                  }
+                                />
+                              </div>
+                            </td>
                           </tr>
-                        ))}
-                    </React.Fragment>
-                  );
-                })}
-              </React.Fragment>
-            );
-          })}
-        </tbody>
-      </table>
+                          {isExpanded &&
+                            rowsToRender.map((variant, index) => (
+                              <tr
+                                key={`${groupKey}-${index}`}
+                                className="border-t border-surface bg-[#70154C14]"
+                              >
+                                <td className="px-3 py-2 whitespace-nowrap" />
+                                <td className="px-3 py-2 whitespace-nowrap" />
+                                <td className="px-3 py-2 whitespace-nowrap">
+                                  {variant.population || "-"}
+                                </td>
+                                <td className="px-3 py-2 whitespace-nowrap">
+                                  {renderCell(variant.alleleCount)}
+                                </td>
+                                <td className="px-3 py-2 whitespace-nowrap">
+                                  {renderCell(variant.alleleNumber)}
+                                </td>
+                                <td className="px-3 py-2 whitespace-nowrap">
+                                  {renderCell(variant.alleleCountHomozygous)}
+                                </td>
+                                <td className="px-3 py-2 whitespace-nowrap">
+                                  {renderCell(variant.alleleCountHeterozygous)}
+                                </td>
+                                <td className="px-3 py-2 whitespace-nowrap">
+                                  {renderCell(variant.alleleCountHemizygous)}
+                                </td>
+                                <td className="px-3 py-2 whitespace-nowrap">
+                                  {variant.alleleFrequency != null
+                                    ? variant.alleleFrequency.toFixed(4)
+                                    : renderCell(undefined)}
+                                </td>
+                                <td className="px-3 py-2 w-[220px] whitespace-nowrap" />
+                              </tr>
+                            ))}
+                        </React.Fragment>
+                      );
+                    })}
+                  </React.Fragment>
+                );
+              })}
+            </tbody>
+          </table>
+        </div>
+      </div>
     </div>
   );
 }

--- a/src/app/allele-frequency/page.tsx
+++ b/src/app/allele-frequency/page.tsx
@@ -44,6 +44,7 @@ export default function AlleleFrequencyPage({
   searchParams,
 }: AlleleFrequencyPageProps) {
   const [results, setResults] = useState<GVariantsSearchResponse[]>([]);
+  const [showSummary, setShowSummary] = useState(false);
   const [datasetActions, setDatasetActions] = useState<
     Record<string, DatasetActionInfo>
   >({});
@@ -202,10 +203,14 @@ export default function AlleleFrequencyPage({
   const handleSearch = async (props: SearchInputData) => {
     setLoading(true);
     setResults([]);
+    setShowSummary(false);
     setDatasetActions({});
     setError(null);
 
     try {
+      const hasSpecificFilterSelected =
+        (!!props.sex && props.sex !== "All") ||
+        (!!props.countryOfBirth && props.countryOfBirth !== "All");
       const params: {
         referenceName?: string;
         start?: number[];
@@ -228,6 +233,7 @@ export default function AlleleFrequencyPage({
           props.datasetType
         );
         setResults(filteredResponse);
+        setShowSummary(hasSpecificFilterSelected);
         setDatasetActions(actions);
         setTriedSearching(true);
         return;
@@ -271,6 +277,7 @@ export default function AlleleFrequencyPage({
         props.datasetType
       );
       setResults(filteredResponse);
+      setShowSummary(hasSpecificFilterSelected);
       setDatasetActions(actions);
       setTriedSearching(true);
     } catch (error) {
@@ -326,7 +333,11 @@ export default function AlleleFrequencyPage({
       )}
 
       {!loading && results.length > 0 && (
-        <GVariantsTable results={results} datasetActions={datasetActions} />
+        <GVariantsTable
+          results={results}
+          datasetActions={datasetActions}
+          showSummary={showSummary}
+        />
       )}
     </PageContainer>
   );

--- a/src/utils/GVariantsTableUtils.ts
+++ b/src/utils/GVariantsTableUtils.ts
@@ -1,0 +1,200 @@
+// SPDX-FileCopyrightText: 2026 PNED G.I.E.
+//
+// SPDX-License-Identifier: Apache-2.0
+import { COUNTRY_OPTIONS } from "@/app/api/discovery/additional-types";
+import { GVariantsSearchResponse } from "@/app/api/discovery/open-api/schemas";
+
+export type DatasetGroup = {
+  totalVariant?: GVariantsSearchResponse;
+  variants: GVariantsSearchResponse[];
+};
+
+export type BeaconGroup = {
+  datasets: Record<string, DatasetGroup>;
+};
+
+export type GVariantSummaryData = {
+  population: string;
+  alleleCount: number | null;
+  alleleNumber: number | null;
+  frequency: number | null;
+};
+
+export class GVariantsTableUtils {
+  static readonly NOT_AVAILABLE = "not available";
+
+  private static readonly COUNTRY_BY_CODE = new Map<string, string>(
+    COUNTRY_OPTIONS.map((country) => [country.value, country.label])
+  );
+
+  static getDisplayText(value?: string): string {
+    return value?.trim() || GVariantsTableUtils.NOT_AVAILABLE;
+  }
+
+  static getBeaconCountryLabel(beaconId: string): string | undefined {
+    const parts = beaconId
+      .toUpperCase()
+      .split(/[^A-Z0-9]+/)
+      .filter(Boolean);
+    const matchedCode = parts.find((part) =>
+      GVariantsTableUtils.COUNTRY_BY_CODE.has(part)
+    );
+    return matchedCode
+      ? GVariantsTableUtils.COUNTRY_BY_CODE.get(matchedCode)
+      : undefined;
+  }
+
+  static sortResults(
+    results: GVariantsSearchResponse[]
+  ): GVariantsSearchResponse[] {
+    return [...results].sort((a, b) => {
+      const beaconComparison = GVariantsTableUtils.getDisplayText(
+        a.beacon
+      ).localeCompare(GVariantsTableUtils.getDisplayText(b.beacon), undefined, {
+        sensitivity: "base",
+        numeric: true,
+      });
+      if (beaconComparison !== 0) {
+        return beaconComparison;
+      }
+
+      const datasetComparison = GVariantsTableUtils.getDisplayText(
+        a.datasetId
+      ).localeCompare(
+        GVariantsTableUtils.getDisplayText(b.datasetId),
+        undefined,
+        {
+          sensitivity: "base",
+          numeric: true,
+        }
+      );
+      if (datasetComparison !== 0) {
+        return datasetComparison;
+      }
+
+      return GVariantsTableUtils.getDisplayText(a.population).localeCompare(
+        GVariantsTableUtils.getDisplayText(b.population),
+        undefined,
+        {
+          sensitivity: "base",
+          numeric: true,
+        }
+      );
+    });
+  }
+
+  static groupByBeacon(
+    sortedResults: GVariantsSearchResponse[]
+  ): Record<string, BeaconGroup> {
+    return sortedResults.reduce(
+      (acc, variant) => {
+        const datasetId = GVariantsTableUtils.getDisplayText(variant.datasetId);
+        const beaconId = GVariantsTableUtils.getDisplayText(variant.beacon);
+
+        if (!acc[beaconId]) {
+          acc[beaconId] = {
+            datasets: {},
+          };
+        }
+
+        if (!acc[beaconId].datasets[datasetId]) {
+          acc[beaconId].datasets[datasetId] = {
+            variants: [],
+          };
+        }
+
+        const population = GVariantsTableUtils.getDisplayText(
+          variant.population
+        ).toLowerCase();
+        if (population === "total") {
+          acc[beaconId].datasets[datasetId].totalVariant ??= variant;
+          return acc;
+        }
+
+        acc[beaconId].datasets[datasetId].variants.push(variant);
+        return acc;
+      },
+      {} as Record<string, BeaconGroup>
+    );
+  }
+
+  static getSortedBeaconIds(groupedByBeacon: Record<string, BeaconGroup>) {
+    return Object.keys(groupedByBeacon).sort((a, b) =>
+      a.localeCompare(b, undefined, {
+        sensitivity: "base",
+        numeric: true,
+      })
+    );
+  }
+
+  static getRowsForSummary(
+    sortedResults: GVariantsSearchResponse[]
+  ): GVariantsSearchResponse[] {
+    return sortedResults.filter(
+      (variant) =>
+        GVariantsTableUtils.getDisplayText(variant.population).toLowerCase() !==
+        "total"
+    );
+  }
+
+  static buildSummaryData(
+    rowsForSummary: GVariantsSearchResponse[]
+  ): GVariantSummaryData | null {
+    if (rowsForSummary.length === 0) {
+      return null;
+    }
+
+    const populations = Array.from(
+      new Set(
+        rowsForSummary
+          .map((variant) => variant.population?.trim())
+          .filter((population): population is string => !!population)
+      )
+    ).sort((a, b) =>
+      a.localeCompare(b, undefined, { sensitivity: "base", numeric: true })
+    );
+
+    let alleleCount = 0;
+    let alleleNumber = 0;
+    let hasAlleleCount = false;
+    let hasAlleleNumber = false;
+
+    rowsForSummary.forEach((variant) => {
+      if (GVariantsTableUtils.isNumber(variant.alleleCount)) {
+        alleleCount += variant.alleleCount;
+        hasAlleleCount = true;
+      }
+      if (GVariantsTableUtils.isNumber(variant.alleleNumber)) {
+        alleleNumber += variant.alleleNumber;
+        hasAlleleNumber = true;
+      }
+    });
+
+    return {
+      population: GVariantsTableUtils.formatPopulationSummary(populations),
+      alleleCount: hasAlleleCount ? alleleCount : null,
+      alleleNumber: hasAlleleNumber ? alleleNumber : null,
+      frequency:
+        hasAlleleCount && hasAlleleNumber && alleleNumber > 0
+          ? alleleCount / alleleNumber
+          : null,
+    };
+  }
+
+  private static isNumber(value: unknown): value is number {
+    return typeof value === "number" && Number.isFinite(value);
+  }
+
+  private static formatPopulationSummary(populations: string[]): string {
+    if (populations.length === 0) {
+      return GVariantsTableUtils.NOT_AVAILABLE;
+    }
+    if (populations.length === 1) {
+      return populations[0];
+    }
+
+    const preview = populations.slice(0, 2).join(", ");
+    const remaining = populations.length - 2;
+    return remaining > 0 ? `${preview}, +${remaining} more` : preview;
+  }
+}


### PR DESCRIPTION
- Introduced a `showSummary` prop in `GVariantsTable` to conditionally render a summary of allele counts and frequencies.
- Updated `AlleleFrequencyPage` to manage the `showSummary` state based on selected filters, enhancing user experience by providing relevant summary data when applicable.

<img width="1523" height="936" alt="Screenshot 2026-06-08 at 11 01 43" src="https://github.com/user-attachments/assets/f977843a-d9b0-4d4a-8a7a-d2394a978b44" />
<img width="1438" height="1268" alt="Screenshot 2026-06-08 at 11 02 24" src="https://github.com/user-attachments/assets/a0446076-53fb-4232-8792-26d2f223ca5a" />

## Summary by Sourcery

Add an optional summary view of allele counts and frequencies to the allele frequency results table and wire it up from the AlleleFrequencyPage based on specific filter selections.

New Features:
- Introduce a showSummary prop on GVariantsTable to optionally render an aggregate summary of allele counts, numbers, and frequencies across visible datasets.
- Add a summary section above detailed results in the allele frequency table when multiple beacons are visible.
- Toggle summary visibility in AlleleFrequencyPage depending on whether specific demographic filters (such as sex or country of birth) are applied.