### PR TITLE
fix: e2e

### DIFF
--- a/tests/real-smoke.spec.ts
+++ b/tests/real-smoke.spec.ts
@@ -33,7 +33,7 @@ test("Real backend smoke: datasets list and detail", async ({ page }) => {
   await expect(datasetLink.first()).toBeVisible({ timeout: 15000 });
 
   await datasetLink.first().click();
-  await expect(page).toHaveURL(/\/(en|fr)\/datasets\/[^/?]+$/);
+  await expect(page).toHaveURL(/\/(?:(en|fr)\/)?datasets\/[^/?]+$/);
   await expect(page.getByRole("heading", { level: 1 })).toBeVisible({
     timeout: 15000,
   });


### PR DESCRIPTION
## Summary by Sourcery

Relax URL expectation in real backend smoke test to support dataset pages with or without a locale prefix.

Bug Fixes:
- Fix e2e smoke test failure caused by asserting a locale-prefixed dataset URL when the locale segment may be absent.

Tests:
- Update dataset detail URL assertion in real smoke test to match both localized and non-localized routes.