### PR TITLE
feat: add locale-prefixed i18n with next-intl

### DIFF
--- a/next.config.mjs
+++ b/next.config.mjs
@@ -1,6 +1,8 @@
 // SPDX-FileCopyrightText: 2025 PNED G.I.E.
 //
 // SPDX-License-Identifier: Apache-2.0
+import createNextIntlPlugin from "next-intl/plugin";
+
 /** @type {import('next').NextConfig} */
 
 const nextConfig = {
@@ -49,4 +51,6 @@ const nextConfig = {
   },
 };
 
-export default nextConfig;
+const withNextIntl = createNextIntlPlugin("./src/i18n/request.ts");
+
+export default withNextIntl(nextConfig);

--- a/package-lock.json
+++ b/package-lock.json
@@ -45,6 +45,7 @@
         "jwt-decode": "^4.0.0",
         "next": "16.2.9",
         "next-auth": "^4.24.12",
+        "next-intl": "^4.13.0",
         "next-runtime-env": "^3.3.0",
         "node-cron": "^4.2.1",
         "node-mocks-http": "^1.17.2",
@@ -1509,6 +1510,36 @@
     "node_modules/@floating-ui/utils": {
       "version": "0.2.10",
       "license": "MIT"
+    },
+    "node_modules/@formatjs/fast-memoize": {
+      "version": "3.1.6",
+      "resolved": "https://registry.npmjs.org/@formatjs/fast-memoize/-/fast-memoize-3.1.6.tgz",
+      "integrity": "sha512-H5aexk1Le7T9TPmscacZ+1pR6CTa2n1wq+HDVGXhH8TzUlQQpeXzZs91dRtmFHrbeNbjPFPfQujUqm7MHgVoXQ==",
+      "license": "MIT"
+    },
+    "node_modules/@formatjs/icu-messageformat-parser": {
+      "version": "3.5.11",
+      "resolved": "https://registry.npmjs.org/@formatjs/icu-messageformat-parser/-/icu-messageformat-parser-3.5.11.tgz",
+      "integrity": "sha512-NVsuNsc2dUVG9+4HBJ/srScxtA/18LqGgwtop/tuN/OIBjVl6QA+0KhfZQddDD9sEh2LeVjLFPGVU3ixa3blcA==",
+      "license": "MIT",
+      "dependencies": {
+        "@formatjs/icu-skeleton-parser": "2.1.10"
+      }
+    },
+    "node_modules/@formatjs/icu-skeleton-parser": {
+      "version": "2.1.10",
+      "resolved": "https://registry.npmjs.org/@formatjs/icu-skeleton-parser/-/icu-skeleton-parser-2.1.10.tgz",
+      "integrity": "sha512-XuSva+8ZGawk8VnD5VD6UeH8KarQ/Z022zgjHDoHmlNiAewstXuuzXc0Hk5pGFSdG+nNw5bfJKXqj1ZXHn9yUA==",
+      "license": "MIT"
+    },
+    "node_modules/@formatjs/intl-localematcher": {
+      "version": "0.8.10",
+      "resolved": "https://registry.npmjs.org/@formatjs/intl-localematcher/-/intl-localematcher-0.8.10.tgz",
+      "integrity": "sha512-P/IC3qws3jH+1fEs+o0RIFgXKRaQlFehjS5W0FPAqdo6hgzawLl+eD0q0JjheQ3XtoOe5n8WSYfX06KQZI/QJA==",
+      "license": "MIT",
+      "dependencies": {
+        "@formatjs/fast-memoize": "3.1.6"
+      }
     },
     "node_modules/@fortawesome/fontawesome-common-types": {
       "version": "7.1.0",
@@ -6411,6 +6442,313 @@
         "url": "https://github.com/sponsors/panva"
       }
     },
+    "node_modules/@parcel/watcher": {
+      "version": "2.5.6",
+      "resolved": "https://registry.npmjs.org/@parcel/watcher/-/watcher-2.5.6.tgz",
+      "integrity": "sha512-tmmZ3lQxAe/k/+rNnXQRawJ4NjxO2hqiOLTHvWchtGZULp4RyFeh6aU4XdOYBFe2KE1oShQTv4AblOs2iOrNnQ==",
+      "hasInstallScript": true,
+      "license": "MIT",
+      "dependencies": {
+        "detect-libc": "^2.0.3",
+        "is-glob": "^4.0.3",
+        "node-addon-api": "^7.0.0",
+        "picomatch": "^4.0.3"
+      },
+      "engines": {
+        "node": ">= 10.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      },
+      "optionalDependencies": {
+        "@parcel/watcher-android-arm64": "2.5.6",
+        "@parcel/watcher-darwin-arm64": "2.5.6",
+        "@parcel/watcher-darwin-x64": "2.5.6",
+        "@parcel/watcher-freebsd-x64": "2.5.6",
+        "@parcel/watcher-linux-arm-glibc": "2.5.6",
+        "@parcel/watcher-linux-arm-musl": "2.5.6",
+        "@parcel/watcher-linux-arm64-glibc": "2.5.6",
+        "@parcel/watcher-linux-arm64-musl": "2.5.6",
+        "@parcel/watcher-linux-x64-glibc": "2.5.6",
+        "@parcel/watcher-linux-x64-musl": "2.5.6",
+        "@parcel/watcher-win32-arm64": "2.5.6",
+        "@parcel/watcher-win32-ia32": "2.5.6",
+        "@parcel/watcher-win32-x64": "2.5.6"
+      }
+    },
+    "node_modules/@parcel/watcher-android-arm64": {
+      "version": "2.5.6",
+      "resolved": "https://registry.npmjs.org/@parcel/watcher-android-arm64/-/watcher-android-arm64-2.5.6.tgz",
+      "integrity": "sha512-YQxSS34tPF/6ZG7r/Ih9xy+kP/WwediEUsqmtf0cuCV5TPPKw/PQHRhueUo6JdeFJaqV3pyjm0GdYjZotbRt/A==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">= 10.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/@parcel/watcher-darwin-arm64": {
+      "version": "2.5.6",
+      "resolved": "https://registry.npmjs.org/@parcel/watcher-darwin-arm64/-/watcher-darwin-arm64-2.5.6.tgz",
+      "integrity": "sha512-Z2ZdrnwyXvvvdtRHLmM4knydIdU9adO3D4n/0cVipF3rRiwP+3/sfzpAwA/qKFL6i1ModaabkU7IbpeMBgiVEA==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">= 10.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/@parcel/watcher-darwin-x64": {
+      "version": "2.5.6",
+      "resolved": "https://registry.npmjs.org/@parcel/watcher-darwin-x64/-/watcher-darwin-x64-2.5.6.tgz",
+      "integrity": "sha512-HgvOf3W9dhithcwOWX9uDZyn1lW9R+7tPZ4sug+NGrGIo4Rk1hAXLEbcH1TQSqxts0NYXXlOWqVpvS1SFS4fRg==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">= 10.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/@parcel/watcher-freebsd-x64": {
+      "version": "2.5.6",
+      "resolved": "https://registry.npmjs.org/@parcel/watcher-freebsd-x64/-/watcher-freebsd-x64-2.5.6.tgz",
+      "integrity": "sha512-vJVi8yd/qzJxEKHkeemh7w3YAn6RJCtYlE4HPMoVnCpIXEzSrxErBW5SJBgKLbXU3WdIpkjBTeUNtyBVn8TRng==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">= 10.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/@parcel/watcher-linux-arm-glibc": {
+      "version": "2.5.6",
+      "resolved": "https://registry.npmjs.org/@parcel/watcher-linux-arm-glibc/-/watcher-linux-arm-glibc-2.5.6.tgz",
+      "integrity": "sha512-9JiYfB6h6BgV50CCfasfLf/uvOcJskMSwcdH1PHH9rvS1IrNy8zad6IUVPVUfmXr+u+Km9IxcfMLzgdOudz9EQ==",
+      "cpu": [
+        "arm"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 10.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/@parcel/watcher-linux-arm-musl": {
+      "version": "2.5.6",
+      "resolved": "https://registry.npmjs.org/@parcel/watcher-linux-arm-musl/-/watcher-linux-arm-musl-2.5.6.tgz",
+      "integrity": "sha512-Ve3gUCG57nuUUSyjBq/MAM0CzArtuIOxsBdQ+ftz6ho8n7s1i9E1Nmk/xmP323r2YL0SONs1EuwqBp2u1k5fxg==",
+      "cpu": [
+        "arm"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 10.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/@parcel/watcher-linux-arm64-glibc": {
+      "version": "2.5.6",
+      "resolved": "https://registry.npmjs.org/@parcel/watcher-linux-arm64-glibc/-/watcher-linux-arm64-glibc-2.5.6.tgz",
+      "integrity": "sha512-f2g/DT3NhGPdBmMWYoxixqYr3v/UXcmLOYy16Bx0TM20Tchduwr4EaCbmxh1321TABqPGDpS8D/ggOTaljijOA==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 10.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/@parcel/watcher-linux-arm64-musl": {
+      "version": "2.5.6",
+      "resolved": "https://registry.npmjs.org/@parcel/watcher-linux-arm64-musl/-/watcher-linux-arm64-musl-2.5.6.tgz",
+      "integrity": "sha512-qb6naMDGlbCwdhLj6hgoVKJl2odL34z2sqkC7Z6kzir8b5W65WYDpLB6R06KabvZdgoHI/zxke4b3zR0wAbDTA==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 10.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/@parcel/watcher-linux-x64-glibc": {
+      "version": "2.5.6",
+      "resolved": "https://registry.npmjs.org/@parcel/watcher-linux-x64-glibc/-/watcher-linux-x64-glibc-2.5.6.tgz",
+      "integrity": "sha512-kbT5wvNQlx7NaGjzPFu8nVIW1rWqV780O7ZtkjuWaPUgpv2NMFpjYERVi0UYj1msZNyCzGlaCWEtzc+exjMGbQ==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 10.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/@parcel/watcher-linux-x64-musl": {
+      "version": "2.5.6",
+      "resolved": "https://registry.npmjs.org/@parcel/watcher-linux-x64-musl/-/watcher-linux-x64-musl-2.5.6.tgz",
+      "integrity": "sha512-1JRFeC+h7RdXwldHzTsmdtYR/Ku8SylLgTU/reMuqdVD7CtLwf0VR1FqeprZ0eHQkO0vqsbvFLXUmYm/uNKJBg==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 10.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/@parcel/watcher-win32-arm64": {
+      "version": "2.5.6",
+      "resolved": "https://registry.npmjs.org/@parcel/watcher-win32-arm64/-/watcher-win32-arm64-2.5.6.tgz",
+      "integrity": "sha512-3ukyebjc6eGlw9yRt678DxVF7rjXatWiHvTXqphZLvo7aC5NdEgFufVwjFfY51ijYEWpXbqF5jtrK275z52D4Q==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">= 10.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/@parcel/watcher-win32-ia32": {
+      "version": "2.5.6",
+      "resolved": "https://registry.npmjs.org/@parcel/watcher-win32-ia32/-/watcher-win32-ia32-2.5.6.tgz",
+      "integrity": "sha512-k35yLp1ZMwwee3Ez/pxBi5cf4AoBKYXj00CZ80jUz5h8prpiaQsiRPKQMxoLstNuqe2vR4RNPEAEcjEFzhEz/g==",
+      "cpu": [
+        "ia32"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">= 10.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/@parcel/watcher-win32-x64": {
+      "version": "2.5.6",
+      "resolved": "https://registry.npmjs.org/@parcel/watcher-win32-x64/-/watcher-win32-x64-2.5.6.tgz",
+      "integrity": "sha512-hbQlYcCq5dlAX9Qx+kFb0FHue6vbjlf0FrNzSKdYK2APUf7tGfGxQCk2ihEREmbR6ZMc0MVAD5RIX/41gpUzTw==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">= 10.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/@parcel/watcher/node_modules/picomatch": {
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.4.tgz",
+      "integrity": "sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/jonschlinkert"
+      }
+    },
     "node_modules/@pkgjs/parseargs": {
       "version": "0.11.0",
       "dev": true,
@@ -7380,6 +7718,12 @@
         "node": ">=v12.22.12"
       }
     },
+    "node_modules/@schummar/icu-type-parser": {
+      "version": "1.21.5",
+      "resolved": "https://registry.npmjs.org/@schummar/icu-type-parser/-/icu-type-parser-1.21.5.tgz",
+      "integrity": "sha512-bXHSaW5jRTmke9Vd0h5P7BtWZG9Znqb8gSDxZnxaGSJnGwPLDPfS+3g0BKzeWqzgZPsIVZkM7m2tbo18cm5HBw==",
+      "license": "MIT"
+    },
     "node_modules/@sinclair/typebox": {
       "version": "0.34.47",
       "dev": true,
@@ -7401,6 +7745,198 @@
         "@sinonjs/commons": "^3.0.1"
       }
     },
+    "node_modules/@swc/core-darwin-arm64": {
+      "version": "1.15.41",
+      "resolved": "https://registry.npmjs.org/@swc/core-darwin-arm64/-/core-darwin-arm64-1.15.41.tgz",
+      "integrity": "sha512-kREh6J5paQFvP3i7f/4FbqRNOJREutVFVOkder4GVyCBQ39YmER55cW/y1NNjwrchzFqgYswFn0mMDCqbqKzrw==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "Apache-2.0 AND MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/@swc/core-darwin-x64": {
+      "version": "1.15.41",
+      "resolved": "https://registry.npmjs.org/@swc/core-darwin-x64/-/core-darwin-x64-1.15.41.tgz",
+      "integrity": "sha512-N8B56ESFazZAWZyIkecADSPCwlLEinW7QLMEeotCpv4J7VXwfH+OLkmRL8o96UZ+1355fwHxDTS6/wK7yucvkA==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "Apache-2.0 AND MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/@swc/core-linux-arm-gnueabihf": {
+      "version": "1.15.41",
+      "resolved": "https://registry.npmjs.org/@swc/core-linux-arm-gnueabihf/-/core-linux-arm-gnueabihf-1.15.41.tgz",
+      "integrity": "sha512-6XrId2fyle0mS5xxON8rU84mPd2Cq1kDJRj+4BnQKTd7u+2kSA6Ww+JkOP0iTNqOqt9OXhPOEAjBHAuonWcdCg==",
+      "cpu": [
+        "arm"
+      ],
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/@swc/core-linux-arm64-gnu": {
+      "version": "1.15.41",
+      "resolved": "https://registry.npmjs.org/@swc/core-linux-arm64-gnu/-/core-linux-arm64-gnu-1.15.41.tgz",
+      "integrity": "sha512-ynLIarxlkVnqHn1D0fKOVht6mNU5ks6lrH+MY3kkS+XFaGGgDxFZVjWKJlkYTKm3RCvBTfA8Ng5fLufXheMRKQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "Apache-2.0 AND MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/@swc/core-linux-arm64-musl": {
+      "version": "1.15.41",
+      "resolved": "https://registry.npmjs.org/@swc/core-linux-arm64-musl/-/core-linux-arm64-musl-1.15.41.tgz",
+      "integrity": "sha512-dXu/5vd4gh8symyhRF+4G7gOPkjmb4pONhh7sl+6GSiW0LOKZlfu5kXmyFbTz9smOT7jgr002qY9b1nujjXt2A==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "Apache-2.0 AND MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/@swc/core-linux-ppc64-gnu": {
+      "version": "1.15.41",
+      "resolved": "https://registry.npmjs.org/@swc/core-linux-ppc64-gnu/-/core-linux-ppc64-gnu-1.15.41.tgz",
+      "integrity": "sha512-XGO6zVPXoPE0gf/XnI4jBbafNT13AYgoh6ns0JCSdOetI/kqVf0vhpz7NuNgAzZrMVCsmieqjPoTwViDgh4mOQ==",
+      "cpu": [
+        "ppc64"
+      ],
+      "license": "Apache-2.0 AND MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/@swc/core-linux-s390x-gnu": {
+      "version": "1.15.41",
+      "resolved": "https://registry.npmjs.org/@swc/core-linux-s390x-gnu/-/core-linux-s390x-gnu-1.15.41.tgz",
+      "integrity": "sha512-0WUglRwyZtW+iMi7J3iFdrCxreZZIKf4egTwEQfIYRsqFax69A0OrFj+NIoFSE03xBT/IFRrg+S8K6f9Ky+4hA==",
+      "cpu": [
+        "s390x"
+      ],
+      "license": "Apache-2.0 AND MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/@swc/core-linux-x64-gnu": {
+      "version": "1.15.41",
+      "resolved": "https://registry.npmjs.org/@swc/core-linux-x64-gnu/-/core-linux-x64-gnu-1.15.41.tgz",
+      "integrity": "sha512-VxkuQK59c0tHm6uJZCUrS3cyA2JhGGfdU6e41SZz0x/JS+4Sm7C1mIc97In14vkZJopEt7yXA2TouCqZDSygEA==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "Apache-2.0 AND MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/@swc/core-linux-x64-musl": {
+      "version": "1.15.41",
+      "resolved": "https://registry.npmjs.org/@swc/core-linux-x64-musl/-/core-linux-x64-musl-1.15.41.tgz",
+      "integrity": "sha512-/0qXIu1ZxggLuovLb22vFfKHq2AA4n6Whw5UwmVCHk4pkw7KWnPIQpMCEqUMPsNkFJig7PPp/TSYFu8ZEb2rtQ==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "Apache-2.0 AND MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/@swc/core-win32-arm64-msvc": {
+      "version": "1.15.41",
+      "resolved": "https://registry.npmjs.org/@swc/core-win32-arm64-msvc/-/core-win32-arm64-msvc-1.15.41.tgz",
+      "integrity": "sha512-Y481sMNZM6rECh9VO4+y26N1lWEDAyxnBZskUf37fl90uHE946VHfmiVQWT0uMFOhyJJFovGTRuF4W82dwewUg==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "Apache-2.0 AND MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/@swc/core-win32-ia32-msvc": {
+      "version": "1.15.41",
+      "resolved": "https://registry.npmjs.org/@swc/core-win32-ia32-msvc/-/core-win32-ia32-msvc-1.15.41.tgz",
+      "integrity": "sha512-BAchBD5qeUzy3hiPSLJtaaoSm4blCLyYffOF1bGE4ETcV+OisqjUAwDQMJj++4bTpvMCDzwC+Bj3PmQyBCtscw==",
+      "cpu": [
+        "ia32"
+      ],
+      "license": "Apache-2.0 AND MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/@swc/core-win32-x64-msvc": {
+      "version": "1.15.41",
+      "resolved": "https://registry.npmjs.org/@swc/core-win32-x64-msvc/-/core-win32-x64-msvc-1.15.41.tgz",
+      "integrity": "sha512-WOkA+fJ/ViVBQDsSV9JC52NACTe5PhlurA6viASDZGb7HR3KS01ZG7RZ+Bg6SVQFIoq3gSbTsskQVe6EbHFAYw==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "Apache-2.0 AND MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=10"
+      }
+    },
     "node_modules/@swc/counter": {
       "version": "0.1.3",
       "license": "Apache-2.0"
@@ -7410,6 +7946,15 @@
       "license": "Apache-2.0",
       "dependencies": {
         "tslib": "^2.8.0"
+      }
+    },
+    "node_modules/@swc/types": {
+      "version": "0.1.27",
+      "resolved": "https://registry.npmjs.org/@swc/types/-/types-0.1.27.tgz",
+      "integrity": "sha512-K6h3iUlqeM946U4sXFYeahefR1YBbXJvko+hv8WS8/0BNJ4OHiHRywMnQUJCqkR7Y9+hqQ1TvEpiKqUhz7NEFg==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@swc/counter": "^0.1.3"
       }
     },
     "node_modules/@tailwindcss/node": {
@@ -11872,6 +12417,21 @@
         "node": ">=10.17.0"
       }
     },
+    "node_modules/icu-minify": {
+      "version": "4.13.0",
+      "resolved": "https://registry.npmjs.org/icu-minify/-/icu-minify-4.13.0.tgz",
+      "integrity": "sha512-SIFMeUHZJjzS5RvIGvybKvWoHjDm9cGVEs2EpJ8PmywOdJLWyblPm7TdPLLoUtkJtwQD7iGhl2WMptZ+N0on+w==",
+      "funding": [
+        {
+          "type": "individual",
+          "url": "https://github.com/sponsors/amannn"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "@formatjs/icu-messageformat-parser": "^3.4.0"
+      }
+    },
     "node_modules/ieee754": {
       "version": "1.2.1",
       "resolved": "https://registry.npmjs.org/ieee754/-/ieee754-1.2.1.tgz",
@@ -12055,6 +12615,16 @@
       },
       "engines": {
         "node": ">= 0.4"
+      }
+    },
+    "node_modules/intl-messageformat": {
+      "version": "11.2.8",
+      "resolved": "https://registry.npmjs.org/intl-messageformat/-/intl-messageformat-11.2.8.tgz",
+      "integrity": "sha512-l323RCl3qJDVQ8U9j74ut/hVMdg3VPsOHpVMDvFfz9qiq4dPO5ooVYFNVUzzrpgG39a+RLzcXyJb8VFgIU+tUA==",
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "@formatjs/fast-memoize": "3.1.6",
+        "@formatjs/icu-messageformat-parser": "3.5.11"
       }
     },
     "node_modules/is-alphabetical": {
@@ -12244,7 +12814,6 @@
     },
     "node_modules/is-extglob": {
       "version": "2.1.1",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=0.10.0"
@@ -12299,7 +12868,6 @@
     },
     "node_modules/is-glob": {
       "version": "4.0.3",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "is-extglob": "^2.1.1"
@@ -15679,6 +16247,103 @@
         "uuid": "dist/bin/uuid"
       }
     },
+    "node_modules/next-intl": {
+      "version": "4.13.0",
+      "resolved": "https://registry.npmjs.org/next-intl/-/next-intl-4.13.0.tgz",
+      "integrity": "sha512-OvNq2v5XLx4EkQOsAhVE9g+6zdb83XHusADCXXtIW4LILYnjEVaeINdr1lkVWKSjzwNUiMSlH5N4K0OQTRiv6A==",
+      "funding": [
+        {
+          "type": "individual",
+          "url": "https://github.com/sponsors/amannn"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "@formatjs/intl-localematcher": "^0.8.1",
+        "@parcel/watcher": "^2.4.1",
+        "@swc/core": "^1.15.2",
+        "icu-minify": "^4.13.0",
+        "negotiator": "^1.0.0",
+        "next-intl-swc-plugin-extractor": "^4.13.0",
+        "po-parser": "^2.1.1",
+        "use-intl": "^4.13.0"
+      },
+      "peerDependencies": {
+        "next": "^12.0.0 || ^13.0.0 || ^14.0.0 || ^15.0.0 || ^16.0.0",
+        "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || >=19.0.0-rc <19.0.0 || ^19.0.0"
+      },
+      "peerDependenciesMeta": {
+        "typescript": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/next-intl-swc-plugin-extractor": {
+      "version": "4.13.0",
+      "resolved": "https://registry.npmjs.org/next-intl-swc-plugin-extractor/-/next-intl-swc-plugin-extractor-4.13.0.tgz",
+      "integrity": "sha512-6S/fJI0KXvLCL8nhBo9P8eGaJPzmwJBTCzX0NaUIj0VyU8U89d//T+vjMLdNIXl5MlLaYH7B9MbAjb8Mvu+tqQ==",
+      "license": "MIT"
+    },
+    "node_modules/next-intl/node_modules/@swc/core": {
+      "version": "1.15.41",
+      "resolved": "https://registry.npmjs.org/@swc/core/-/core-1.15.41.tgz",
+      "integrity": "sha512-03nQq/082QRJJiOvp3FGbgxTGyyxMxohPTjhk/W9bD2J0tk4ukITI7goOhOO2WbaHn/lsPmo/zf8+DIXhwpgYQ==",
+      "hasInstallScript": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@swc/counter": "^0.1.3",
+        "@swc/types": "^0.1.26"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/swc"
+      },
+      "optionalDependencies": {
+        "@swc/core-darwin-arm64": "1.15.41",
+        "@swc/core-darwin-x64": "1.15.41",
+        "@swc/core-linux-arm-gnueabihf": "1.15.41",
+        "@swc/core-linux-arm64-gnu": "1.15.41",
+        "@swc/core-linux-arm64-musl": "1.15.41",
+        "@swc/core-linux-ppc64-gnu": "1.15.41",
+        "@swc/core-linux-s390x-gnu": "1.15.41",
+        "@swc/core-linux-x64-gnu": "1.15.41",
+        "@swc/core-linux-x64-musl": "1.15.41",
+        "@swc/core-win32-arm64-msvc": "1.15.41",
+        "@swc/core-win32-ia32-msvc": "1.15.41",
+        "@swc/core-win32-x64-msvc": "1.15.41"
+      },
+      "peerDependencies": {
+        "@swc/helpers": ">=0.5.17"
+      },
+      "peerDependenciesMeta": {
+        "@swc/helpers": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/next-intl/node_modules/@swc/helpers": {
+      "version": "0.5.23",
+      "resolved": "https://registry.npmjs.org/@swc/helpers/-/helpers-0.5.23.tgz",
+      "integrity": "sha512-5lSsMOTXURePglDfvuAQUqkGek9Hg2kksOYay2m0+XR++b2NWYL/4sWyuvVBIs8oKnJaxkdi9whaL/sqN13afw==",
+      "license": "Apache-2.0",
+      "optional": true,
+      "peer": true,
+      "dependencies": {
+        "tslib": "^2.8.0"
+      }
+    },
+    "node_modules/next-intl/node_modules/negotiator": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/negotiator/-/negotiator-1.0.0.tgz",
+      "integrity": "sha512-8Ofs/AUQh8MaEcrlq5xOX0CQ9ypTF5dl78mjlMNfOK08fzpgTHQRQPBxcPlEtIw0yRpws+Zo/3r+5WRby7u3Gg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
     "node_modules/next-runtime-env": {
       "version": "3.3.0",
       "license": "MIT",
@@ -16026,6 +16691,12 @@
         "@img/sharp-win32-ia32": "0.34.5",
         "@img/sharp-win32-x64": "0.34.5"
       }
+    },
+    "node_modules/node-addon-api": {
+      "version": "7.1.1",
+      "resolved": "https://registry.npmjs.org/node-addon-api/-/node-addon-api-7.1.1.tgz",
+      "integrity": "sha512-5m3bsyrjFWE1xf7nz7YXdN4udnVtXK6/Yfgn5qnahL6bCkf2yKt4k3nuTKAtT4r3IG8JNR2ncsIMdZuAzJjHQQ==",
+      "license": "MIT"
     },
     "node_modules/node-cron": {
       "version": "4.2.1",
@@ -16827,6 +17498,12 @@
       "engines": {
         "node": ">=18"
       }
+    },
+    "node_modules/po-parser": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/po-parser/-/po-parser-2.1.1.tgz",
+      "integrity": "sha512-ECF4zHLbUItpUgE3OTtLKlPjeBN+fKEczj2zYjDfCGOzicNs0GK3Vg2IoAYwx7LH/XYw43fZQP6xnZ4TkNxSLQ==",
+      "license": "MIT"
     },
     "node_modules/possible-typed-array-names": {
       "version": "1.1.0",
@@ -19795,6 +20472,27 @@
         }
       }
     },
+    "node_modules/use-intl": {
+      "version": "4.13.0",
+      "resolved": "https://registry.npmjs.org/use-intl/-/use-intl-4.13.0.tgz",
+      "integrity": "sha512-fAFDrWaASxlhXOipcOyb5VDD+YONqj6+8O8EcG/J7RBoOUF3A8YahRWLN+mBxYMrlMQB8N6Voqk5X+YC+HSL0A==",
+      "funding": [
+        {
+          "type": "individual",
+          "url": "https://github.com/sponsors/amannn"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "@formatjs/fast-memoize": "^3.1.0",
+        "@schummar/icu-type-parser": "1.21.5",
+        "icu-minify": "^4.13.0",
+        "intl-messageformat": "^11.1.0"
+      },
+      "peerDependencies": {
+        "react": "^17.0.0 || ^18.0.0 || >=19.0.0-rc <19.0.0 || ^19.0.0"
+      }
+    },
     "node_modules/use-sidecar": {
       "version": "1.1.3",
       "license": "MIT",
@@ -20380,6 +21078,111 @@
       "funding": {
         "type": "github",
         "url": "https://github.com/sponsors/wooorm"
+      }
+    },
+    "node_modules/next-runtime-env/node_modules/@next/swc-darwin-x64": {
+      "version": "16.2.9",
+      "resolved": "https://registry.npmjs.org/@next/swc-darwin-x64/-/swc-darwin-x64-16.2.9.tgz",
+      "integrity": "sha512-7IAtK4MeybpqRV9GRABWEhJ62mOS+rzWOzOTFie4cSEtm12xsoOMJRcECoZx3FHPzFAqN/IJtHqWAFOLfl152w==",
+      "cpu": [
+        "x64"
+      ],
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/next-runtime-env/node_modules/@next/swc-linux-arm64-gnu": {
+      "version": "16.2.9",
+      "resolved": "https://registry.npmjs.org/@next/swc-linux-arm64-gnu/-/swc-linux-arm64-gnu-16.2.9.tgz",
+      "integrity": "sha512-hBD75iWpUtkL9SmQmcRhmLomn9jgkPzCEkbOcLgHymPEKzv+6ONy13RRiIEz/iEObjkS2Jlb5gYS2XGoS3X4rw==",
+      "cpu": [
+        "arm64"
+      ],
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/next-runtime-env/node_modules/@next/swc-linux-arm64-musl": {
+      "version": "16.2.9",
+      "resolved": "https://registry.npmjs.org/@next/swc-linux-arm64-musl/-/swc-linux-arm64-musl-16.2.9.tgz",
+      "integrity": "sha512-qZTI3pf9SGc/obr8NkQAekBxmp1QK+kVm+VAf3BALLfFAj+1kUhkTxmrWpVos9R/UYIA8AWX2p6cGI5WdwzVUA==",
+      "cpu": [
+        "arm64"
+      ],
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/next-runtime-env/node_modules/@next/swc-linux-x64-gnu": {
+      "version": "16.2.9",
+      "resolved": "https://registry.npmjs.org/@next/swc-linux-x64-gnu/-/swc-linux-x64-gnu-16.2.9.tgz",
+      "integrity": "sha512-xm0HfRNX+UkH4R3c18ynswjj5o5uEj/7iI9p9omdtTSIsRCzQqkGMA+10nzJ4EHnYC3as65IMhbbl5fWRUWHYg==",
+      "cpu": [
+        "x64"
+      ],
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/next-runtime-env/node_modules/@next/swc-linux-x64-musl": {
+      "version": "16.2.9",
+      "resolved": "https://registry.npmjs.org/@next/swc-linux-x64-musl/-/swc-linux-x64-musl-16.2.9.tgz",
+      "integrity": "sha512-QumimHkGEG6vM3PfEDWKyKen03NcqLOkeKB1EfcPe7VxzmEiCa4jNnMyBn/US5zcd/VE1CI+O8Ovb3lfjVHfGw==",
+      "cpu": [
+        "x64"
+      ],
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/next-runtime-env/node_modules/@next/swc-win32-arm64-msvc": {
+      "version": "16.2.9",
+      "resolved": "https://registry.npmjs.org/@next/swc-win32-arm64-msvc/-/swc-win32-arm64-msvc-16.2.9.tgz",
+      "integrity": "sha512-hzQpKZvw8rAwI6A2uQh6SacCSvNAXaIkPNsWwzqqfRiIMiXMfH936skDhz1OO6KpvdKkJrgHHtqQOq5PIXOvdQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/next-runtime-env/node_modules/@next/swc-win32-x64-msvc": {
+      "version": "16.2.9",
+      "resolved": "https://registry.npmjs.org/@next/swc-win32-x64-msvc/-/swc-win32-x64-msvc-16.2.9.tgz",
+      "integrity": "sha512-qr2VL3Ce5QrwgO2yh1ujSBawrimjVKX8FGF/cOynmdYKJY0BdHpGVNIRK1tqONB10Vkm25Ub1BD2bkjWs4+96w==",
+      "cpu": [
+        "x64"
+      ],
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">= 10"
       }
     }
   }

--- a/package.json
+++ b/package.json
@@ -65,6 +65,7 @@
     "jwt-decode": "^4.0.0",
     "next": "16.2.9",
     "next-auth": "^4.24.12",
+    "next-intl": "^4.13.0",
     "next-runtime-env": "^3.3.0",
     "node-cron": "^4.2.1",
     "node-mocks-http": "^1.17.2",

--- a/src/app/Footer.tsx
+++ b/src/app/Footer.tsx
@@ -4,6 +4,9 @@
 
 "use client";
 
+import ContactUsModal from "@/components/ContactUsModal";
+import LocaleSwitcher from "@/components/LocaleSwitcher";
+import { Link } from "@/i18n/navigation";
 import {
   faGithub,
   faLinkedin,
@@ -17,11 +20,12 @@ import {
 } from "@fortawesome/free-solid-svg-icons";
 import { FontAwesomeIcon } from "@fortawesome/react-fontawesome";
 import Image from "next/image";
+import { useTranslations } from "next-intl";
 import contentConfig from "@/config/contentConfig";
-import Link from "next/link";
-import ContactUsModal from "@/components/ContactUsModal";
 
 function Footer() {
+  const t = useTranslations();
+
   return (
     <>
       <div className="bg-primary p-4 text-center mt-4">
@@ -31,9 +35,7 @@ function Footer() {
           rel="noopener noreferrer"
         >
           <FontAwesomeIcon icon={faInfoCircle} className="mr-2 text-warning" />
-          <h2 className="inline text-lg text-white">
-            How to use the data portal
-          </h2>
+          <h2 className="inline text-lg text-white">{t("footer.banner")}</h2>
           <FontAwesomeIcon icon={faArrowRight} className="ml-2 text-white" />
         </a>
       </div>
@@ -78,48 +80,48 @@ function Footer() {
               />
             </div>
             <p className="text-xs md:text-sm">
-              {contentConfig.footerText.split("\n").map((line, index) => (
-                <span key={index}>
-                  {line}
-                  {index < contentConfig.footerText.split("\n").length - 1 && (
-                    <br />
-                  )}
-                </span>
-              ))}
+              {t("footer.funding")
+                .split("\n")
+                .map((line, index, lines) => (
+                  <span key={index}>
+                    {line}
+                    {index < lines.length - 1 && <br />}
+                  </span>
+                ))}
             </p>
           </div>
           {/* Second column: Legal */}
           <div className="flex flex-col gap-2 text-left w-full md:w-1/6">
-            <h3 className="text-lg font-bold">Legal</h3>
-            <a href="/legal#website-terms" className="hover:text-info">
-              Terms & Conditions
-            </a>
-            <a href="/legal#privacy-notice" className="hover:text-info">
-              Privacy Notice
-            </a>
-            <a href="/legal#cookies" className="hover:text-info">
-              Cookie Policy
-            </a>
+            <h3 className="text-lg font-bold">{t("footer.legal")}</h3>
+            <Link href="/legal#website-terms" className="hover:text-info">
+              {t("footer.terms")}
+            </Link>
+            <Link href="/legal#privacy-notice" className="hover:text-info">
+              {t("footer.privacy")}
+            </Link>
+            <Link href="/legal#cookies" className="hover:text-info">
+              {t("footer.cookies")}
+            </Link>
           </div>
           {/* Third column: Portal links */}
           <div className="flex flex-col gap-2 text-left w-full md:w-1/6">
-            <h3 className="text-lg font-bold">Portal Links</h3>
+            <h3 className="text-lg font-bold">{t("footer.portalLinks")}</h3>
             <Link className="hover:text-info" href="/datasets">
-              Datasets
+              {t("nav.datasets")}
             </Link>
             <Link className="hover:text-info" href="/themes">
-              Themes
+              {t("nav.themes")}
             </Link>
             <Link className="hover:text-info" href="/publishers">
-              Publishers
+              {t("nav.publishers")}
             </Link>
             <Link className="hover:text-info" href="/about">
-              About
+              {t("nav.about")}
             </Link>
           </div>
           {/* Fourth column: Contact us */}
           <div className="flex flex-col gap-2 text-left w-full md:w-1/3">
-            <h3 className="text-lg font-bold">Contact Us</h3>
+            <h3 className="text-lg font-bold">{t("footer.contactUs")}</h3>
             <div className="flex gap-4">
               {contentConfig.linkedInUrl && (
                 <a
@@ -199,6 +201,9 @@ function Footer() {
                 {contentConfig.email}
               </a>
             )}
+            <div className="mt-2 max-w-[180px]">
+              <LocaleSwitcher />
+            </div>
             {contentConfig.contactUsEnabled && <ContactUsModal />}
           </div>
         </div>

--- a/src/app/[locale]/about/page.tsx
+++ b/src/app/[locale]/about/page.tsx
@@ -1,0 +1,5 @@
+// SPDX-FileCopyrightText: 2026 PNED G.I.E.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+export { default } from "../../about/page";

--- a/src/app/[locale]/allele-frequency/page.tsx
+++ b/src/app/[locale]/allele-frequency/page.tsx
@@ -1,0 +1,5 @@
+// SPDX-FileCopyrightText: 2026 PNED G.I.E.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+export { default } from "../../allele-frequency/page";

--- a/src/app/[locale]/applications/[id]/layout.tsx
+++ b/src/app/[locale]/applications/[id]/layout.tsx
@@ -1,0 +1,5 @@
+// SPDX-FileCopyrightText: 2026 PNED G.I.E.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+export { default } from "../../../applications/[id]/layout";

--- a/src/app/[locale]/applications/[id]/page.tsx
+++ b/src/app/[locale]/applications/[id]/page.tsx
@@ -1,0 +1,5 @@
+// SPDX-FileCopyrightText: 2026 PNED G.I.E.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+export { default } from "../../../applications/[id]/page";

--- a/src/app/[locale]/basket/page.tsx
+++ b/src/app/[locale]/basket/page.tsx
@@ -1,0 +1,5 @@
+// SPDX-FileCopyrightText: 2026 PNED G.I.E.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+export { default } from "../../basket/page";

--- a/src/app/[locale]/datasets/[id]/page.tsx
+++ b/src/app/[locale]/datasets/[id]/page.tsx
@@ -1,0 +1,5 @@
+// SPDX-FileCopyrightText: 2026 PNED G.I.E.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+export { default } from "../../../datasets/[id]/page";

--- a/src/app/[locale]/datasets/page.tsx
+++ b/src/app/[locale]/datasets/page.tsx
@@ -1,0 +1,5 @@
+// SPDX-FileCopyrightText: 2026 PNED G.I.E.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+export { default } from "../../datasets/page";

--- a/src/app/[locale]/howto/page.tsx
+++ b/src/app/[locale]/howto/page.tsx
@@ -1,0 +1,5 @@
+// SPDX-FileCopyrightText: 2026 PNED G.I.E.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+export { default } from "../../howto/page";

--- a/src/app/[locale]/layout.tsx
+++ b/src/app/[locale]/layout.tsx
@@ -1,0 +1,35 @@
+// SPDX-FileCopyrightText: 2026 PNED G.I.E.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+import { routing, type AppLocale } from "@/i18n/routing";
+import { setRequestLocale } from "next-intl/server";
+import { notFound } from "next/navigation";
+
+type LocaleLayoutProps = {
+  children: React.ReactNode;
+  params: Promise<{ locale: string }>;
+};
+
+function isValidLocale(locale: string): locale is AppLocale {
+  return routing.locales.includes(locale as AppLocale);
+}
+
+export function generateStaticParams() {
+  return routing.locales.map((locale) => ({ locale }));
+}
+
+export default async function LocaleLayout({
+  children,
+  params,
+}: Readonly<LocaleLayoutProps>) {
+  const { locale } = await params;
+
+  if (!isValidLocale(locale)) {
+    notFound();
+  }
+
+  setRequestLocale(locale);
+
+  return children;
+}

--- a/src/app/[locale]/legal/page.tsx
+++ b/src/app/[locale]/legal/page.tsx
@@ -1,0 +1,5 @@
+// SPDX-FileCopyrightText: 2026 PNED G.I.E.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+export { default } from "../../legal/page";

--- a/src/app/[locale]/page.tsx
+++ b/src/app/[locale]/page.tsx
@@ -1,0 +1,5 @@
+// SPDX-FileCopyrightText: 2026 PNED G.I.E.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+export { default } from "../page";

--- a/src/app/[locale]/publishers/page.tsx
+++ b/src/app/[locale]/publishers/page.tsx
@@ -1,0 +1,5 @@
+// SPDX-FileCopyrightText: 2026 PNED G.I.E.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+export { default } from "../../publishers/page";

--- a/src/app/[locale]/requests/page.tsx
+++ b/src/app/[locale]/requests/page.tsx
@@ -1,0 +1,5 @@
+// SPDX-FileCopyrightText: 2026 PNED G.I.E.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+export { default } from "../../requests/page";

--- a/src/app/[locale]/themes/page.tsx
+++ b/src/app/[locale]/themes/page.tsx
@@ -1,0 +1,5 @@
+// SPDX-FileCopyrightText: 2026 PNED G.I.E.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+export { default } from "../../themes/page";

--- a/src/app/applications/[id]/page.tsx
+++ b/src/app/applications/[id]/page.tsx
@@ -13,6 +13,7 @@ import Chip from "@/components/Chip";
 import PageContainer from "@/components/PageContainer";
 import PageHeading from "@/components/PageHeading";
 import Sidebar from "@/components/Sidebar";
+import { useRouter } from "@/i18n/navigation";
 import { useApplicationDetails } from "@/providers/application/ApplicationProvider";
 import {
   formatApplicationProp,
@@ -27,7 +28,7 @@ import {
   faXmarkCircle,
 } from "@fortawesome/free-solid-svg-icons";
 import { FontAwesomeIcon } from "@fortawesome/react-fontawesome";
-import { useRouter } from "next/navigation";
+import { useTranslations } from "next-intl";
 import { use, useEffect, useState } from "react";
 import FormContainer from "./FormContainer";
 import { createApplicationSidebarItems } from "./sidebarItems";
@@ -40,6 +41,7 @@ type ApplicationDetailsPageProps = {
 export default function ApplicationDetailsPage({
   searchParams,
 }: ApplicationDetailsPageProps) {
+  const t = useTranslations();
   const _searchParams = use(searchParams);
   const router = useRouter();
   const [alert, setAlert] = useState<AlertState | null>(null);
@@ -133,7 +135,7 @@ export default function ApplicationDetailsPage({
           <div className="sm:flex sm:justify-between">
             <div className="flex items-center gap-x-4">
               <PageHeading className="text-black">
-                Application {application.externalId}
+                {t("application.title", { id: application.externalId ?? "" })}
               </PageHeading>
               {application.id && (
                 <Chip
@@ -146,7 +148,7 @@ export default function ApplicationDetailsPage({
               {isDraft && (
                 <Button
                   type="warning"
-                  text="Delete"
+                  text={t("application.delete")}
                   icon={faXmarkCircle}
                   disabled={isLoading}
                   onClick={handleDelete}
@@ -155,7 +157,7 @@ export default function ApplicationDetailsPage({
               {editable && (
                 <Button
                   type="primary"
-                  text="Submit"
+                  text={t("application.submit")}
                   icon={faPaperPlane}
                   disabled={isLoading}
                   onClick={handleSubmission}
@@ -167,16 +169,21 @@ export default function ApplicationDetailsPage({
             <div className="gap-x-1 flex items-center">
               {" "}
               <FontAwesomeIcon icon={faSpinner} />{" "}
-              <span>Saving Changes...</span>
+              <span>{t("application.savingChanges")}</span>
             </div>
           ) : (
-            <p>{`Last Event: ${formatApplicationProp(lastEvent.eventType!)} at ${formatDateTime(lastEvent.eventTime!.toString())}`}</p>
+            <p>
+              {t("application.lastEvent", {
+                event: formatApplicationProp(lastEvent.eventType!) ?? "",
+                time: formatDateTime(lastEvent.eventTime!.toString()),
+              })}
+            </p>
           )}
 
           <div className="h-[2px] bg-secondary opacity-80"></div>
 
           <div className="lg:hidden w-full">
-            <Sidebar items={createApplicationSidebarItems(application)} />
+            <Sidebar items={createApplicationSidebarItems(application, t)} />
           </div>
 
           <div className="h-[2px] bg-secondary opacity-80 lg:hidden"></div>
@@ -214,7 +221,7 @@ export default function ApplicationDetailsPage({
         </div>
 
         <aside className="hidden w-full lg:block lg:w-1/3">
-          <Sidebar items={createApplicationSidebarItems(application)} />
+          <Sidebar items={createApplicationSidebarItems(application, t)} />
         </aside>
       </div>
     </PageContainer>

--- a/src/app/applications/[id]/sidebarItems.tsx
+++ b/src/app/applications/[id]/sidebarItems.tsx
@@ -18,13 +18,14 @@ import AddParticipantForm from "./AddParticipantForm";
 import contentConfig from "@/config/contentConfig";
 
 export function createApplicationSidebarItems(
-  application: RetrievedApplication
+  application: RetrievedApplication,
+  t: (key: string) => string
 ): SidebarItem[] {
   const { datasets, applicant, events, members } = application;
 
   return [
     {
-      label: "Datasets",
+      label: t("application.sidebar.datasets"),
       value: datasets!.map((dataset, index) => (
         <span
           className="mb-3 flex items-center gap-x-6"
@@ -36,7 +37,7 @@ export function createApplicationSidebarItems(
       )),
     },
     {
-      label: "Participants",
+      label: t("application.sidebar.participants"),
       value: (
         <>
           <div className="mb-6">
@@ -58,7 +59,7 @@ export function createApplicationSidebarItems(
       ),
     },
     {
-      label: "Events",
+      label: t("application.sidebar.events"),
       value: (
         <ul>
           {events!.slice(0, 5).map((event, index) => (
@@ -68,7 +69,7 @@ export function createApplicationSidebarItems(
                 <div>
                   {formatApplicationProp(event!.eventType!)}
                   <div className="text-xs md:text-sm">
-                    at{" "}
+                    {t("application.sidebar.at")}{" "}
                     <span className="font-date text-info">
                       {formatDateTime(event.eventTime!.toString())}
                     </span>
@@ -81,7 +82,7 @@ export function createApplicationSidebarItems(
       ),
     },
     {
-      label: "Terms & Conditions",
+      label: t("application.sidebar.terms"),
       value: <TermsAcceptance />,
     },
   ];

--- a/src/app/basket/page.tsx
+++ b/src/app/basket/page.tsx
@@ -15,28 +15,30 @@ import { signIn, useSession } from "next-auth/react";
 import DatasetList from "../datasets/DatasetList";
 import { AxiosError } from "axios";
 import { createApplicationApi } from "../api/access-management";
-import { useRouter } from "next/navigation";
+import { useRouter } from "@/i18n/navigation";
 import { UrlSearchParams } from "@/app/params";
 import { use } from "react";
+import { useTranslations } from "next-intl";
 
 type BasketPageProps = {
   searchParams: Promise<UrlSearchParams>;
 };
 
 export default function Page({ searchParams }: BasketPageProps) {
+  const t = useTranslations();
   const _searchParams = use(searchParams);
   const { basket, isLoading, emptyBasket } = useDatasetBasket();
   const { setAlert } = useAlert();
   const { data: session, status } = useSession();
   const router = useRouter();
 
-  let heading = "Your Basket";
+  let heading = t("basket.title");
   if (basket.length > 0) {
-    heading = `Your Basket (${basket.length})`;
+    heading = t("basket.titleWithCount", { count: basket.length });
   }
 
   if (isLoading || status === "loading") {
-    return <LoadingContainer text="Loading your basket..." />;
+    return <LoadingContainer text={t("basket.loading")} />;
   }
 
   const requestNow = async () => {
@@ -70,7 +72,7 @@ export default function Page({ searchParams }: BasketPageProps) {
       actionBtn = (
         <Button
           icon={faPaperPlane}
-          text="Login to request"
+          text={t("basket.loginToRequest")}
           onClick={() => signIn("keycloak")}
           type="primary"
         />
@@ -79,7 +81,7 @@ export default function Page({ searchParams }: BasketPageProps) {
       actionBtn = (
         <Button
           icon={faPaperPlane}
-          text="Request now"
+          text={t("basket.requestNow")}
           type="primary"
           onClick={requestNow}
         />
@@ -95,7 +97,7 @@ export default function Page({ searchParams }: BasketPageProps) {
           {basket.length > 0 && (
             <Button
               icon={faPlusCircle}
-              text="Continue adding"
+              text={t("basket.continueAdding")}
               href="/datasets"
               type="info"
             />
@@ -107,11 +109,11 @@ export default function Page({ searchParams }: BasketPageProps) {
         ) : (
           <div className="flex w-full flex-col items-center justify-center gap-4">
             <p className="text-center text-lg text-primary">
-              Your basket is empty.
+              {t("basket.empty")}
             </p>
             <Button
               icon={faPlusCircle}
-              text="Add datasets"
+              text={t("basket.addDatasets")}
               href="/datasets"
               type="primary"
             />

--- a/src/app/datasets/BeaconToggle.tsx
+++ b/src/app/datasets/BeaconToggle.tsx
@@ -4,10 +4,13 @@
 
 "use client";
 
-import { useRouter, useSearchParams } from "next/navigation";
+import { useRouter } from "@/i18n/navigation";
+import { useSearchParams } from "next/navigation";
 import { useSession } from "next-auth/react";
+import { useTranslations } from "next-intl";
 
 export default function BeaconToggle() {
+  const t = useTranslations("datasets");
   const { data: session } = useSession();
   const router = useRouter();
   const searchParams = useSearchParams();
@@ -58,27 +61,18 @@ export default function BeaconToggle() {
           />
           <div className="flex-1">
             <div className="flex items-center gap-2 font-semibold text-base mb-1">
-              <span>Include Individual-level data discovery</span>
+              <span>{t("beaconToggle")}</span>
               {includeBeacon && (
                 <span className="text-xs bg-warning text-black px-2 py-0.5 rounded-full font-normal">
-                  Active
+                  {t("beaconActive")}
                 </span>
               )}
             </div>
             <div className="text-sm text-gray-600 font-normal">
               {includeBeacon ? (
-                <>
-                  Showing datasets with individual-level data and record counts
-                  from Individual-level data discovery{" "}
-                  <span className="text-secondary font-medium">
-                    (searches may be slower)
-                  </span>
-                </>
+                <>{t("beaconEnabled")}</>
               ) : (
-                <>
-                  Enable to filter by individual-level data characteristics and
-                  see record counts
-                </>
+                <>{t("beaconDisabled")}</>
               )}
             </div>
           </div>

--- a/src/app/datasets/DatasetCard.tsx
+++ b/src/app/datasets/DatasetCard.tsx
@@ -24,6 +24,7 @@ import { FontAwesomeIcon } from "@fortawesome/react-fontawesome";
 import Card, { CardItem } from "../../components/Card";
 import { useEffect, useState, useRef, useMemo } from "react";
 import { ExternalDatasetConfirmationDialog } from "@/components/ExternalDatasetCardLink";
+import { useTranslations } from "next-intl";
 
 type DatasetCardProps = {
   dataset: SearchedDataset;
@@ -36,6 +37,7 @@ function DatasetCard({
   cardItems,
   displayBasketButton = true,
 }: Readonly<DatasetCardProps>) {
+  const t = useTranslations("basket");
   const screenSize = useWindowSize();
   const truncatedDesc = dataset.description
     ? truncateDescription(dataset.description, screenSize)
@@ -147,7 +149,7 @@ function DatasetCard({
           icon={isInBasket ? faMinusCircle : faPlusCircle}
           className="mr-2"
         />
-        <span>{isInBasket ? "Remove from basket" : "Add to basket"}</span>
+        <span>{isInBasket ? t("removeFromBasket") : t("addToBasket")}</span>
       </button>
     );
 

--- a/src/app/datasets/DatasetCount.tsx
+++ b/src/app/datasets/DatasetCount.tsx
@@ -5,16 +5,18 @@
 "use client";
 
 import { useDatasets } from "@/providers/datasets/DatasetsProvider";
+import { useTranslations } from "next-intl";
 
 export default function DatasetCount() {
+  const t = useTranslations("datasets");
   const { datasetCount, isLoading, errorCode } = useDatasets();
   let text;
   if (isLoading || datasetCount === undefined) {
     text = "";
   } else if (errorCode) {
-    text = "No dataset found";
+    text = t("results", { count: 0 });
   } else {
-    text = `${datasetCount} ${datasetCount > 1 ? "datasets" : "dataset"} found`;
+    text = t("results", { count: datasetCount });
   }
   return (
     <p className="col-start-0 col-span-12 mt-5 xl:mb-12 mb-4 text-center text-sm text-info h-9">

--- a/src/app/datasets/DatasetListContainer.tsx
+++ b/src/app/datasets/DatasetListContainer.tsx
@@ -48,7 +48,6 @@ export default function DatasetListContainer({
         <PaginationContainer
           datasetCount={datasetCount || 0}
           datasetPerPage={DATASET_PER_PAGE}
-          pathname="/datasets"
           currentPage={currentPage}
         />
       </div>

--- a/src/app/datasets/FilterList/index.tsx
+++ b/src/app/datasets/FilterList/index.tsx
@@ -6,10 +6,12 @@
 
 import { useSearchParams } from "next/navigation";
 import { useSession } from "next-auth/react";
+import { useTranslations } from "next-intl";
 import FilterItem from "./FilterItem";
 import { useFilters } from "@/providers/filters/FilterProvider";
 
 export default function FilterList() {
+  const t = useTranslations("datasets");
   const { data: session } = useSession();
   const { filters } = useFilters();
   const searchParams = useSearchParams();
@@ -46,7 +48,7 @@ export default function FilterList() {
       {catalogueFilters.length > 0 && (
         <section>
           <h3 className="text-sm font-semibold text-gray-500 uppercase mb-4 tracking-wide">
-            Catalogue Filters
+            {t("catalogueFilters")}
           </h3>
           <ul className="flex flex-col gap-y-6">
             {catalogueFilters.map((filter) => (
@@ -63,10 +65,10 @@ export default function FilterList() {
         <section>
           <div className="border-t pt-6">
             <h3 className="text-sm font-semibold text-gray-500 uppercase mb-2 tracking-wide">
-              Individual-level data discovery Filters
+              {t("individualFilters")}
             </h3>
             <p className="text-xs text-gray-600 mb-4">
-              Filter by individual-level data characteristics
+              {t("individualFiltersDescription")}
             </p>
             <ul className="flex flex-col gap-y-6">
               {beaconFilters.map((filter) => (

--- a/src/app/datasets/NoDatasetMessage.tsx
+++ b/src/app/datasets/NoDatasetMessage.tsx
@@ -5,10 +5,12 @@
 "use client";
 
 import React from "react";
+import { useTranslations } from "next-intl";
 import { useDatasets } from "@/providers/datasets/DatasetsProvider";
 import { useFilters } from "@/providers/filters/FilterProvider";
 
 export default function NoDatasetMessage() {
+  const t = useTranslations("datasets");
   const { datasetCount, isLoading } = useDatasets();
   const { activeFilters } = useFilters();
 
@@ -20,10 +22,7 @@ export default function NoDatasetMessage() {
 
   return (
     <div className="text-center py-8 mt-4">
-      <p className="text-lg text-primary mb-4">
-        No datasets found matching your criteria. Try adjusting your search or
-        filters.
-      </p>
+      <p className="text-lg text-primary mb-4">{t("noResults")}</p>
     </div>
   );
 }

--- a/src/app/datasets/[id]/DataSeriesAccordion.tsx
+++ b/src/app/datasets/[id]/DataSeriesAccordion.tsx
@@ -5,7 +5,7 @@
 "use client";
 
 import React, { useEffect, useRef, useState } from "react";
-import Link from "next/link";
+import { Link } from "@/i18n/navigation";
 import { FontAwesomeIcon } from "@fortawesome/react-fontawesome";
 import {
   faChevronDown,

--- a/src/app/datasets/[id]/DatasetMetadata.tsx
+++ b/src/app/datasets/[id]/DatasetMetadata.tsx
@@ -35,7 +35,7 @@ import {
 import { formatDate } from "@/utils/formatDate";
 import DistributionAccordion from "./DistributionAccordion";
 import DataSeriesAccordion from "./DataSeriesAccordion";
-import Link from "next/link";
+import { Link } from "@/i18n/navigation";
 import Tooltip from "./Tooltip";
 import Chips from "@/components/Chips";
 import {

--- a/src/app/datasets/page.tsx
+++ b/src/app/datasets/page.tsx
@@ -3,7 +3,7 @@
 // SPDX-License-Identifier: Apache-2.0
 "use client";
 
-import { redirect } from "next/navigation";
+import { redirect } from "@/i18n/navigation";
 import DatasetCount from "./DatasetCount";
 import DatasetListContainer from "./DatasetListContainer";
 import FilterList from "./FilterList";
@@ -18,6 +18,7 @@ import DatasetsProvider, {
 } from "@/providers/datasets/DatasetsProvider";
 import Error from "@/app/error";
 import { UrlSearchParams } from "@/app/params";
+import { useLocale } from "next-intl";
 import BeaconToggle from "./BeaconToggle";
 import BeaconErrorAlert from "./BeaconErrorAlert";
 
@@ -36,9 +37,10 @@ function BeaconErrorWrapper() {
 
 export default function DatasetsPage({ searchParams }: DatasetsPageProps) {
   const _searchParams = use(searchParams);
+  const locale = useLocale();
 
   if (!_searchParams.page) {
-    redirect("/datasets?page=1");
+    redirect({ href: "/datasets?page=1", locale });
   }
 
   const currentPage = Number(_searchParams.page);

--- a/src/app/error.tsx
+++ b/src/app/error.tsx
@@ -6,6 +6,7 @@
 
 import Button from "@/components/Button";
 import { faHouse } from "@fortawesome/free-solid-svg-icons";
+import { useTranslations } from "next-intl";
 
 interface ErrorBoundaryProps {
   errorTitle?: string;
@@ -20,9 +21,9 @@ export default function ErrorBoundary({
   stack,
   statusCode,
 }: Readonly<ErrorBoundaryProps>) {
-  let heading = "Something Went Wrong";
-  let message =
-    "Our apologies, but our server has encountered an internal error that prevents it from fulfilling your request. This is a temporary issue, and we're on the case to get it fixed. Please try again in a little while.";
+  const t = useTranslations("error");
+  let heading = t("genericHeading");
+  let message = t("genericMessage");
 
   if (errorTitle && errorDetail) {
     heading = errorTitle;
@@ -31,14 +32,12 @@ export default function ErrorBoundary({
 
   switch (statusCode) {
     case 404:
-      heading = "Page Not Found";
-      message =
-        "The page you're looking for doesn't seem to exist. It might have been moved or deleted.";
+      heading = t("notFoundHeading");
+      message = t("notFoundMessage");
       break;
     case 401:
-      heading = "Unauthorized";
-      message =
-        "You're not authorized to access this page. Please log in and try again.";
+      heading = t("unauthorizedHeading");
+      message = t("unauthorizedMessage");
       break;
   }
 
@@ -58,7 +57,7 @@ export default function ErrorBoundary({
           <div className="mt-6">
             <Button
               href="/"
-              text="Take me home"
+              text={t("takeMeHome")}
               icon={faHouse}
               type="primary"
             />

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -4,10 +4,13 @@
 
 import Header from "@/components/Header";
 import Navbar from "@/components/Navbar";
+import { routing, type AppLocale } from "@/i18n/routing";
 import { DatasetBasketProvider } from "@/providers/DatasetBasketProvider";
 import { AlertProvider } from "@/providers/AlertProvider";
 import { config } from "@fortawesome/fontawesome-svg-core";
 import "@fortawesome/fontawesome-svg-core/styles.css";
+import { NextIntlClientProvider } from "next-intl";
+import { headers } from "next/headers";
 import { PublicEnvScript } from "next-runtime-env";
 import Footer from "./Footer";
 import SessionProviderWrapper from "./SessionProviderWrapper";
@@ -15,18 +18,35 @@ import "./globals.css";
 config.autoAddCss = false;
 import contentConfig from "@/config/contentConfig";
 import { FilterProvider } from "@/providers/filters/FilterProvider";
+import { getFlatMessages, getMessages } from "@/i18n/messages";
 
-export default function RootLayout({
+function isValidLocale(locale: string): locale is AppLocale {
+  return routing.locales.includes(locale as AppLocale);
+}
+
+export default async function RootLayout({
   children,
 }: Readonly<{
   children: React.ReactNode;
 }>) {
+  const requestHeaders = await headers();
+  const headerLocale = requestHeaders.get("x-next-intl-locale");
+  const locale =
+    headerLocale && isValidLocale(headerLocale)
+      ? headerLocale
+      : routing.defaultLocale;
+  const messages = getMessages(locale);
+  const flatMessages = getFlatMessages(locale);
+
   return (
-    <html lang="en">
+    <html lang={locale}>
       <head>
-        <title>{contentConfig.siteTitle}</title>
+        <title>{flatMessages["metadata.siteTitle"]}</title>
         <meta name="viewport" content="width=device-width, initial-scale=1" />
-        <meta name="description" content={contentConfig.siteDescription} />
+        <meta
+          name="description"
+          content={flatMessages["metadata.siteDescription"]}
+        />
         <link rel="icon" href={contentConfig.favicon} />
         <link rel="preconnect" href="https://fonts.googleapis.com" />
         <link
@@ -43,22 +63,24 @@ export default function RootLayout({
         <link rel="stylesheet" href={"/fonts.css"} />
       </head>
       <body>
-        <AlertProvider>
-          <DatasetBasketProvider>
-            <div className="grid h-screen w-full grid-rows-[auto_1fr_auto]">
-              <SessionProviderWrapper>
-                <div>
-                  <Header />
-                </div>
-                <FilterProvider>
-                  <div>{children}</div>
-                </FilterProvider>
-                <Navbar />
-                <Footer />
-              </SessionProviderWrapper>
-            </div>
-          </DatasetBasketProvider>
-        </AlertProvider>
+        <NextIntlClientProvider locale={locale} messages={messages}>
+          <AlertProvider>
+            <DatasetBasketProvider>
+              <div className="grid h-screen w-full grid-rows-[auto_1fr_auto]">
+                <SessionProviderWrapper>
+                  <div>
+                    <Header />
+                  </div>
+                  <FilterProvider>
+                    <div>{children}</div>
+                  </FilterProvider>
+                  <Navbar />
+                  <Footer />
+                </SessionProviderWrapper>
+              </div>
+            </DatasetBasketProvider>
+          </AlertProvider>
+        </NextIntlClientProvider>
       </body>
     </html>
   );

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -3,6 +3,7 @@
 
 "use client";
 
+import { Link } from "@/i18n/navigation";
 import PageContainer from "@/components/PageContainer";
 import SearchBar from "@/components/Searchbar";
 import { use, useEffect, useState } from "react";
@@ -11,8 +12,8 @@ import { FontAwesomeIcon } from "@fortawesome/react-fontawesome";
 import { faTriangleExclamation } from "@fortawesome/free-solid-svg-icons";
 import { useAlert } from "@/providers/AlertProvider";
 import { AxiosError } from "axios";
-import contentConfig from "@/config/contentConfig";
 import ValueList from "@/components/ValueList";
+import { useTranslations } from "next-intl";
 import {
   retrieveFilterValuesApi,
   searchDatasetsApi,
@@ -29,6 +30,7 @@ type HomePageProps = {
 };
 
 const HomePage = ({ searchParams }: HomePageProps) => {
+  const t = useTranslations();
   const [datasets, setDatasets] = useState<SearchedDataset[]>([]);
   const [themes, setThemes] = useState<ValueLabel[]>([]);
   const { setAlert } = useAlert();
@@ -85,14 +87,11 @@ const HomePage = ({ searchParams }: HomePageProps) => {
       className="container mx-auto px-4 pt-5 text-center"
     >
       <div className="my-8">
-        <h1 className="font-bold text-4xl font-title">
-          {contentConfig.homepageTitle}
-        </h1>
-        <h2 className="text-xl mt-4 font-body">
-          {contentConfig.homepageSubtitle}
-        </h2>
+        <h1 className="font-bold text-4xl font-title">{t("home.title")}</h1>
+        <h2 className="text-xl mt-4 font-body">{t("home.subtitle")}</h2>
       </div>
-      {contentConfig.homeNoticeEnabled && contentConfig.homeNoticeMessage && (
+      {process.env.NEXT_PUBLIC_HOME_NOTICE_ENABLED?.toLowerCase() ===
+        "true" && (
         <div
           className="mx-auto mb-10 w-full max-w-4xl rounded-lg border-l-4 border-l-warning bg-warning/10 p-4 text-left shadow-lg"
           role="status"
@@ -105,10 +104,10 @@ const HomePage = ({ searchParams }: HomePageProps) => {
             />
             <div>
               <h3 className="mb-1 text-lg font-semibold">
-                {contentConfig.homeNoticeTitle}
+                {t("home.noticeTitle")}
               </h3>
               <p className="text-sm leading-6 md:text-base">
-                {contentConfig.homeNoticeMessage}
+                {t("home.noticeMessage")}
               </p>
             </div>
           </div>
@@ -123,7 +122,7 @@ const HomePage = ({ searchParams }: HomePageProps) => {
         <ValueList
           items={themes}
           filterKey={FilterValueType.THEME}
-          title="Themes"
+          title={t("home.themesSectionTitle")}
         />
       )}
       <div className="mb-20 relative text-left flex items-center py-8">
@@ -137,26 +136,26 @@ const HomePage = ({ searchParams }: HomePageProps) => {
           }}
         ></div>
         <div className="relative z-10 w-full md:w-3/4 lg:w-2/3 xl:w-3/5">
-          <h3 className="mb-4 text-2xl">About the data portal</h3>
+          <h3 className="mb-4 text-2xl">{t("home.aboutPortal")}</h3>
           <p
             className="text-lg"
             dangerouslySetInnerHTML={{
-              __html: contentConfig.aboutContent.replace(/\n/g, "<br />"),
+              __html: t("home.aboutContent").replace(/\n/g, "<br />"),
             }}
           />
           <br />
-          <a
+          <Link
             className="link-arrow text-primary hover:text-hover-color"
             href="/about"
           >
-            Read more
-          </a>
+            {t("home.readMore")}
+          </Link>
         </div>
       </div>
 
       <div className="text-left flex items-center">
         <div className="relative z-10 w-full my-8">
-          <h3 className="mb-4 text-2xl">Most Recent Datasets</h3>
+          <h3 className="mb-4 text-2xl">{t("home.recentDatasets")}</h3>
           <RecentDatasets datasets={datasets} />
         </div>
       </div>

--- a/src/app/publishers/page.tsx
+++ b/src/app/publishers/page.tsx
@@ -11,6 +11,7 @@ import { retrieveFilterValuesApi } from "../api/discovery";
 import { ValueLabel } from "@/app/api/discovery/open-api/schemas";
 import { FilterValueType } from "@/app/api/discovery/additional-types";
 import { UrlSearchParams } from "@/app/params";
+import { getTranslations } from "next-intl/server";
 
 async function getPublishers(): Promise<ValueLabel[]> {
   try {
@@ -28,6 +29,7 @@ type PublishersPageProps = {
 export default async function PublishersPage({
   searchParams,
 }: PublishersPageProps) {
+  const t = await getTranslations("publishers");
   const _searchParams = await searchParams;
   let publishers: ValueLabel[];
 
@@ -45,7 +47,7 @@ export default async function PublishersPage({
     >
       <div className="my-8 flex items-center gap-2 px-4 sm:px-6 lg:px-8">
         <h1 className="text-left font-title text-2xl sm:text-3xl">
-          Publishers
+          {t("title")}
         </h1>
         <span className="bg-info text-white text-sm px-2 py-1 rounded-full">
           {publishers.length}
@@ -54,7 +56,7 @@ export default async function PublishersPage({
       <Suspense
         fallback={
           <LoadingContainer
-            text="Retrieving publishers. This may take a few moments."
+            text={t("loading")}
             className="mt-4 px-4 text-center sm:mt-8 sm:px-8"
           />
         }
@@ -63,10 +65,10 @@ export default async function PublishersPage({
           <ValueList
             items={publishers}
             filterKey={FilterValueType.PUBLISHER}
-            title="Publishers"
+            title={t("title")}
           />
         ) : (
-          <p className="text-center text-sm text-info">No publishers found.</p>
+          <p className="text-center text-sm text-info">{t("empty")}</p>
         )}
       </Suspense>
     </PageContainer>

--- a/src/app/requests/applications/index.tsx
+++ b/src/app/requests/applications/index.tsx
@@ -11,6 +11,7 @@ import ListItem from "@/components/List/ListItem";
 import ListContainer from "@/components/ListContainer";
 import PageHeading from "@/components/PageHeading";
 import { faPlusCircle } from "@fortawesome/free-solid-svg-icons";
+import { useTranslations } from "next-intl";
 import React, { useEffect, useState } from "react";
 import { Status } from "@/utils/pageStatus.types";
 import LoadingContainer from "@/components/LoadingContainer";
@@ -29,6 +30,7 @@ interface ApplicationResponse {
 }
 
 const ApplicationsPage: React.FC = () => {
+  const t = useTranslations();
   const [response, setResponse] = useState<ApplicationResponse>({
     status: "loading",
   });
@@ -54,7 +56,7 @@ const ApplicationsPage: React.FC = () => {
   if (response.status === "loading") {
     return (
       <LoadingContainer
-        text="Retrieving applications..."
+        text={t("requests.applications.loading")}
         className="text-center"
       />
     );
@@ -72,8 +74,10 @@ const ApplicationsPage: React.FC = () => {
 
   return (
     <div className="pt-5 md:pt-10">
-      <PageHeading className="mb-4">Manage your Applications</PageHeading>
-      <span>View and update your submitted applications</span>
+      <PageHeading className="mb-4">
+        {t("requests.applications.title")}
+      </PageHeading>
+      <span>{t("requests.applications.subtitle")}</span>
       <ListContainer>
         {response.applications?.length && response.applications.length > 0 ? (
           <List>
@@ -89,11 +93,11 @@ const ApplicationsPage: React.FC = () => {
         ) : (
           <div className="flex w-full flex-col items-center justify-center gap-4">
             <p className="text-md text-center text-primary">
-              You don&apos;t have any applications yet.
+              {t("requests.applications.empty")}
             </p>
             <Button
               icon={faPlusCircle}
-              text="Add datasets"
+              text={t("requests.applications.addDatasets")}
               href="/datasets"
               type="primary"
               className="text-xs"

--- a/src/app/requests/entitlements/EmptyEntitlements.tsx
+++ b/src/app/requests/entitlements/EmptyEntitlements.tsx
@@ -4,21 +4,21 @@
 
 import Button from "@/components/Button";
 import { faPlusCircle } from "@fortawesome/free-solid-svg-icons";
+import { useTranslations } from "next-intl";
 
 export function EmptyEntitlements() {
+  const t = useTranslations();
+
   return (
     <div className="mb-7 flex w-full flex-col items-center justify-center gap-4">
       <p className="text-md text-center text-primary">
-        <span>You don&apos;t have any entitlement yet.</span>
+        <span>{t("requests.entitlements.empty").split("\n")[0]}</span>
         <br />
-        <span>
-          Wait for your application(s) to be approved, or submit a new
-          application.
-        </span>
+        <span>{t("requests.entitlements.empty").split("\n")[1]}</span>
       </p>
       <Button
         icon={faPlusCircle}
-        text="Add datasets"
+        text={t("requests.applications.addDatasets")}
         href="/datasets"
         type="primary"
         className="text-xs"

--- a/src/app/requests/entitlements/index.tsx
+++ b/src/app/requests/entitlements/index.tsx
@@ -12,6 +12,7 @@ import EntitlementsList from "./EntitlementsList";
 import LoadingContainer from "@/components/LoadingContainer";
 import Error from "@/app/error";
 import axios from "axios";
+import { useTranslations } from "next-intl";
 import { EmptyEntitlements } from "./EmptyEntitlements";
 import { retrieveEntitlementsApi } from "../../api/access-management";
 import { ErrorResponse } from "@/app/api/access-management/open-api/schemas";
@@ -24,6 +25,7 @@ interface EntitlementsResponse {
 }
 
 function EntitlementsPage() {
+  const t = useTranslations();
   const [response, setResponse] = useState<EntitlementsResponse>({
     status: "loading",
   });
@@ -65,7 +67,7 @@ function EntitlementsPage() {
   if (response.status === "loading") {
     return (
       <LoadingContainer
-        text="Retrieving entitlements..."
+        text={t("requests.entitlements.loading")}
         className="text-center"
       />
     );
@@ -83,8 +85,10 @@ function EntitlementsPage() {
 
   return (
     <div className="pt-5 md:pt-10">
-      <PageHeading className="mb-4">Entitlements</PageHeading>
-      <span>View your entitlements</span>
+      <PageHeading className="mb-4">
+        {t("requests.entitlements.title")}
+      </PageHeading>
+      <span>{t("requests.entitlements.subtitle")}</span>
       <ListContainer>
         {hasEntitlements ? (
           <EntitlementsList entitlements={response.datasetEntitlements ?? []} />

--- a/src/app/requests/page.tsx
+++ b/src/app/requests/page.tsx
@@ -4,23 +4,26 @@
 
 "use client";
 
+import { redirect, usePathname, useRouter } from "@/i18n/navigation";
 import PageContainer from "@/components/PageContainer";
 import { ITabItem, TabComponent } from "@/components/Tab";
 import { faDatabase, faFileText } from "@fortawesome/free-solid-svg-icons";
-import { redirect, usePathname, useRouter } from "next/navigation";
+import { useLocale, useTranslations } from "next-intl";
 import ApplicationsPage from "./applications";
 import EntitlementsPage from "./entitlements";
 import { UrlSearchParams } from "@/app/params";
 import { use } from "react";
 
-function createTabItems(): ITabItem[] {
+function createTabItems(t: ReturnType<typeof useTranslations>): ITabItem[] {
   return [
     {
       name: "applications",
+      label: t("requests.tabs.applications"),
       icon: faFileText,
     },
     {
       name: "entitlements",
+      label: t("requests.tabs.entitlements"),
       icon: faDatabase,
     },
   ];
@@ -31,6 +34,8 @@ type RequestPageProps = {
 };
 
 function RequestPage({ searchParams }: RequestPageProps) {
+  const locale = useLocale();
+  const t = useTranslations();
   const router = useRouter();
   const _searchParams = use(searchParams);
 
@@ -38,14 +43,14 @@ function RequestPage({ searchParams }: RequestPageProps) {
 
   const activeTab: string = _searchParams.tab || "";
 
-  const tabItems = createTabItems();
+  const tabItems = createTabItems(t);
   const tabNames = tabItems.map(
     (tabItem: ITabItem) => tabItem.name
   ) as ReadonlyArray<string>;
 
   if (!activeTab || !tabNames.includes(activeTab)) {
     const newPath = `${path}?tab=${tabNames[0]}`;
-    redirect(newPath);
+    redirect({ href: newPath, locale });
   }
 
   function setActiveTab(activeTab: string) {

--- a/src/app/sitemap.tsx
+++ b/src/app/sitemap.tsx
@@ -3,30 +3,24 @@
 // SPDX-License-Identifier: Apache-2.0
 
 import type { MetadataRoute } from "next";
+import { routing } from "@/i18n/routing";
 
 export default function sitemap(): MetadataRoute.Sitemap {
   const baseUrl = process.env.NEXT_PUBLIC_BASE_URL ?? "http://localhost:3000";
+  const publicPaths = ["/", "/datasets", "/themes", "/publishers", "/about"];
 
-  return [
-    {
-      url: baseUrl,
-      priority: 1,
-    },
-    {
-      url: `${baseUrl}/datasets`,
-      priority: 0.8,
-    },
-    {
-      url: `${baseUrl}/themes`,
-      priority: 0.8,
-    },
-    {
-      url: `${baseUrl}/publishers`,
-      priority: 0.8,
-    },
-    {
-      url: `${baseUrl}/about`,
-      priority: 0.8,
-    },
-  ];
+  return routing.locales.flatMap((locale) =>
+    publicPaths.map((path) => ({
+      url: `${baseUrl}/${locale}${path === "/" ? "" : path}`,
+      priority: path === "/" ? 1 : 0.8,
+      alternates: {
+        languages: Object.fromEntries(
+          routing.locales.map((alternateLocale) => [
+            alternateLocale,
+            `${baseUrl}/${alternateLocale}${path === "/" ? "" : path}`,
+          ])
+        ),
+      },
+    }))
+  );
 }

--- a/src/app/themes/page.tsx
+++ b/src/app/themes/page.tsx
@@ -11,6 +11,7 @@ import { retrieveFilterValuesApi } from "../api/discovery";
 import { ValueLabel } from "@/app/api/discovery/open-api/schemas";
 import { FilterValueType } from "@/app/api/discovery/additional-types";
 import { UrlSearchParams } from "@/app/params";
+import { getTranslations } from "next-intl/server";
 
 async function getThemes(): Promise<ValueLabel[]> {
   try {
@@ -26,6 +27,7 @@ type ThemesPageProps = {
 };
 
 export default async function ThemesPage({ searchParams }: ThemesPageProps) {
+  const t = await getTranslations("themes");
   const _searchParams = await searchParams;
 
   let themes: ValueLabel[];
@@ -43,7 +45,9 @@ export default async function ThemesPage({ searchParams }: ThemesPageProps) {
       className="container mx-auto px-4 pt-5"
     >
       <div className="my-8 flex items-center gap-2 px-4 sm:px-6 lg:px-8">
-        <h1 className="text-left font-title text-2xl sm:text-3xl">Themes</h1>
+        <h1 className="text-left font-title text-2xl sm:text-3xl">
+          {t("title")}
+        </h1>
         <span className="bg-info text-white text-sm px-2 py-1 rounded-full">
           {themes.length}
         </span>
@@ -51,7 +55,7 @@ export default async function ThemesPage({ searchParams }: ThemesPageProps) {
       <Suspense
         fallback={
           <LoadingContainer
-            text="Retrieving themes. This may take a few moments."
+            text={t("loading")}
             className="mt-4 px-4 text-center sm:mt-8 sm:px-8"
           />
         }
@@ -60,10 +64,10 @@ export default async function ThemesPage({ searchParams }: ThemesPageProps) {
           <ValueList
             items={themes}
             filterKey={FilterValueType.THEME}
-            title="Themes"
+            title={t("title")}
           />
         ) : (
-          <p className="text-center text-sm text-info">No themes found.</p>
+          <p className="text-center text-sm text-info">{t("empty")}</p>
         )}
       </Suspense>
     </PageContainer>

--- a/src/components/AddToBasketButton.tsx
+++ b/src/components/AddToBasketButton.tsx
@@ -7,6 +7,7 @@ import Button from "@/components/Button";
 import { useDatasetBasket } from "@/providers/DatasetBasketProvider";
 import { faMinusCircle, faPlusCircle } from "@fortawesome/free-solid-svg-icons";
 import { SearchedDataset } from "@/app/api/discovery/open-api/schemas";
+import { useTranslations } from "next-intl";
 
 type AddToBasketButtonProps = {
   dataset: SearchedDataset | null;
@@ -17,6 +18,7 @@ function AddToBasketButton({
   dataset,
   disabled: isDisabledProp = false,
 }: Readonly<AddToBasketButtonProps>) {
+  const t = useTranslations("basket");
   const { basket, addDatasetToBasket, removeDatasetFromBasket, isLoading } =
     useDatasetBasket();
 
@@ -33,7 +35,7 @@ function AddToBasketButton({
 
   return (
     <Button
-      text={isInBasket ? "Remove from basket" : "Add to basket"}
+      text={isInBasket ? t("removeFromBasket") : t("addToBasket")}
       icon={isInBasket ? faMinusCircle : faPlusCircle}
       onClick={toggleDatasetInBasket}
       type={isInBasket ? "warning" : "primary"}

--- a/src/components/Button.tsx
+++ b/src/components/Button.tsx
@@ -2,6 +2,7 @@
 //
 // SPDX-License-Identifier: Apache-2.0
 
+import { Link } from "@/i18n/navigation";
 import { cn } from "@/utils/tailwindMerge";
 import { IconDefinition } from "@fortawesome/fontawesome-svg-core";
 import { FontAwesomeIcon } from "@fortawesome/react-fontawesome";
@@ -12,7 +13,9 @@ interface ButtonProps {
   type?: "primary" | "secondary" | "info" | "warning";
   icon?: IconDefinition;
   href?: string;
-  onClick?: (e: React.MouseEvent<HTMLAnchorElement>) => void;
+  onClick?: (
+    e: React.MouseEvent<HTMLAnchorElement | HTMLButtonElement>
+  ) => void;
   disabled?: boolean;
   className?: string;
   props?: React.ComponentPropsWithoutRef<"a">;
@@ -48,7 +51,9 @@ const Button: React.FC<ButtonProps> = ({
     : "";
   const flexClasses = flex ? "shrink-0" : "sm:w-auto";
 
-  const handleClick = (e: React.MouseEvent<HTMLAnchorElement>) => {
+  const handleClick = (
+    e: React.MouseEvent<HTMLAnchorElement | HTMLButtonElement>
+  ) => {
     if (disabled) {
       e.preventDefault();
       e.stopPropagation();
@@ -59,9 +64,37 @@ const Button: React.FC<ButtonProps> = ({
     }
   };
 
+  const content = (
+    <>
+      {icon && <FontAwesomeIcon icon={icon} className="mr-2" />}
+      <span>{text}</span>
+      {children}
+    </>
+  );
+
+  if (href) {
+    return (
+      <Link
+        href={href}
+        className={cn(
+          classes[type!] || "",
+          common,
+          flexClasses,
+          className,
+          disabledClasses
+        )}
+        onClick={handleClick}
+        aria-disabled={disabled}
+        {...props}
+      >
+        {content}
+      </Link>
+    );
+  }
+
   return (
-    <a
-      href={href}
+    <button
+      type="button"
       className={cn(
         classes[type!] || "",
         common,
@@ -70,13 +103,10 @@ const Button: React.FC<ButtonProps> = ({
         disabledClasses
       )}
       onClick={handleClick}
-      aria-disabled={disabled}
-      {...props}
+      disabled={disabled}
     >
-      {icon && <FontAwesomeIcon icon={icon} className="mr-2" />}
-      <span>{text}</span>
-      {children}
-    </a>
+      {content}
+    </button>
   );
 };
 

--- a/src/components/Card.tsx
+++ b/src/components/Card.tsx
@@ -8,9 +8,10 @@ import {
   faLayerGroup,
 } from "@fortawesome/free-solid-svg-icons";
 import { FontAwesomeIcon } from "@fortawesome/react-fontawesome";
-import Link from "next/link";
+import { Link } from "@/i18n/navigation";
 import Chips from "./Chips";
 import contentConfig from "@/config/contentConfig";
+import { useTranslations } from "next-intl";
 
 export type CardItem = {
   text: string;
@@ -44,6 +45,7 @@ export default function Card({
   externalLabel,
   entityLabel,
 }: CardProps) {
+  const t = useTranslations();
   const isExternal = isExternalProp ?? !!externalUrl;
   return (
     <Link
@@ -93,7 +95,7 @@ export default function Card({
                 icon={faCircleInfo}
                 className="w-3 h-3 shrink-0"
               />
-              <span>Conforms to: Not specified for this dataset</span>
+              <span>{t("datasets.conformsToUnspecified")}</span>
             </div>
           ) : null}
 
@@ -126,7 +128,7 @@ export default function Card({
         <div className="mt-4 bg-info/5 rounded-md p-3 border-l-4 border-info w-full">
           <div className="flex items-center gap-x-2 mb-2">
             <span className="text-sm font-semibold text-black">
-              Individual-level data discovery
+              {t("datasets.individualFilters")}
             </span>
           </div>
           <div className="flex gap-x-2.5 text-xs sm:text-[15px]">

--- a/src/components/ContactUsModal.tsx
+++ b/src/components/ContactUsModal.tsx
@@ -15,6 +15,7 @@ import {
   DialogHeader,
   DialogTitle,
 } from "@/components/shadcn/dialog";
+import { useTranslations } from "next-intl";
 
 type TopicOption = {
   value: string;
@@ -47,6 +48,7 @@ function isValidEmailFormat(value: string): boolean {
 }
 
 export default function ContactUsModal() {
+  const t = useTranslations("contact");
   const [open, setOpen] = useState(false);
   const [topics, setTopics] = useState<TopicOption[]>([]);
   const [formState, setFormState] =
@@ -77,9 +79,7 @@ export default function ContactUsModal() {
         };
 
         if (!response.ok) {
-          throw new Error(
-            responseBody.error || "Unable to load support topic options."
-          );
+          throw new Error(responseBody.error || t("errorTopics"));
         }
 
         const loadedTopics = responseBody.topics ?? [];
@@ -93,9 +93,7 @@ export default function ContactUsModal() {
         }
       } catch (error) {
         setErrorMessage(
-          error instanceof Error
-            ? error.message
-            : "Unable to load support topic options."
+          error instanceof Error ? error.message : t("errorTopics")
         );
       } finally {
         setIsLoadingTopics(false);
@@ -103,10 +101,10 @@ export default function ContactUsModal() {
     };
 
     loadTopics().catch(() => {
-      setErrorMessage("Unable to load support topic options.");
+      setErrorMessage(t("errorTopics"));
       setIsLoadingTopics(false);
     });
-  }, [isLoadingTopics, open, topics.length]);
+  }, [isLoadingTopics, open, t, topics.length]);
 
   const updateField =
     (field: keyof ContactFormState) =>
@@ -141,32 +139,32 @@ export default function ContactUsModal() {
     event.preventDefault();
 
     if (!formState.firstName.trim()) {
-      setErrorMessage("Please provide your first name.");
+      setErrorMessage(t("validation.firstName"));
       return;
     }
 
     if (!formState.lastName.trim()) {
-      setErrorMessage("Please provide your last name.");
+      setErrorMessage(t("validation.lastName"));
       return;
     }
 
     if (!isValidEmailFormat(formState.email.trim())) {
-      setErrorMessage("Please provide a valid email address.");
+      setErrorMessage(t("validation.email"));
       return;
     }
 
     if (!formState.topic.trim()) {
-      setErrorMessage("Please select a topic.");
+      setErrorMessage(t("validation.topic"));
       return;
     }
 
     if (!formState.title.trim()) {
-      setErrorMessage("Please provide a title.");
+      setErrorMessage(t("validation.subject"));
       return;
     }
 
     if (!formState.message.trim()) {
-      setErrorMessage("Please enter a message.");
+      setErrorMessage(t("validation.message"));
       return;
     }
 
@@ -196,13 +194,10 @@ export default function ContactUsModal() {
       };
 
       if (!response.ok) {
-        throw new Error(
-          responseBody.error ||
-            "Your request could not be submitted. Please try again."
-        );
+        throw new Error(responseBody.error || t("errorSubmit"));
       }
 
-      setSuccessMessage("Your request has been submitted successfully.");
+      setSuccessMessage(t("success"));
 
       setFormState((previousState) => ({
         ...INITIAL_FORM_STATE,
@@ -210,9 +205,7 @@ export default function ContactUsModal() {
       }));
     } catch (error) {
       setErrorMessage(
-        error instanceof Error
-          ? error.message
-          : "Your request could not be submitted. Please try again."
+        error instanceof Error ? error.message : t("errorSubmit")
       );
     } finally {
       setIsSubmitting(false);
@@ -222,7 +215,7 @@ export default function ContactUsModal() {
   return (
     <>
       <AppButton
-        text="Get in touch"
+        text={t("open")}
         type="primary"
         className="self-start"
         onClick={(event) => {
@@ -234,56 +227,54 @@ export default function ContactUsModal() {
       <Dialog open={open} onOpenChange={closeDialog}>
         <DialogContent className="sm:max-w-xl bg-white max-h-[90vh] overflow-y-auto">
           <DialogHeader>
-            <DialogTitle>Contact Us</DialogTitle>
-            <DialogDescription>
-              Send your inquiry to the right team by selecting a topic.
-            </DialogDescription>
+            <DialogTitle>{t("title")}</DialogTitle>
+            <DialogDescription>{t("description")}</DialogDescription>
           </DialogHeader>
 
           <form className="space-y-4" onSubmit={handleSubmit}>
             <div className="space-y-2">
               <label htmlFor="firstName" className="text-sm font-title">
-                First Name
+                {t("firstName")}
               </label>
               <Input
                 id="firstName"
                 value={formState.firstName}
                 onChange={updateField("firstName")}
-                placeholder="Your first name"
+                placeholder={t("firstNamePlaceholder")}
                 required
               />
             </div>
 
             <div className="space-y-2">
               <label htmlFor="lastName" className="text-sm font-title">
-                Last Name
+                {t("lastName")}
               </label>
               <Input
                 id="lastName"
                 value={formState.lastName}
                 onChange={updateField("lastName")}
-                placeholder="Your last name"
+                placeholder={t("lastNamePlaceholder")}
                 required
               />
             </div>
 
             <div className="space-y-2">
               <label htmlFor="email" className="text-sm font-title">
-                Email
+                {t("email")}
               </label>
               <Input
                 id="email"
                 type="email"
                 value={formState.email}
                 onChange={updateField("email")}
-                placeholder="you@example.org"
+                placeholder={t("emailPlaceholder")}
                 required
               />
             </div>
 
             <div className="space-y-2">
               <label htmlFor="topic" className="text-sm font-title">
-                Topic
+                {t("topic")}
               </label>
               <select
                 id="topic"
@@ -295,9 +286,7 @@ export default function ContactUsModal() {
               >
                 {!isTopicAvailable && (
                   <option value="">
-                    {isLoadingTopics
-                      ? "Loading topics..."
-                      : "No topics available"}
+                    {isLoadingTopics ? t("topicLoading") : t("topicEmpty")}
                   </option>
                 )}
                 {topics.map((topic) => (
@@ -310,13 +299,13 @@ export default function ContactUsModal() {
 
             <div className="space-y-2">
               <label htmlFor="title" className="text-sm font-title">
-                Title
+                {t("subject")}
               </label>
               <Input
                 id="title"
                 value={formState.title}
                 onChange={updateField("title")}
-                placeholder="A short title"
+                placeholder={t("subjectPlaceholder")}
                 maxLength={160}
                 required
               />
@@ -324,13 +313,13 @@ export default function ContactUsModal() {
 
             <div className="space-y-2">
               <label htmlFor="message" className="text-sm font-title">
-                Message
+                {t("message")}
               </label>
               <textarea
                 id="message"
                 value={formState.message}
                 onChange={updateField("message")}
-                placeholder="Describe your request"
+                placeholder={t("messagePlaceholder")}
                 className="border-input bg-background ring-offset-background placeholder:text-muted-foreground min-h-[140px] w-full rounded-md border px-3 py-2 text-sm focus-visible:outline-hidden disabled:cursor-not-allowed disabled:opacity-50"
                 maxLength={4000}
                 required
@@ -355,13 +344,13 @@ export default function ContactUsModal() {
                 onClick={() => closeDialog(false)}
                 disabled={isSubmitting}
               >
-                Cancel
+                {t("cancel")}
               </DialogButton>
               <DialogButton
                 type="submit"
                 disabled={isSubmitting || !isTopicAvailable}
               >
-                {isSubmitting ? "Submitting..." : "Submit"}
+                {isSubmitting ? t("submitting") : t("submit")}
               </DialogButton>
             </div>
           </form>

--- a/src/components/Header/Avatar.tsx
+++ b/src/components/Header/Avatar.tsx
@@ -14,6 +14,7 @@ import { User } from "@/app/api/auth/types/user.types";
 import { keycloackSessionLogOut } from "@/utils/logout";
 import { faSignOut, faUser } from "@fortawesome/free-solid-svg-icons";
 import { FontAwesomeIcon } from "@fortawesome/react-fontawesome";
+import { useLocale, useTranslations } from "next-intl";
 import { signOut } from "next-auth/react";
 import Image from "next/image";
 
@@ -21,11 +22,14 @@ type AvatarProps = {
   user: User;
 };
 
-function handleSignOut() {
-  keycloackSessionLogOut().then(() => signOut({ callbackUrl: "/" }));
-}
-
 function Avatar({ user }: Readonly<AvatarProps>) {
+  const locale = useLocale();
+  const t = useTranslations("auth");
+
+  function handleSignOut() {
+    keycloackSessionLogOut().then(() => signOut({ callbackUrl: `/${locale}` }));
+  }
+
   return (
     <DropdownMenu>
       <DropdownMenuTrigger asChild>
@@ -50,7 +54,7 @@ function Avatar({ user }: Readonly<AvatarProps>) {
             onClick={handleSignOut}
           >
             <FontAwesomeIcon icon={faSignOut} className="text-lg" />
-            <span>Log out</span>
+            <span>{t("logout")}</span>
           </DropdownMenuItem>
         </DropdownMenuGroup>
       </DropdownMenuContent>

--- a/src/components/Header/RequestIcon.tsx
+++ b/src/components/Header/RequestIcon.tsx
@@ -4,7 +4,7 @@
 
 import { faFolderOpen } from "@fortawesome/free-solid-svg-icons";
 import { FontAwesomeIcon } from "@fortawesome/react-fontawesome";
-import Link from "next/link";
+import { Link } from "@/i18n/navigation";
 import React from "react";
 
 interface RequestIconProps {

--- a/src/components/Header/index.tsx
+++ b/src/components/Header/index.tsx
@@ -4,8 +4,10 @@
 "use client";
 
 import { User } from "@/app/api/auth/types/user.types";
+import { Link, usePathname } from "@/i18n/navigation";
 import contentConfig from "@/config/contentConfig";
 import { useDatasetBasket } from "@/providers/DatasetBasketProvider";
+import { useTranslations } from "next-intl";
 import {
   faBars,
   faBook,
@@ -20,54 +22,54 @@ import {
 import { FontAwesomeIcon } from "@fortawesome/react-fontawesome";
 import { signIn, useSession } from "next-auth/react";
 import Image from "next/image";
-import Link from "next/link";
-import { usePathname } from "next/navigation";
 import { useEffect, useState } from "react";
 import Button from "../Button";
 import Avatar from "./Avatar";
 import RequestIcon from "./RequestIcon";
 
 function Header() {
+  const t = useTranslations();
   const { data: session, status } = useSession();
   const [isMenuOpen, setIsMenuOpen] = useState<boolean>(false);
   const activeTab = usePathname();
   const { basket, isLoading } = useDatasetBasket();
+  const isExternalHeaderLogo = contentConfig.headerLogoUrl.startsWith("http");
 
   let navItems = [
     {
       icon: faHome,
-      label: "Home",
+      label: t("nav.home"),
       href: "/",
       isActive: (activePath: string) => activePath === "/",
     },
     {
       icon: faDatabase,
-      label: "Datasets",
+      label: t("nav.datasets"),
       href: "/datasets",
       isActive: (activePath: string) => activePath.includes("/datasets"),
     },
     {
       icon: faLineChart,
-      label: "Allele Frequency",
+      label: t("nav.alleleFrequency"),
       href: "/allele-frequency",
       isActive: (activePath: string) =>
         activePath.includes("/allele-frequency"),
     },
     {
       icon: faWandSparkles,
-      label: "Themes",
+      label: t("nav.themes"),
       href: "/themes",
       isActive: (activePath: string) => activePath === "/themes",
     },
     {
       icon: faBook,
-      label: "Publishers",
+      label: t("nav.publishers"),
       href: "/publishers",
       isActive: (activePath: string) => activePath === "/publishers",
     },
     {
       icon: faInfoCircle,
-      label: "About",
+      label: t("nav.about"),
       href: "/about",
       isActive: (activePath: string) => activePath === "/about",
     },
@@ -107,7 +109,7 @@ function Header() {
     ) : (
       <Button
         icon={faUser}
-        text="Login"
+        text={t("auth.login")}
         type="primary"
         onClick={() => signIn("keycloak")}
         flex={true}
@@ -155,28 +157,32 @@ function Header() {
               )}
             </div>
 
-            <Link
-              href={contentConfig.headerLogoUrl}
-              className="py-2"
-              target={
-                contentConfig.headerLogoUrl.startsWith("http")
-                  ? "_blank"
-                  : undefined
-              }
-              rel={
-                contentConfig.headerLogoUrl.startsWith("http")
-                  ? "noopener noreferrer"
-                  : undefined
-              }
-            >
-              <Image
-                src={"/logo.png"}
-                alt={"Logo"}
-                width="100"
-                height="37"
-                className={"mb-2 mt-2 w-[70px] md:w-[100px]"}
-              />
-            </Link>
+            {isExternalHeaderLogo ? (
+              <a
+                href={contentConfig.headerLogoUrl}
+                className="py-2"
+                target="_blank"
+                rel="noopener noreferrer"
+              >
+                <Image
+                  src={"/logo.png"}
+                  alt={"Logo"}
+                  width="100"
+                  height="37"
+                  className={"mb-2 mt-2 w-[70px] md:w-[100px]"}
+                />
+              </a>
+            ) : (
+              <Link href={contentConfig.headerLogoUrl} className="py-2">
+                <Image
+                  src={"/logo.png"}
+                  alt={"Logo"}
+                  width="100"
+                  height="37"
+                  className={"mb-2 mt-2 w-[70px] md:w-[100px]"}
+                />
+              </Link>
+            )}
 
             <div className="hidden items-center gap-x-2 text-base font-body lg:flex lg:text-lg xl:gap-x-4">
               {navItems.map((item) => {

--- a/src/components/LocaleSwitcher.tsx
+++ b/src/components/LocaleSwitcher.tsx
@@ -1,0 +1,47 @@
+// SPDX-FileCopyrightText: 2026 PNED G.I.E.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+"use client";
+
+import { routing } from "@/i18n/routing";
+import { useLocale, useTranslations } from "next-intl";
+
+export default function LocaleSwitcher() {
+  const t = useTranslations("localeSwitcher");
+  const locale = useLocale();
+
+  function buildLocalePath(nextLocale: string) {
+    const { pathname, search, hash } = window.location;
+    const localePrefixPattern = new RegExp(
+      `^/(?:${routing.locales.join("|")})(?=/|$)`
+    );
+    const pathWithoutLocale = pathname.replace(localePrefixPattern, "") || "/";
+    const localizedPath =
+      pathWithoutLocale === "/"
+        ? `/${nextLocale}`
+        : `/${nextLocale}${pathWithoutLocale}`;
+
+    return `${localizedPath}${search}${hash}`;
+  }
+
+  return (
+    <label className="flex flex-col gap-1 text-sm">
+      <span className="font-semibold">{t("label")}</span>
+      <select
+        className="rounded-md border border-gray-300 bg-white px-3 py-2 text-sm text-primary"
+        value={locale}
+        onChange={(event) => {
+          window.location.assign(buildLocalePath(event.target.value));
+        }}
+        aria-label={t("label")}
+      >
+        {routing.locales.map((supportedLocale) => (
+          <option key={supportedLocale} value={supportedLocale}>
+            {t(supportedLocale)}
+          </option>
+        ))}
+      </select>
+    </label>
+  );
+}

--- a/src/components/Navbar/index.tsx
+++ b/src/components/Navbar/index.tsx
@@ -3,8 +3,10 @@
 
 "use client";
 
+import { Link, usePathname } from "@/i18n/navigation";
 import contentConfig from "@/config/contentConfig";
 import debounce from "@/utils/debounce";
+import { useTranslations } from "next-intl";
 import {
   faBook,
   faDatabase,
@@ -13,11 +15,10 @@ import {
   faWandSparkles,
 } from "@fortawesome/free-solid-svg-icons";
 import { FontAwesomeIcon } from "@fortawesome/react-fontawesome";
-import Link from "next/link";
-import { usePathname } from "next/navigation";
 import { useEffect, useRef, useState } from "react";
 
 function Navbar() {
+  const t = useTranslations();
   const activeTab = usePathname();
   const [showNavbar, setShowNavbar] = useState(true);
   const prevScrollPos = useRef(
@@ -27,32 +28,32 @@ function Navbar() {
   let navItems = [
     {
       icon: faHome,
-      label: "Home",
+      label: t("nav.home"),
       href: "/",
       isActive: (activePath: string) => activePath === "/",
     },
     {
       icon: faDatabase,
-      label: "Datasets",
+      label: t("nav.datasets"),
       href: "/datasets",
       isActive: (activePath: string) => activePath.includes("/datasets"),
     },
     {
       icon: faLineChart,
-      label: "Allele Frequency",
+      label: t("nav.alleleFrequency"),
       href: "/allele-frequency",
       isActive: (activePath: string) =>
         activePath.includes("/allele-frequency"),
     },
     {
       icon: faWandSparkles,
-      label: "Themes",
+      label: t("nav.themes"),
       href: "/themes",
       isActive: (activePath: string) => activePath === "/themes",
     },
     {
       icon: faBook,
-      label: "Publishers",
+      label: t("nav.publishers"),
       href: "/publishers",
       isActive: (activePath: string) => activePath === "/publishers",
     },

--- a/src/components/PaginationContainer.tsx
+++ b/src/components/PaginationContainer.tsx
@@ -13,22 +13,22 @@ import {
   PaginationNext,
   PaginationPrevious,
 } from "./shadcn/pagination";
+import { usePathname } from "@/i18n/navigation";
 import { useSearchParams } from "next/navigation";
 
 type PaginationProps = {
   datasetCount: number;
   datasetPerPage: number;
-  pathname: string;
   currentPage: number;
 };
 
 function PaginationContainer({
   datasetCount,
   datasetPerPage,
-  pathname,
   currentPage,
 }: Readonly<PaginationProps>) {
   const searchParams = useSearchParams();
+  const pathname = usePathname();
   const lastPageNb = Math.ceil(datasetCount / datasetPerPage) || 1;
 
   function createHref(page: number) {

--- a/src/components/RecentDatasets.tsx
+++ b/src/components/RecentDatasets.tsx
@@ -1,11 +1,12 @@
 // SPDX-FileCopyrightText: 2025 PNED G.I.E.
 // SPDX-License-Identifier: Apache-2.0
 
-import Link from "next/link";
+import { Link } from "@/i18n/navigation";
 import { FontAwesomeIcon } from "@fortawesome/react-fontawesome";
 import { faArrowRight } from "@fortawesome/free-solid-svg-icons";
 import { formatDate } from "@/utils/formatDate";
 import { SearchedDataset } from "@/app/api/discovery/open-api/schemas";
+import { useTranslations } from "next-intl";
 
 type DatasetLinkProps = Pick<
   SearchedDataset,
@@ -13,6 +14,8 @@ type DatasetLinkProps = Pick<
 >;
 
 const RecentDatasets = ({ datasets }: { datasets: SearchedDataset[] }) => {
+  const t = useTranslations();
+
   return (
     <div className="bg-white">
       <div className="flex flex-col items-center w-full">
@@ -37,7 +40,7 @@ const RecentDatasets = ({ datasets }: { datasets: SearchedDataset[] }) => {
           href="/datasets"
           className="link-arrow text-primary hover:text-hover-color"
         >
-          See all
+          {t("recent.seeAll")}
         </Link>
       </div>
     </div>
@@ -49,6 +52,8 @@ function DatasetLink({
   createdAt,
   description,
 }: Readonly<DatasetLinkProps>) {
+  const t = useTranslations();
+
   return (
     <div className="p-5 h-full flex flex-col w-full">
       <span className="text-info text-sm font-subheading mb-2">
@@ -57,7 +62,7 @@ function DatasetLink({
       <h3 className="text-lg font-title mb-2 line-clamp-2">{title}</h3>
       <p className="mb-4 line-clamp-3 text-heading-secondary">{description}</p>
       <div className="mt-auto text-primary text-sm font-title link-arrow">
-        Read More
+        {t("recent.readMore")}
       </div>
     </div>
   );

--- a/src/components/Searchbar.tsx
+++ b/src/components/Searchbar.tsx
@@ -5,7 +5,8 @@
 "use client";
 import { FontAwesomeIcon } from "@fortawesome/react-fontawesome";
 import { faSearch } from "@fortawesome/free-solid-svg-icons";
-import { useRouter, useSearchParams } from "next/navigation";
+import { useRouter } from "@/i18n/navigation";
+import { useTranslations } from "next-intl";
 import React, { useEffect, useState } from "react";
 import { UrlSearchParams } from "@/app/params";
 
@@ -15,6 +16,7 @@ type SearchBarProps = {
 };
 
 function SearchBar({ size, searchParams }: Readonly<SearchBarProps>) {
+  const t = useTranslations();
   const [query, setQuery] = useState("");
   const [isFocused, setIsFocused] = useState(false);
   const router = useRouter();
@@ -34,7 +36,6 @@ function SearchBar({ size, searchParams }: Readonly<SearchBarProps>) {
   function handleQueryChange(e: React.ChangeEvent<HTMLInputElement>): void {
     setQuery(e.target.value);
   }
-  useSearchParams();
 
   function redirectToSearchResults(query: string): void {
     const params = new URLSearchParams();
@@ -61,7 +62,7 @@ function SearchBar({ size, searchParams }: Readonly<SearchBarProps>) {
     <form onSubmit={handleSubmit} className="w-full text-sm">
       <div className="relative">
         <input
-          placeholder="Search datasets"
+          placeholder={t("search.placeholder")}
           className={`${sizeClass} w-full rounded-lg px-4 py-[9px] shadow-xl ease-in-out hover:shadow-2xl border border-gray-300 focus:border-primary focus:ring-2 focus:ring-focus-ring focus:outline-none transition-all duration-300`}
           value={query}
           onChange={handleQueryChange}

--- a/src/components/Tab.tsx
+++ b/src/components/Tab.tsx
@@ -9,6 +9,7 @@ import ListItem from "./List/ListItem";
 
 type ITabItem = {
   name: string;
+  label: string;
   icon: IconDefinition;
 };
 
@@ -27,7 +28,7 @@ function TabItem({ tabItem, activeTab, setActiveTab }: Readonly<TabItemProps>) {
       } transition-all duration-300 ease-linear`}
     >
       <FontAwesomeIcon icon={tabItem.icon} />
-      <span>{tabItem.name.toUpperCase()}</span>
+      <span>{tabItem.label}</span>
     </button>
   );
 }

--- a/src/components/ValueList.tsx
+++ b/src/components/ValueList.tsx
@@ -2,11 +2,13 @@
 // SPDX-License-Identifier: Apache-2.0
 
 "use client";
-import Link from "next/link";
+
+import { Link } from "@/i18n/navigation";
 import { FontAwesomeIcon } from "@fortawesome/react-fontawesome";
 import { faArrowRight, faDatabase } from "@fortawesome/free-solid-svg-icons";
 import { useFilters } from "@/providers/filters/FilterProvider";
 import { ValueLabel } from "@/app/api/discovery/open-api/schemas";
+import { useTranslations } from "next-intl";
 
 interface ValueListProps {
   items: ValueLabel[];
@@ -15,6 +17,7 @@ interface ValueListProps {
 }
 
 const ValueList: React.FC<ValueListProps> = ({ items, filterKey, title }) => {
+  const t = useTranslations();
   const { addActiveFilter } = useFilters();
   const validItems = items.filter(
     (item): item is typeof item & { value: string } => !!item.value
@@ -45,7 +48,7 @@ const ValueList: React.FC<ValueListProps> = ({ items, filterKey, title }) => {
                 </h3>
                 <div className="flex items-center mb-3 text-sm text-heading-secondary">
                   <FontAwesomeIcon icon={faDatabase} className="mr-2" />
-                  {item.count} {item.count === 1 ? "dataset" : "datasets"}
+                  {t("valueList.datasetCount", { count: item.count ?? 0 })}
                 </div>
                 <div className="mt-auto text-sm">
                   <Link
@@ -53,7 +56,7 @@ const ValueList: React.FC<ValueListProps> = ({ items, filterKey, title }) => {
                     href={`/datasets?page=1`}
                     className="link-arrow text-primary hover:text-hover-color"
                   >
-                    See datasets
+                    {t("valueList.seeDatasets")}
                   </Link>
                 </div>
               </div>

--- a/src/components/shadcn/pagination.tsx
+++ b/src/components/shadcn/pagination.tsx
@@ -5,6 +5,7 @@
 import * as React from "react";
 
 import { ButtonProps, buttonVariants } from "@/components/shadcn/button";
+import { Link } from "@/i18n/navigation";
 import { cn } from "@/utils/tailwindMerge";
 import {
   faChevronLeft,
@@ -12,7 +13,6 @@ import {
   faEllipsisH,
 } from "@fortawesome/free-solid-svg-icons";
 import { FontAwesomeIcon } from "@fortawesome/react-fontawesome";
-import Link from "next/link";
 
 const Pagination = ({ className, ...props }: React.ComponentProps<"nav">) => (
   <nav

--- a/src/i18n/__tests__/messages.test.ts
+++ b/src/i18n/__tests__/messages.test.ts
@@ -1,0 +1,35 @@
+// SPDX-FileCopyrightText: 2026 PNED G.I.E.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+import { getFlatMessages, getMessages } from "@/i18n/messages";
+
+jest.mock("next-intl/routing", () => ({
+  defineRouting: (config: {
+    locales: string[];
+    defaultLocale: string;
+    localePrefix: string;
+  }) => ({
+    ...config,
+    localePrefix: { mode: config.localePrefix },
+  }),
+}));
+
+describe("i18n messages", () => {
+  it("returns flat messages for a locale", () => {
+    const messages = getFlatMessages("fr");
+
+    expect(messages["auth.login"]).toBe("Connexion");
+    expect(messages["basket.addToBasket"]).toBe("Ajouter au panier");
+  });
+
+  it("returns nested messages for next-intl consumption", () => {
+    const messages = getMessages("en") as {
+      auth: { logout: string };
+      basket: { removeFromBasket: string };
+    };
+
+    expect(messages.auth.logout).toBe("Log out");
+    expect(messages.basket.removeFromBasket).toBe("Remove from basket");
+  });
+});

--- a/src/i18n/__tests__/navigation.test.ts
+++ b/src/i18n/__tests__/navigation.test.ts
@@ -1,0 +1,38 @@
+// SPDX-FileCopyrightText: 2026 PNED G.I.E.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+const createNavigationMock = jest.fn(() => ({
+  Link: "Link",
+  redirect: jest.fn(),
+  permanentRedirect: jest.fn(),
+  usePathname: jest.fn(),
+  useRouter: jest.fn(),
+  getPathname: jest.fn(),
+}));
+
+jest.mock("next-intl/navigation", () => ({
+  createNavigation: (routing: unknown) => createNavigationMock(routing),
+}));
+
+jest.mock("next-intl/routing", () => ({
+  defineRouting: (config: {
+    locales: string[];
+    defaultLocale: string;
+    localePrefix: string;
+  }) => ({
+    ...config,
+    localePrefix: { mode: config.localePrefix },
+  }),
+}));
+
+describe("i18n navigation", () => {
+  it("creates navigation helpers from the routing config", async () => {
+    const { routing } = await import("@/i18n/routing");
+    const navigation = await import("@/i18n/navigation");
+
+    expect(createNavigationMock).toHaveBeenCalledWith(routing);
+    expect(navigation.Link).toBe("Link");
+    expect(typeof navigation.redirect).toBe("function");
+  });
+});

--- a/src/i18n/__tests__/navigation.test.ts
+++ b/src/i18n/__tests__/navigation.test.ts
@@ -2,7 +2,7 @@
 //
 // SPDX-License-Identifier: Apache-2.0
 
-const createNavigationMock = jest.fn(() => ({
+const createNavigationMock = jest.fn((_routing?: unknown) => ({
   Link: "Link",
   redirect: jest.fn(),
   permanentRedirect: jest.fn(),

--- a/src/i18n/__tests__/request.test.ts
+++ b/src/i18n/__tests__/request.test.ts
@@ -1,0 +1,52 @@
+// SPDX-FileCopyrightText: 2026 PNED G.I.E.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+jest.mock("next-intl/server", () => ({
+  getRequestConfig: (
+    factory: (params: {
+      requestLocale: Promise<string | undefined>;
+    }) => Promise<unknown>
+  ) => factory,
+}));
+
+jest.mock("next-intl/routing", () => ({
+  defineRouting: (config: {
+    locales: string[];
+    defaultLocale: string;
+    localePrefix: string;
+  }) => ({
+    ...config,
+    localePrefix: { mode: config.localePrefix },
+  }),
+}));
+
+describe("i18n request config", () => {
+  it("returns locale specific messages for a supported locale", async () => {
+    const requestConfig = (await import("@/i18n/request")).default;
+
+    const result = (await requestConfig({
+      requestLocale: Promise.resolve("fr"),
+    })) as {
+      locale: string;
+      messages: { auth: { login: string } };
+    };
+
+    expect(result.locale).toBe("fr");
+    expect(result.messages.auth.login).toBe("Connexion");
+  });
+
+  it("falls back to the default locale for unsupported locales", async () => {
+    const requestConfig = (await import("@/i18n/request")).default;
+
+    const result = (await requestConfig({
+      requestLocale: Promise.resolve("de"),
+    })) as {
+      locale: string;
+      messages: { nav: { home: string } };
+    };
+
+    expect(result.locale).toBe("en");
+    expect(result.messages.nav.home).toBe("Home");
+  });
+});

--- a/src/i18n/__tests__/routing.test.ts
+++ b/src/i18n/__tests__/routing.test.ts
@@ -19,6 +19,6 @@ describe("i18n routing", () => {
   it("defines the supported locales and default locale", () => {
     expect(routing.locales).toEqual(["en", "fr"]);
     expect(routing.defaultLocale).toBe("en");
-    expect(routing.localePrefix.mode).toBe("always");
+    expect(routing.localePrefix).toBe("always");
   });
 });

--- a/src/i18n/__tests__/routing.test.ts
+++ b/src/i18n/__tests__/routing.test.ts
@@ -1,0 +1,24 @@
+// SPDX-FileCopyrightText: 2026 PNED G.I.E.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+import { routing } from "@/i18n/routing";
+
+jest.mock("next-intl/routing", () => ({
+  defineRouting: (config: {
+    locales: string[];
+    defaultLocale: string;
+    localePrefix: string;
+  }) => ({
+    ...config,
+    localePrefix: { mode: config.localePrefix },
+  }),
+}));
+
+describe("i18n routing", () => {
+  it("defines the supported locales and default locale", () => {
+    expect(routing.locales).toEqual(["en", "fr"]);
+    expect(routing.defaultLocale).toBe("en");
+    expect(routing.localePrefix.mode).toBe("always");
+  });
+});

--- a/src/i18n/__tests__/routing.test.ts
+++ b/src/i18n/__tests__/routing.test.ts
@@ -19,6 +19,6 @@ describe("i18n routing", () => {
   it("defines the supported locales and default locale", () => {
     expect(routing.locales).toEqual(["en", "fr"]);
     expect(routing.defaultLocale).toBe("en");
-    expect(routing.localePrefix).toBe("always");
+    expect(routing.localePrefix).toEqual({ mode: "always" });
   });
 });

--- a/src/i18n/messages.json
+++ b/src/i18n/messages.json
@@ -1,0 +1,478 @@
+{
+  "metadata.siteTitle": {
+    "en": "GDI - User Portal",
+    "fr": "GDI - Portail utilisateur"
+  },
+  "metadata.siteDescription": {
+    "en": "Genomic Data Infrastructure User Portal",
+    "fr": "Portail utilisateur de l'infrastructure de donnees genomiques"
+  },
+  "nav.home": {
+    "en": "Home",
+    "fr": "Accueil"
+  },
+  "nav.datasets": {
+    "en": "Datasets",
+    "fr": "Jeux de donnees"
+  },
+  "nav.alleleFrequency": {
+    "en": "Allele Frequency",
+    "fr": "Frequence allelique"
+  },
+  "nav.themes": {
+    "en": "Themes",
+    "fr": "Themes"
+  },
+  "nav.publishers": {
+    "en": "Publishers",
+    "fr": "Fournisseurs"
+  },
+  "nav.about": {
+    "en": "About",
+    "fr": "A propos"
+  },
+  "nav.requests": {
+    "en": "Requests",
+    "fr": "Demandes"
+  },
+  "auth.login": {
+    "en": "Login",
+    "fr": "Connexion"
+  },
+  "auth.logout": {
+    "en": "Log out",
+    "fr": "Se deconnecter"
+  },
+  "localeSwitcher.label": {
+    "en": "Language",
+    "fr": "Langue"
+  },
+  "localeSwitcher.en": {
+    "en": "EN",
+    "fr": "EN"
+  },
+  "localeSwitcher.fr": {
+    "en": "FR",
+    "fr": "FR"
+  },
+  "home.title": {
+    "en": "WELCOME TO GDI",
+    "fr": "BIENVENUE SUR GDI"
+  },
+  "home.subtitle": {
+    "en": "The Genomic Data Infrastructure (GDI) project is enabling access to genomic and related phenotypic and clinical data across Europe.",
+    "fr": "Le projet Genomic Data Infrastructure (GDI) permet l'acces aux donnees genomiques ainsi qu'aux donnees phenotypiques et cliniques associees a travers l'Europe."
+  },
+  "home.noticeTitle": {
+    "en": "Planned maintenance notice",
+    "fr": "Avis de maintenance planifiee"
+  },
+  "home.noticeMessage": {
+    "en": "Because of scheduled migration in our provider, the User portal could get service disruption on 19 February between 11:00 and 14:00.",
+    "fr": "En raison d'une migration planifiee chez notre fournisseur, le portail utilisateur pourrait subir une interruption de service le 19 fevrier entre 11h00 et 14h00."
+  },
+  "home.aboutContent": {
+    "en": "The Genomic Data Infrastructure (GDI) homepage is your gateway to an extensive network of genomic data designed to revolutionize research, policymaking, and healthcare in Europe. The GDI project aims to provide seamless access to over one million genome sequences, facilitating groundbreaking advancements in personalized medicine for various diseases, including cancer and rare conditions. By integrating genomic, phenotypic, and clinical data, GDI supports precise diagnostics, treatments, and clinical decision-making. Explore our user-friendly platform to connect with crucial datasets, and join our mission to enhance healthcare outcomes and foster innovation across Europe. Visit the GDI website for more information.",
+    "fr": "La page d'accueil de la Genomic Data Infrastructure (GDI) est votre porte d'entree vers un vaste reseau de donnees genomiques concu pour transformer la recherche, l'elaboration des politiques publiques et les soins de sante en Europe. Le projet GDI vise a fournir un acces fluide a plus d'un million de genomes, en favorisant des avancees majeures en medecine personnalisee pour diverses maladies, notamment le cancer et les maladies rares. En integrant les donnees genomiques, phenotypiques et cliniques, GDI soutient des diagnostics, des traitements et une prise de decision clinique plus precise. Explorez notre plateforme conviviale pour acceder a des jeux de donnees essentiels et rejoignez notre mission d'amelioration des soins et de stimulation de l'innovation a travers l'Europe. Consultez le site web de GDI pour en savoir plus."
+  },
+  "home.aboutPortal": {
+    "en": "About the data portal",
+    "fr": "A propos du portail de donnees"
+  },
+  "home.readMore": {
+    "en": "Read more",
+    "fr": "En savoir plus"
+  },
+  "home.recentDatasets": {
+    "en": "Most Recent Datasets",
+    "fr": "Jeux de donnees les plus recents"
+  },
+  "home.themesSectionTitle": {
+    "en": "Themes",
+    "fr": "Themes"
+  },
+  "footer.banner": {
+    "en": "How to use the data portal",
+    "fr": "Comment utiliser le portail de donnees"
+  },
+  "footer.funding": {
+    "en": "GDI project receives funding from the European Union's Digital Europe \n Programme under grant agreement number 101081813.",
+    "fr": "Le projet GDI recoit un financement de l'Union europeenne dans le cadre du programme Europe numerique \n au titre de la convention de subvention numero 101081813."
+  },
+  "footer.legal": {
+    "en": "Legal",
+    "fr": "Mentions legales"
+  },
+  "footer.terms": {
+    "en": "Terms & Conditions",
+    "fr": "Conditions generales"
+  },
+  "footer.privacy": {
+    "en": "Privacy Notice",
+    "fr": "Avis de confidentialite"
+  },
+  "footer.cookies": {
+    "en": "Cookie Policy",
+    "fr": "Politique relative aux cookies"
+  },
+  "footer.portalLinks": {
+    "en": "Portal Links",
+    "fr": "Liens du portail"
+  },
+  "footer.contactUs": {
+    "en": "Contact Us",
+    "fr": "Nous contacter"
+  },
+  "footer.getInTouch": {
+    "en": "Get in touch",
+    "fr": "Nous contacter"
+  },
+  "search.placeholder": {
+    "en": "Search datasets",
+    "fr": "Rechercher des jeux de donnees"
+  },
+  "recent.seeAll": {
+    "en": "See all",
+    "fr": "Voir tout"
+  },
+  "recent.readMore": {
+    "en": "Read More",
+    "fr": "En savoir plus"
+  },
+  "valueList.datasetCount": {
+    "en": "{count, plural, one {# dataset} other {# datasets}}",
+    "fr": "{count, plural, one {# jeu de donnees} other {# jeux de donnees}}"
+  },
+  "valueList.seeDatasets": {
+    "en": "See datasets",
+    "fr": "Voir les jeux de donnees"
+  },
+  "error.genericHeading": {
+    "en": "Something Went Wrong",
+    "fr": "Une erreur est survenue"
+  },
+  "error.genericMessage": {
+    "en": "Our apologies, but our server has encountered an internal error that prevents it from fulfilling your request. This is a temporary issue, and we're on the case to get it fixed. Please try again in a little while.",
+    "fr": "Toutes nos excuses, mais notre serveur a rencontre une erreur interne qui l'empeche de traiter votre requete. Il s'agit d'un probleme temporaire et nous travaillons deja a sa resolution. Veuillez reessayer dans quelques instants."
+  },
+  "error.notFoundHeading": {
+    "en": "Page Not Found",
+    "fr": "Page introuvable"
+  },
+  "error.notFoundMessage": {
+    "en": "The page you're looking for doesn't seem to exist. It might have been moved or deleted.",
+    "fr": "La page que vous recherchez semble ne pas exister. Elle a peut-etre ete deplacee ou supprimee."
+  },
+  "error.unauthorizedHeading": {
+    "en": "Unauthorized",
+    "fr": "Acces non autorise"
+  },
+  "error.unauthorizedMessage": {
+    "en": "You're not authorized to access this page. Please log in and try again.",
+    "fr": "Vous n'etes pas autorise a acceder a cette page. Veuillez vous connecter puis reessayer."
+  },
+  "error.takeMeHome": {
+    "en": "Take me home",
+    "fr": "Retour a l'accueil"
+  },
+  "datasets.results": {
+    "en": "{count, plural, =0 {No datasets found} one {# dataset found} other {# datasets found}}",
+    "fr": "{count, plural, =0 {Aucun jeu de donnees trouve} one {# jeu de donnees trouve} other {# jeux de donnees trouves}}"
+  },
+  "datasets.noResults": {
+    "en": "No datasets found matching your criteria. Try adjusting your search or filters.",
+    "fr": "Aucun jeu de donnees ne correspond a vos criteres. Essayez d'ajuster votre recherche ou vos filtres."
+  },
+  "datasets.catalogueFilters": {
+    "en": "Catalogue Filters",
+    "fr": "Filtres du catalogue"
+  },
+  "datasets.individualFilters": {
+    "en": "Individual-level data discovery Filters",
+    "fr": "Filtres de decouverte de donnees au niveau individuel"
+  },
+  "datasets.individualFiltersDescription": {
+    "en": "Filter by individual-level data characteristics",
+    "fr": "Filtrer par caracteristiques de donnees au niveau individuel"
+  },
+  "datasets.conformsToUnspecified": {
+    "en": "Conforms to: Not specified for this dataset",
+    "fr": "Conforme a : non precise pour ce jeu de donnees"
+  },
+  "datasets.beaconToggle": {
+    "en": "Include Individual-level data discovery",
+    "fr": "Inclure la decouverte de donnees au niveau individuel"
+  },
+  "datasets.beaconActive": {
+    "en": "Active",
+    "fr": "Actif"
+  },
+  "datasets.beaconEnabled": {
+    "en": "Showing datasets with individual-level data and record counts from Individual-level data discovery (searches may be slower)",
+    "fr": "Affichage des jeux de donnees avec donnees individuelles et nombre d'enregistrements issus de la decouverte de donnees au niveau individuel (les recherches peuvent etre plus lentes)"
+  },
+  "datasets.beaconDisabled": {
+    "en": "Enable to filter by individual-level data characteristics and see record counts",
+    "fr": "Activez cette option pour filtrer par caracteristiques de donnees au niveau individuel et voir le nombre d'enregistrements"
+  },
+  "themes.title": {
+    "en": "Themes",
+    "fr": "Themes"
+  },
+  "themes.loading": {
+    "en": "Retrieving themes. This may take a few moments.",
+    "fr": "Recuperation des themes. Cela peut prendre quelques instants."
+  },
+  "themes.empty": {
+    "en": "No themes found.",
+    "fr": "Aucun theme trouve."
+  },
+  "publishers.title": {
+    "en": "Publishers",
+    "fr": "Fournisseurs"
+  },
+  "publishers.loading": {
+    "en": "Retrieving publishers. This may take a few moments.",
+    "fr": "Recuperation des fournisseurs. Cela peut prendre quelques instants."
+  },
+  "publishers.empty": {
+    "en": "No publishers found.",
+    "fr": "Aucun fournisseur trouve."
+  },
+  "basket.title": {
+    "en": "Your Basket",
+    "fr": "Votre panier"
+  },
+  "basket.titleWithCount": {
+    "en": "Your Basket ({count})",
+    "fr": "Votre panier ({count})"
+  },
+  "basket.loading": {
+    "en": "Loading your basket...",
+    "fr": "Chargement de votre panier..."
+  },
+  "basket.loginToRequest": {
+    "en": "Login to request",
+    "fr": "Se connecter pour demander"
+  },
+  "basket.requestNow": {
+    "en": "Request now",
+    "fr": "Faire la demande"
+  },
+  "basket.continueAdding": {
+    "en": "Continue adding",
+    "fr": "Continuer a ajouter"
+  },
+  "basket.empty": {
+    "en": "Your basket is empty.",
+    "fr": "Votre panier est vide."
+  },
+  "basket.addDatasets": {
+    "en": "Add datasets",
+    "fr": "Ajouter des jeux de donnees"
+  },
+  "basket.addToBasket": {
+    "en": "Add to basket",
+    "fr": "Ajouter au panier"
+  },
+  "basket.removeFromBasket": {
+    "en": "Remove from basket",
+    "fr": "Retirer du panier"
+  },
+  "requests.tabs.applications": {
+    "en": "Applications",
+    "fr": "Demandes"
+  },
+  "requests.tabs.entitlements": {
+    "en": "Entitlements",
+    "fr": "Autorisations"
+  },
+  "requests.applications.loading": {
+    "en": "Retrieving applications...",
+    "fr": "Recuperation des demandes..."
+  },
+  "requests.applications.title": {
+    "en": "Manage your Applications",
+    "fr": "Gerer vos demandes"
+  },
+  "requests.applications.subtitle": {
+    "en": "View and update your submitted applications",
+    "fr": "Consultez et mettez a jour vos demandes soumises"
+  },
+  "requests.applications.empty": {
+    "en": "You don't have any applications yet.",
+    "fr": "Vous n'avez encore aucune demande."
+  },
+  "requests.applications.addDatasets": {
+    "en": "Add datasets",
+    "fr": "Ajouter des jeux de donnees"
+  },
+  "requests.entitlements.loading": {
+    "en": "Retrieving entitlements...",
+    "fr": "Recuperation des autorisations..."
+  },
+  "requests.entitlements.title": {
+    "en": "Entitlements",
+    "fr": "Autorisations"
+  },
+  "requests.entitlements.subtitle": {
+    "en": "View your entitlements",
+    "fr": "Consultez vos autorisations"
+  },
+  "requests.entitlements.empty": {
+    "en": "You don't have any entitlement yet.\nWait for your application(s) to be approved, or submit a new application.",
+    "fr": "Vous n'avez encore aucune autorisation.\nAttendez l'approbation de votre ou vos demandes, ou soumettez une nouvelle demande."
+  },
+  "application.title": {
+    "en": "Application {id}",
+    "fr": "Demande {id}"
+  },
+  "application.delete": {
+    "en": "Delete",
+    "fr": "Supprimer"
+  },
+  "application.submit": {
+    "en": "Submit",
+    "fr": "Soumettre"
+  },
+  "application.savingChanges": {
+    "en": "Saving Changes...",
+    "fr": "Enregistrement des modifications..."
+  },
+  "application.lastEvent": {
+    "en": "Last Event: {event} at {time}",
+    "fr": "Dernier evenement : {event} a {time}"
+  },
+  "application.sidebar.datasets": {
+    "en": "Datasets",
+    "fr": "Jeux de donnees"
+  },
+  "application.sidebar.participants": {
+    "en": "Participants",
+    "fr": "Participants"
+  },
+  "application.sidebar.events": {
+    "en": "Events",
+    "fr": "Evenements"
+  },
+  "application.sidebar.at": {
+    "en": "at",
+    "fr": "a"
+  },
+  "application.sidebar.terms": {
+    "en": "Terms & Conditions",
+    "fr": "Conditions generales"
+  },
+  "contact.open": {
+    "en": "Get in touch",
+    "fr": "Nous contacter"
+  },
+  "contact.title": {
+    "en": "Contact Us",
+    "fr": "Nous contacter"
+  },
+  "contact.description": {
+    "en": "Send your inquiry to the right team by selecting a topic.",
+    "fr": "Envoyez votre demande a la bonne equipe en selectionnant un sujet."
+  },
+  "contact.firstName": {
+    "en": "First Name",
+    "fr": "Prenom"
+  },
+  "contact.firstNamePlaceholder": {
+    "en": "Your first name",
+    "fr": "Votre prenom"
+  },
+  "contact.lastName": {
+    "en": "Last Name",
+    "fr": "Nom"
+  },
+  "contact.lastNamePlaceholder": {
+    "en": "Your last name",
+    "fr": "Votre nom"
+  },
+  "contact.email": {
+    "en": "Email",
+    "fr": "E-mail"
+  },
+  "contact.emailPlaceholder": {
+    "en": "you@example.org",
+    "fr": "vous@exemple.org"
+  },
+  "contact.topic": {
+    "en": "Topic",
+    "fr": "Sujet"
+  },
+  "contact.topicLoading": {
+    "en": "Loading topics...",
+    "fr": "Chargement des sujets..."
+  },
+  "contact.topicEmpty": {
+    "en": "No topics available",
+    "fr": "Aucun sujet disponible"
+  },
+  "contact.subject": {
+    "en": "Title",
+    "fr": "Titre"
+  },
+  "contact.subjectPlaceholder": {
+    "en": "A short title",
+    "fr": "Un titre court"
+  },
+  "contact.message": {
+    "en": "Message",
+    "fr": "Message"
+  },
+  "contact.messagePlaceholder": {
+    "en": "Describe your request",
+    "fr": "Decrivez votre demande"
+  },
+  "contact.cancel": {
+    "en": "Cancel",
+    "fr": "Annuler"
+  },
+  "contact.submit": {
+    "en": "Submit",
+    "fr": "Envoyer"
+  },
+  "contact.submitting": {
+    "en": "Submitting...",
+    "fr": "Envoi en cours..."
+  },
+  "contact.success": {
+    "en": "Your request has been submitted successfully.",
+    "fr": "Votre demande a ete envoyee avec succes."
+  },
+  "contact.errorTopics": {
+    "en": "Unable to load support topic options.",
+    "fr": "Impossible de charger les options de sujet d'assistance."
+  },
+  "contact.errorSubmit": {
+    "en": "Your request could not be submitted. Please try again.",
+    "fr": "Votre demande n'a pas pu etre envoyee. Veuillez reessayer."
+  },
+  "contact.validation.firstName": {
+    "en": "Please provide your first name.",
+    "fr": "Veuillez renseigner votre prenom."
+  },
+  "contact.validation.lastName": {
+    "en": "Please provide your last name.",
+    "fr": "Veuillez renseigner votre nom."
+  },
+  "contact.validation.email": {
+    "en": "Please provide a valid email address.",
+    "fr": "Veuillez renseigner une adresse e-mail valide."
+  },
+  "contact.validation.topic": {
+    "en": "Please select a topic.",
+    "fr": "Veuillez selectionner un sujet."
+  },
+  "contact.validation.subject": {
+    "en": "Please provide a title.",
+    "fr": "Veuillez renseigner un titre."
+  },
+  "contact.validation.message": {
+    "en": "Please enter a message.",
+    "fr": "Veuillez saisir un message."
+  }
+}

--- a/src/i18n/messages.json.license
+++ b/src/i18n/messages.json.license
@@ -1,0 +1,3 @@
+// SPDX-FileCopyrightText: 2026 PNED G.I.E.
+//
+// SPDX-License-Identifier: Apache-2.0

--- a/src/i18n/messages.ts
+++ b/src/i18n/messages.ts
@@ -1,0 +1,67 @@
+// SPDX-FileCopyrightText: 2026 PNED G.I.E.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+import messageCatalog from "./messages.json";
+import { routing, type AppLocale } from "./routing";
+
+type FlatMessageCatalog = Record<string, Record<AppLocale, string>>;
+type FlatMessages = Record<string, string>;
+type NestedMessages = Record<string, unknown>;
+
+const typedCatalog = messageCatalog as FlatMessageCatalog;
+
+function toLocaleMessages(locale: AppLocale): FlatMessages {
+  return Object.fromEntries(
+    Object.entries(typedCatalog).map(([key, translations]) => [
+      key,
+      translations[locale],
+    ])
+  );
+}
+
+function toNestedMessages(messages: FlatMessages): NestedMessages {
+  const nestedMessages: NestedMessages = {};
+
+  for (const [key, value] of Object.entries(messages)) {
+    const keyParts = key.split(".");
+    let currentLevel = nestedMessages;
+
+    keyParts.forEach((keyPart, index) => {
+      if (index === keyParts.length - 1) {
+        currentLevel[keyPart] = value;
+        return;
+      }
+
+      if (
+        typeof currentLevel[keyPart] !== "object" ||
+        currentLevel[keyPart] === null
+      ) {
+        currentLevel[keyPart] = {};
+      }
+
+      currentLevel = currentLevel[keyPart] as NestedMessages;
+    });
+  }
+
+  return nestedMessages;
+}
+
+const flatMessages = Object.fromEntries(
+  routing.locales.map((locale) => [locale, toLocaleMessages(locale)])
+) as Record<AppLocale, FlatMessages>;
+
+const nestedMessages = Object.fromEntries(
+  routing.locales.map((locale) => [
+    locale,
+    toNestedMessages(flatMessages[locale]),
+  ])
+) as Record<AppLocale, NestedMessages>;
+
+export function getMessages(locale: AppLocale): NestedMessages {
+  return nestedMessages[locale];
+}
+
+export function getFlatMessages(locale: AppLocale): FlatMessages {
+  return flatMessages[locale];
+}

--- a/src/i18n/navigation.ts
+++ b/src/i18n/navigation.ts
@@ -1,0 +1,15 @@
+// SPDX-FileCopyrightText: 2026 PNED G.I.E.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+import { createNavigation } from "next-intl/navigation";
+import { routing } from "./routing";
+
+export const {
+  Link,
+  redirect,
+  permanentRedirect,
+  usePathname,
+  useRouter,
+  getPathname,
+} = createNavigation(routing);

--- a/src/i18n/request.ts
+++ b/src/i18n/request.ts
@@ -1,0 +1,24 @@
+// SPDX-FileCopyrightText: 2026 PNED G.I.E.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+import { getRequestConfig } from "next-intl/server";
+import { getMessages } from "./messages";
+import { routing, type AppLocale } from "./routing";
+
+function isValidLocale(locale: string): locale is AppLocale {
+  return routing.locales.includes(locale as AppLocale);
+}
+
+export default getRequestConfig(async ({ requestLocale }) => {
+  const requestedLocale = await requestLocale;
+  const locale =
+    requestedLocale && isValidLocale(requestedLocale)
+      ? requestedLocale
+      : routing.defaultLocale;
+
+  return {
+    locale,
+    messages: getMessages(locale),
+  };
+});

--- a/src/i18n/routing.ts
+++ b/src/i18n/routing.ts
@@ -1,0 +1,13 @@
+// SPDX-FileCopyrightText: 2026 PNED G.I.E.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+import { defineRouting } from "next-intl/routing";
+
+export const routing = defineRouting({
+  locales: ["en", "fr"],
+  defaultLocale: "en",
+  localePrefix: "always",
+});
+
+export type AppLocale = (typeof routing.locales)[number];

--- a/src/proxy.ts
+++ b/src/proxy.ts
@@ -1,11 +1,31 @@
-// SPDX-FileCopyrightText: 2024 PNED G.I.E.
+// SPDX-FileCopyrightText: 2026 PNED G.I.E.
 //
 // SPDX-License-Identifier: Apache-2.0
 
+import { routing } from "@/i18n/routing";
 import { getToken } from "next-auth/jwt";
+import createMiddleware from "next-intl/middleware";
 import { NextRequest, NextResponse } from "next/server";
 
+const handleI18nRouting = createMiddleware(routing);
+
+function isProtectedPathname(pathname: string) {
+  return new RegExp(
+    `^/(?:${routing.locales.join("|")})/(?:requests|applications)(?:/.*)?$`
+  ).test(pathname);
+}
+
 export async function proxy(req: NextRequest) {
+  const response = handleI18nRouting(req);
+
+  if (response.headers.get("location")) {
+    return response;
+  }
+
+  if (!isProtectedPathname(req.nextUrl.pathname)) {
+    return response;
+  }
+
   const token = await getToken({ req });
 
   if (!token) {
@@ -16,14 +36,19 @@ export async function proxy(req: NextRequest) {
       "client_id",
       process.env.KEYCLOAK_CLIENT_ID!
     );
-    keycloakLoginUrl.searchParams.append("redirect_uri", `/`);
+    keycloakLoginUrl.searchParams.append(
+      "redirect_uri",
+      `${req.nextUrl.pathname}${req.nextUrl.search}`
+    );
     keycloakLoginUrl.searchParams.append("response_type", "code");
     keycloakLoginUrl.searchParams.append("scope", "openid profile email");
 
     return NextResponse.redirect(keycloakLoginUrl.toString());
   }
 
-  return NextResponse.next();
+  return response;
 }
 
-export const config = { matcher: ["/requests", "/applications"] };
+export const config = {
+  matcher: ["/((?!api|_next|.*\\..*).*)"],
+};


### PR DESCRIPTION
PR description
Adds internationalization to the public Next.js app using next-intl with SEO-friendly locale-prefixed routes (/en/..., /fr/...).

What changed

 - added App Router i18n setup with locale-prefixed routing
 - merged locale handling into proxy/middleware flow
 - introduced a single translation catalog in src/i18n/messages.json
 - switched translation authoring to key-first entries with per-locale values
 - added locale-aware navigation and footer language dropdown
 - localized shared UI and key public/authenticated flows, including basket and logout labels
 - updated sitemap generation for localized public URLs

Notes

 - canonical language URLs are now locale-prefixed
 - existing non-prefixed links should redirect to the appropriate localized routes
 - markdown-backed content is not yet split into separate localized content files
 - there are still unrelated pre-existing TypeScript issues elsewhere in the repo not introduced by this change

## Summary by Sourcery

Introduce locale-prefixed internationalization using next-intl and update public navigation, layouts, and messaging to use translated copy.

New Features:
- Add next-intl-based i18n infrastructure with locale-prefixed routing and shared message catalog.
- Introduce a locale switcher in the footer to let users toggle between supported languages.
- Serve localized sitemap entries for each public route and locale.
- Localize key user flows including home, datasets, basket, applications, requests, footer, and error pages.

Enhancements:
- Refine proxy middleware to integrate i18n routing and preserve protected route redirects with locale-aware callback URLs.
- Adjust navigation, links, and routing helpers to use locale-aware navigation utilities.
- Improve accessibility and semantics of buttons and links in shared components like Button and header logo handling.

Build:
- Configure next-intl plugin in Next.js config and wire request-level i18n config.