### PR TITLE
fix: e2e test

### DIFF
--- a/tests/real-smoke.spec.ts
+++ b/tests/real-smoke.spec.ts
@@ -29,11 +29,11 @@ test("Real backend smoke: datasets list and detail", async ({ page }) => {
     return;
   }
 
-  const datasetLink = page.locator('a[href^="/datasets/"]:not([href*="?"])');
+  const datasetLink = page.locator('a[href*="/datasets/"]:not([href*="?"])');
   await expect(datasetLink.first()).toBeVisible({ timeout: 15000 });
 
   await datasetLink.first().click();
-  await expect(page).toHaveURL(/\/datasets\/[^/?]+$/);
+  await expect(page).toHaveURL(/\/(en|fr)\/datasets\/[^/?]+$/);
   await expect(page.getByRole("heading", { level: 1 })).toBeVisible({
     timeout: 15000,
   });
@@ -44,11 +44,11 @@ test("Real backend smoke: basket page", async ({ page }) => {
 
   await page.goto("/datasets?page=1");
 
-  const datasetLink = page.locator('a[href^="/datasets/"]:not([href*="?"])');
+  const datasetLink = page.locator('a[href*="/datasets/"]:not([href*="?"])');
   if (await datasetLink.count()) {
     await datasetLink.first().click();
 
-    const addButton = page.locator("a", { hasText: /add to basket/i });
+    const addButton = page.getByRole("button", { name: /add to basket/i });
     if (await addButton.count()) {
       await addButton.click();
     }


### PR DESCRIPTION
## Summary by Sourcery

Update end-to-end smoke tests to align with localized dataset URLs and revised basket interaction.

Tests:
- Adjust dataset link locator and URL assertion in smoke tests to account for language-prefixed paths.
- Update basket smoke test to target the 'add to basket' button by role and label instead of a link selector.