### PR TITLE
feat: add french translations

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -18974,6 +18974,111 @@
         "type": "github",
         "url": "https://github.com/sponsors/wooorm"
       }
+    },
+    "node_modules/next-runtime-env/node_modules/@next/swc-darwin-x64": {
+      "version": "16.2.9",
+      "resolved": "https://registry.npmjs.org/@next/swc-darwin-x64/-/swc-darwin-x64-16.2.9.tgz",
+      "integrity": "sha512-7IAtK4MeybpqRV9GRABWEhJ62mOS+rzWOzOTFie4cSEtm12xsoOMJRcECoZx3FHPzFAqN/IJtHqWAFOLfl152w==",
+      "cpu": [
+        "x64"
+      ],
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/next-runtime-env/node_modules/@next/swc-linux-arm64-gnu": {
+      "version": "16.2.9",
+      "resolved": "https://registry.npmjs.org/@next/swc-linux-arm64-gnu/-/swc-linux-arm64-gnu-16.2.9.tgz",
+      "integrity": "sha512-hBD75iWpUtkL9SmQmcRhmLomn9jgkPzCEkbOcLgHymPEKzv+6ONy13RRiIEz/iEObjkS2Jlb5gYS2XGoS3X4rw==",
+      "cpu": [
+        "arm64"
+      ],
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/next-runtime-env/node_modules/@next/swc-linux-arm64-musl": {
+      "version": "16.2.9",
+      "resolved": "https://registry.npmjs.org/@next/swc-linux-arm64-musl/-/swc-linux-arm64-musl-16.2.9.tgz",
+      "integrity": "sha512-qZTI3pf9SGc/obr8NkQAekBxmp1QK+kVm+VAf3BALLfFAj+1kUhkTxmrWpVos9R/UYIA8AWX2p6cGI5WdwzVUA==",
+      "cpu": [
+        "arm64"
+      ],
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/next-runtime-env/node_modules/@next/swc-linux-x64-gnu": {
+      "version": "16.2.9",
+      "resolved": "https://registry.npmjs.org/@next/swc-linux-x64-gnu/-/swc-linux-x64-gnu-16.2.9.tgz",
+      "integrity": "sha512-xm0HfRNX+UkH4R3c18ynswjj5o5uEj/7iI9p9omdtTSIsRCzQqkGMA+10nzJ4EHnYC3as65IMhbbl5fWRUWHYg==",
+      "cpu": [
+        "x64"
+      ],
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/next-runtime-env/node_modules/@next/swc-linux-x64-musl": {
+      "version": "16.2.9",
+      "resolved": "https://registry.npmjs.org/@next/swc-linux-x64-musl/-/swc-linux-x64-musl-16.2.9.tgz",
+      "integrity": "sha512-QumimHkGEG6vM3PfEDWKyKen03NcqLOkeKB1EfcPe7VxzmEiCa4jNnMyBn/US5zcd/VE1CI+O8Ovb3lfjVHfGw==",
+      "cpu": [
+        "x64"
+      ],
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/next-runtime-env/node_modules/@next/swc-win32-arm64-msvc": {
+      "version": "16.2.9",
+      "resolved": "https://registry.npmjs.org/@next/swc-win32-arm64-msvc/-/swc-win32-arm64-msvc-16.2.9.tgz",
+      "integrity": "sha512-hzQpKZvw8rAwI6A2uQh6SacCSvNAXaIkPNsWwzqqfRiIMiXMfH936skDhz1OO6KpvdKkJrgHHtqQOq5PIXOvdQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/next-runtime-env/node_modules/@next/swc-win32-x64-msvc": {
+      "version": "16.2.9",
+      "resolved": "https://registry.npmjs.org/@next/swc-win32-x64-msvc/-/swc-win32-x64-msvc-16.2.9.tgz",
+      "integrity": "sha512-qr2VL3Ce5QrwgO2yh1ujSBawrimjVKX8FGF/cOynmdYKJY0BdHpGVNIRK1tqONB10Vkm25Ub1BD2bkjWs4+96w==",
+      "cpu": [
+        "x64"
+      ],
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
     }
   }
 }

--- a/src/app/allele-frequency/GVariantsSearchBar.tsx
+++ b/src/app/allele-frequency/GVariantsSearchBar.tsx
@@ -10,6 +10,7 @@ import { faInfoCircle, faSearch } from "@fortawesome/free-solid-svg-icons";
 import { FontAwesomeIcon } from "@fortawesome/react-fontawesome";
 import React, { useState } from "react";
 import Tooltip from "../datasets/[id]/Tooltip";
+import { useTranslations } from "next-intl";
 
 type FormFieldProps = {
   fieldKey: string;
@@ -94,21 +95,6 @@ export type SearchInputData = {
   datasetType: string;
 };
 
-const REFERENCE_OPTIONS = [
-  { value: "", label: "Select reference genome" },
-  { value: "GRCh37", label: "GRCh37" },
-  { value: "GRCh38", label: "GRCh38" },
-];
-
-const SEX_OPTIONS = [
-  { value: "", label: "Select sex" },
-  { value: "All", label: "All" },
-  { value: "M", label: "Male" },
-  { value: "F", label: "Female" },
-];
-
-const DISABLED_SEARCH_TOOLTIP =
-  "First select the reference genome, then provide the variant. Position is entered as 1-based and converted to 0-based for the query.";
 const ALL_VARIANT_SEARCH_ENABLED = contentConfig.enableAllVariantSearch;
 
 export default function GVariantsSearchBar({
@@ -116,6 +102,23 @@ export default function GVariantsSearchBar({
   loading,
   datasetTypeOptions,
 }: GVariantsSearchBarProps) {
+  const t = useTranslations("alleleFrequency");
+
+  const REFERENCE_OPTIONS = [
+    { value: "", label: t("selectReferenceGenome") },
+    { value: "GRCh37", label: "GRCh37" },
+    { value: "GRCh38", label: "GRCh38" },
+  ];
+
+  const SEX_OPTIONS = [
+    { value: "", label: t("selectSex") },
+    { value: "All", label: "All" },
+    { value: "M", label: t("male") },
+    { value: "F", label: t("female") },
+  ];
+
+  const DISABLED_SEARCH_TOOLTIP = t("disabledSearchTooltip");
+
   const [searchFilterInput, setSearchFilterInput] = useState<SearchInputData>({
     variant: "",
     refGenome: "",
@@ -172,10 +175,10 @@ export default function GVariantsSearchBar({
           ? ""
           : normalizedVariant.toLowerCase() === "all" &&
               !ALL_VARIANT_SEARCH_ENABLED
-            ? "Incorrect variant information"
+            ? t("incorrectVariant")
             : isVariantValid(normalizedVariant)
               ? ""
-              : "Incorrect variant information"
+              : t("incorrectVariant")
       );
       return updatedState;
     });
@@ -201,12 +204,12 @@ export default function GVariantsSearchBar({
   };
   return (
     <div className="mb-6">
-      <h2 className="text-lg font-semibold mb-2">Search for your variant:</h2>
+      <h2 className="text-lg font-semibold mb-2">{t("searchForYourVariant")}</h2>
 
       <div className="grid grid-cols-2 md:grid-cols-3 lg:grid-cols-6 gap-4 items-end">
         <FormField
           fieldKey="refGenome"
-          label="Ref Genome"
+          label={t("refGenome")}
           type="select"
           value={searchFilterInput.refGenome}
           onChange={(value) => updateData("refGenome", value)}
@@ -216,19 +219,19 @@ export default function GVariantsSearchBar({
         {canShowVariant && (
           <FormField
             fieldKey="variant"
-            label="Variant"
+            label={t("variant")}
             type="text"
             value={searchFilterInput.variant}
             onChange={(value) => updateData("variant", value)}
-            placeholder="e.g. 21-9411449 or 21-9411449-G-T"
-            tooltip="Supported formats: chromosome-position (e.g. 21-9411449) or chromosome-position-reference-alternate (e.g. 21-9411449-G-T). Position is interpreted as 1-based."
+            placeholder={t("variantPlaceholder")}
+            tooltip={t("variantTooltip")}
           />
         )}
 
         {canShowSex && (
           <FormField
             fieldKey="sex"
-            label="Sex"
+            label={t("sex")}
             type="select"
             value={searchFilterInput.sex}
             onChange={(value) => updateData("sex", value)}
@@ -239,12 +242,12 @@ export default function GVariantsSearchBar({
         {canShowCountry && (
           <FormField
             fieldKey="countryOfBirth"
-            label="Country of Birth"
+            label={t("countryOfBirth")}
             type="select"
             value={searchFilterInput.countryOfBirth}
             onChange={(value) => updateData("countryOfBirth", value)}
             options={[
-              { value: "", label: "Select country" },
+              { value: "", label: t("selectCountry") },
               { value: "All", label: "All" },
               ...COUNTRY_OPTIONS,
             ]}
@@ -254,7 +257,7 @@ export default function GVariantsSearchBar({
         {canShowVariant && (
           <FormField
             fieldKey="datasetType"
-            label="Dataset Type"
+            label={t("datasetType")}
             type="select"
             value={searchFilterInput.datasetType}
             onChange={(value) => updateData("datasetType", value)}
@@ -273,7 +276,7 @@ export default function GVariantsSearchBar({
             disabled={isSearchDisabled}
             icon={faSearch}
             onClick={search}
-            text="Search"
+            text={t("search")}
             type="primary"
             className="text-center"
             props={
@@ -285,7 +288,7 @@ export default function GVariantsSearchBar({
 
       {canShowVariant && (
         <div className="text-md flex items-end gap-2 mt-2">
-          <span className="text-black text-md">Variant Example: </span>
+          <span className="text-black text-md">{t("variantExample")}</span>
           <Button
             className="text-info hover:underline p-0 m-0"
             text="21-9411449-G-T"

--- a/src/app/allele-frequency/GVariantsSearchBar.tsx
+++ b/src/app/allele-frequency/GVariantsSearchBar.tsx
@@ -204,7 +204,9 @@ export default function GVariantsSearchBar({
   };
   return (
     <div className="mb-6">
-      <h2 className="text-lg font-semibold mb-2">{t("searchForYourVariant")}</h2>
+      <h2 className="text-lg font-semibold mb-2">
+        {t("searchForYourVariant")}
+      </h2>
 
       <div className="grid grid-cols-2 md:grid-cols-3 lg:grid-cols-6 gap-4 items-end">
         <FormField

--- a/src/app/allele-frequency/GVariantsTable.tsx
+++ b/src/app/allele-frequency/GVariantsTable.tsx
@@ -272,7 +272,8 @@ export default function GVariantsTable({
                                 colSpan={10}
                                 className="px-3 py-2 text-base sm:text-lg font-bold"
                               >
-                                {t("beacon")}{beaconId}
+                                {t("beacon")}
+                                {beaconId}
                                 {beaconCountryLabel
                                   ? ` (${beaconCountryLabel})`
                                   : ""}
@@ -333,10 +334,16 @@ export default function GVariantsTable({
                                     </td>
                                     <td className="px-3 py-2 whitespace-nowrap" />
                                     <td className="px-3 py-2 whitespace-nowrap">
-                                      {renderCell(totals?.alleleCount, notAvailableLabel)}
+                                      {renderCell(
+                                        totals?.alleleCount,
+                                        notAvailableLabel
+                                      )}
                                     </td>
                                     <td className="px-3 py-2 whitespace-nowrap">
-                                      {renderCell(totals?.alleleNumber, notAvailableLabel)}
+                                      {renderCell(
+                                        totals?.alleleNumber,
+                                        notAvailableLabel
+                                      )}
                                     </td>
                                     <td className="px-3 py-2 whitespace-nowrap">
                                       {renderCell(
@@ -360,7 +367,10 @@ export default function GVariantsTable({
                                       {typeof totals?.alleleFrequency ===
                                       "number"
                                         ? totals.alleleFrequency.toFixed(4)
-                                        : renderCell(undefined, notAvailableLabel)}
+                                        : renderCell(
+                                            undefined,
+                                            notAvailableLabel
+                                          )}
                                     </td>
                                     <td className="px-3 py-2 w-[220px] whitespace-nowrap">
                                       <div className="w-[220px]">
@@ -398,10 +408,16 @@ export default function GVariantsTable({
                                           {variant.population || "-"}
                                         </td>
                                         <td className="px-3 py-2 whitespace-nowrap">
-                                          {renderCell(variant.alleleCount, notAvailableLabel)}
+                                          {renderCell(
+                                            variant.alleleCount,
+                                            notAvailableLabel
+                                          )}
                                         </td>
                                         <td className="px-3 py-2 whitespace-nowrap">
-                                          {renderCell(variant.alleleNumber, notAvailableLabel)}
+                                          {renderCell(
+                                            variant.alleleNumber,
+                                            notAvailableLabel
+                                          )}
                                         </td>
                                         <td className="px-3 py-2 whitespace-nowrap">
                                           {renderCell(
@@ -424,7 +440,10 @@ export default function GVariantsTable({
                                         <td className="px-3 py-2 whitespace-nowrap">
                                           {variant.alleleFrequency != null
                                             ? variant.alleleFrequency.toFixed(4)
-                                            : renderCell(undefined, notAvailableLabel)}
+                                            : renderCell(
+                                                undefined,
+                                                notAvailableLabel
+                                              )}
                                         </td>
                                         <td className="px-3 py-2 w-[220px] whitespace-nowrap" />
                                       </tr>

--- a/src/app/allele-frequency/GVariantsTable.tsx
+++ b/src/app/allele-frequency/GVariantsTable.tsx
@@ -11,6 +11,7 @@ import VariantAddToBasketButton from "./components/VariantAddToBasketButton";
 import { GVariantsTableUtils } from "@/utils/GVariantsTableUtils";
 import { findDatasetByIdentifier } from "@/utils/datasetEntitlements";
 import React, { useEffect, useMemo, useState } from "react";
+import { useTranslations } from "next-intl";
 
 type GVariantsTableProps = {
   results: GVariantsSearchResponse[];
@@ -26,11 +27,11 @@ type DatasetActionInfo = {
 
 const NOT_AVAILABLE = GVariantsTableUtils.NOT_AVAILABLE;
 
-const renderCell = (value: unknown) =>
+const renderCell = (value: unknown, notAvailableLabel: string) =>
   value != null && (typeof value === "string" || typeof value === "number") ? (
     value
   ) : (
-    <span className="text-xs text-gray-400">not available</span>
+    <span className="text-xs text-gray-400">{notAvailableLabel}</span>
   );
 
 export default function GVariantsTable({
@@ -38,6 +39,8 @@ export default function GVariantsTable({
   datasetActions,
   showSummary = false,
 }: GVariantsTableProps) {
+  const t = useTranslations("alleleFrequency");
+  const notAvailableLabel = t("notAvailable");
   const [expandedDatasets, setExpandedDatasets] = useState<
     Record<string, boolean>
   >({});
@@ -138,33 +141,33 @@ export default function GVariantsTable({
       {showSummary && summaryData && beaconIds.length > 1 && (
         <div>
           <h3 className="text-base sm:text-lg font-semibold mb-2">
-            Summary for current filter
+            {t("summaryForCurrentFilter")}
           </h3>
           <div className="overflow-x-auto">
             <table className="min-w-[1100px] lg:min-w-full border border-surface shadow-lg rounded-xl overflow-hidden table-fixed text-xs sm:text-sm">
               <thead>
                 <tr className="bg-primary text-surface">
                   <th className="px-3 py-2 text-left whitespace-nowrap">
-                    Scope
+                    {t("scope")}
                   </th>
                   <th className="px-3 py-2 text-left whitespace-nowrap">
-                    Population
+                    {t("population")}
                   </th>
                   <th className="px-3 py-2 text-left whitespace-nowrap">
-                    Allele Count
+                    {t("alleleCount")}
                   </th>
                   <th className="px-3 py-2 text-left whitespace-nowrap">
-                    Allele Number
+                    {t("alleleNumber")}
                   </th>
                   <th className="px-3 py-2 text-left whitespace-nowrap">
-                    Frequency
+                    {t("frequency")}
                   </th>
                 </tr>
               </thead>
               <tbody>
                 <tr className="bg-surface border border-secondary">
                   <td className="px-3 py-2 whitespace-nowrap">
-                    All visible matching datasets
+                    {t("allVisibleDatasets")}
                   </td>
                   <td className="px-3 py-2 whitespace-nowrap">
                     {summaryData.population}
@@ -172,17 +175,17 @@ export default function GVariantsTable({
                   <td className="px-3 py-2 whitespace-nowrap">
                     {summaryData.alleleCount != null
                       ? summaryData.alleleCount.toLocaleString()
-                      : renderCell(undefined)}
+                      : renderCell(undefined, notAvailableLabel)}
                   </td>
                   <td className="px-3 py-2 whitespace-nowrap">
                     {summaryData.alleleNumber != null
                       ? summaryData.alleleNumber.toLocaleString()
-                      : renderCell(undefined)}
+                      : renderCell(undefined, notAvailableLabel)}
                   </td>
                   <td className="px-3 py-2 whitespace-nowrap">
                     {summaryData.frequency != null
                       ? summaryData.frequency.toFixed(4)
-                      : renderCell(undefined)}
+                      : renderCell(undefined, notAvailableLabel)}
                   </td>
                 </tr>
               </tbody>
@@ -193,7 +196,7 @@ export default function GVariantsTable({
 
       <div>
         <h3 className="text-base sm:text-lg font-semibold mb-2">
-          Detailed results
+          {t("detailedResults")}
         </h3>
         <div className="space-y-6">
           {variantGroups.map((variantGroup) => {
@@ -205,7 +208,7 @@ export default function GVariantsTable({
               <div key={variantGroup.key} className="space-y-2">
                 {showVariantTitle && (
                   <p className="text-base sm:text-lg font-semibold">
-                    Variant:{" "}
+                    {t("variantLabel")}
                     <span className="text-info break-all">
                       {variantGroup.label}
                     </span>
@@ -216,34 +219,34 @@ export default function GVariantsTable({
                     <thead>
                       <tr className="bg-primary text-surface">
                         <th className="px-3 py-2 text-left whitespace-nowrap">
-                          Dataset
+                          {t("dataset")}
                         </th>
                         <th className="px-3 py-2 text-left whitespace-nowrap">
-                          Dataset Type
+                          {t("datasetType")}
                         </th>
                         <th className="px-3 py-2 text-left whitespace-nowrap">
-                          Population
+                          {t("population")}
                         </th>
                         <th className="px-3 py-2 text-left whitespace-nowrap">
-                          Allele Count
+                          {t("alleleCount")}
                         </th>
                         <th className="px-3 py-2 text-left whitespace-nowrap">
-                          Allele Number
+                          {t("alleleNumber")}
                         </th>
                         <th className="px-3 py-2 text-left whitespace-nowrap">
-                          Homozygous
+                          {t("homozygous")}
                         </th>
                         <th className="px-3 py-2 text-left whitespace-nowrap">
-                          Heterozygous
+                          {t("heterozygous")}
                         </th>
                         <th className="px-3 py-2 text-left whitespace-nowrap">
-                          Hemizygous
+                          {t("hemizygous")}
                         </th>
                         <th className="px-3 py-2 text-left whitespace-nowrap">
-                          Frequency
+                          {t("frequency")}
                         </th>
                         <th className="px-3 py-2 text-left w-[220px] whitespace-nowrap">
-                          Actions
+                          {t("actions")}
                         </th>
                       </tr>
                     </thead>
@@ -269,7 +272,7 @@ export default function GVariantsTable({
                                 colSpan={10}
                                 className="px-3 py-2 text-base sm:text-lg font-bold"
                               >
-                                Beacon: {beaconId}
+                                {t("beacon")}{beaconId}
                                 {beaconCountryLabel
                                   ? ` (${beaconCountryLabel})`
                                   : ""}
@@ -330,31 +333,34 @@ export default function GVariantsTable({
                                     </td>
                                     <td className="px-3 py-2 whitespace-nowrap" />
                                     <td className="px-3 py-2 whitespace-nowrap">
-                                      {renderCell(totals?.alleleCount)}
+                                      {renderCell(totals?.alleleCount, notAvailableLabel)}
                                     </td>
                                     <td className="px-3 py-2 whitespace-nowrap">
-                                      {renderCell(totals?.alleleNumber)}
+                                      {renderCell(totals?.alleleNumber, notAvailableLabel)}
                                     </td>
                                     <td className="px-3 py-2 whitespace-nowrap">
                                       {renderCell(
-                                        totals?.alleleCountHomozygous
+                                        totals?.alleleCountHomozygous,
+                                        notAvailableLabel
                                       )}
                                     </td>
                                     <td className="px-3 py-2 whitespace-nowrap">
                                       {renderCell(
-                                        totals?.alleleCountHeterozygous
+                                        totals?.alleleCountHeterozygous,
+                                        notAvailableLabel
                                       )}
                                     </td>
                                     <td className="px-3 py-2 whitespace-nowrap">
                                       {renderCell(
-                                        totals?.alleleCountHemizygous
+                                        totals?.alleleCountHemizygous,
+                                        notAvailableLabel
                                       )}
                                     </td>
                                     <td className="px-3 py-2 whitespace-nowrap">
                                       {typeof totals?.alleleFrequency ===
                                       "number"
                                         ? totals.alleleFrequency.toFixed(4)
-                                        : renderCell(undefined)}
+                                        : renderCell(undefined, notAvailableLabel)}
                                     </td>
                                     <td className="px-3 py-2 w-[220px] whitespace-nowrap">
                                       <div className="w-[220px]">
@@ -392,30 +398,33 @@ export default function GVariantsTable({
                                           {variant.population || "-"}
                                         </td>
                                         <td className="px-3 py-2 whitespace-nowrap">
-                                          {renderCell(variant.alleleCount)}
+                                          {renderCell(variant.alleleCount, notAvailableLabel)}
                                         </td>
                                         <td className="px-3 py-2 whitespace-nowrap">
-                                          {renderCell(variant.alleleNumber)}
+                                          {renderCell(variant.alleleNumber, notAvailableLabel)}
                                         </td>
                                         <td className="px-3 py-2 whitespace-nowrap">
                                           {renderCell(
-                                            variant.alleleCountHomozygous
+                                            variant.alleleCountHomozygous,
+                                            notAvailableLabel
                                           )}
                                         </td>
                                         <td className="px-3 py-2 whitespace-nowrap">
                                           {renderCell(
-                                            variant.alleleCountHeterozygous
+                                            variant.alleleCountHeterozygous,
+                                            notAvailableLabel
                                           )}
                                         </td>
                                         <td className="px-3 py-2 whitespace-nowrap">
                                           {renderCell(
-                                            variant.alleleCountHemizygous
+                                            variant.alleleCountHemizygous,
+                                            notAvailableLabel
                                           )}
                                         </td>
                                         <td className="px-3 py-2 whitespace-nowrap">
                                           {variant.alleleFrequency != null
                                             ? variant.alleleFrequency.toFixed(4)
-                                            : renderCell(undefined)}
+                                            : renderCell(undefined, notAvailableLabel)}
                                         </td>
                                         <td className="px-3 py-2 w-[220px] whitespace-nowrap" />
                                       </tr>

--- a/src/app/allele-frequency/components/VariantAddToBasketButton.tsx
+++ b/src/app/allele-frequency/components/VariantAddToBasketButton.tsx
@@ -9,6 +9,7 @@ import { SearchedDataset } from "@/app/api/discovery/open-api/schemas";
 import { ExternalDatasetConfirmationDialog } from "@/components/ExternalDatasetCardLink";
 import { FontAwesomeIcon } from "@fortawesome/react-fontawesome";
 import { faArrowRight } from "@fortawesome/free-solid-svg-icons";
+import { useTranslations } from "next-intl";
 
 type VariantAddToBasketButtonProps = {
   datasetId: string;
@@ -25,6 +26,7 @@ export default function VariantAddToBasketButton({
   externalAccessUrl,
   disabled = false,
 }: VariantAddToBasketButtonProps) {
+  const t = useTranslations("alleleFrequency");
   if (isExternal) {
     if (externalAccessUrl) {
       return (
@@ -38,7 +40,7 @@ export default function VariantAddToBasketButton({
               }}
               className="text-sm text-primary hover:text-info underline hover:no-underline font-semibold transition-colors duration-200 cursor-pointer inline-flex items-center gap-1"
             >
-              <span>Access external dataset</span>
+              <span>{t("accessExternalDataset")}</span>
               <FontAwesomeIcon icon={faArrowRight} className="text-xs" />
             </button>
           )}
@@ -48,7 +50,7 @@ export default function VariantAddToBasketButton({
 
     return (
       <span className="text-sm text-gray-400 cursor-not-allowed">
-        External link not available
+        {t("externalLinkNotAvailable")}
       </span>
     );
   }

--- a/src/app/allele-frequency/page.tsx
+++ b/src/app/allele-frequency/page.tsx
@@ -27,6 +27,7 @@ import {
 } from "@/utils/datasetHelpers";
 import { isAxiosError } from "axios";
 import { use, useEffect, useRef, useState } from "react";
+import { useTranslations } from "next-intl";
 
 type AlleleFrequencyPageProps = {
   searchParams: Promise<UrlSearchParams>;
@@ -43,6 +44,7 @@ const ALL_VARIANT_SEARCH_ENABLED = contentConfig.enableAllVariantSearch;
 export default function AlleleFrequencyPage({
   searchParams,
 }: AlleleFrequencyPageProps) {
+  const t = useTranslations("alleleFrequency");
   const [results, setResults] = useState<GVariantsSearchResponse[]>([]);
   const [showSummary, setShowSummary] = useState(false);
   const [datasetActions, setDatasetActions] = useState<
@@ -332,12 +334,12 @@ export default function AlleleFrequencyPage({
 
       {loading && (
         <p className="text-center text-gray-500">
-          Searching and preparing results...
+          {t("searching")}
         </p>
       )}
 
       {!loading && triedSearching && results.length == 0 && (
-        <p className="text-center text-gray-500">No results found</p>
+        <p className="text-center text-gray-500">{t("noResults")}</p>
       )}
 
       {!loading && results.length > 0 && (

--- a/src/app/allele-frequency/page.tsx
+++ b/src/app/allele-frequency/page.tsx
@@ -332,11 +332,7 @@ export default function AlleleFrequencyPage({
         datasetTypeOptions={datasetTypeOptions}
       />
 
-      {loading && (
-        <p className="text-center text-gray-500">
-          {t("searching")}
-        </p>
-      )}
+      {loading && <p className="text-center text-gray-500">{t("searching")}</p>}
 
       {!loading && triedSearching && results.length == 0 && (
         <p className="text-center text-gray-500">{t("noResults")}</p>

--- a/src/app/applications/[id]/AddParticipantForm.tsx
+++ b/src/app/applications/[id]/AddParticipantForm.tsx
@@ -14,12 +14,15 @@ import { inviteMemberApi } from "../../api/access-management";
 import { useAlert } from "@/providers/AlertProvider";
 import { useState } from "react";
 import { faUserPlus } from "@fortawesome/free-solid-svg-icons";
+import { useTranslations } from "next-intl";
 
 const AddParticipantForm = ({
   application,
 }: {
   application: RetrievedApplication;
 }) => {
+  const t = useTranslations("application");
+  const tCommon = useTranslations("common");
   const [isAddParticipantFormShown, showAddParticipantForm] = useState(false);
   const [currentAddParticipantName, setCurrentAddParticipantName] =
     useState("");
@@ -55,14 +58,14 @@ const AddParticipantForm = ({
 
       setAlert({
         type: "success",
-        message: "Invitation sent successfully",
+        message: t("invitationSentSuccessfully"),
       });
       closeForm();
     } catch (error: Error | unknown) {
       const err = error as Error;
       setAlert({
         type: "error",
-        message: "Failed to invite member",
+        message: t("failedToInviteMember"),
         details: err.message === "Failed to invite member" ? "" : err.message,
       });
     }
@@ -73,7 +76,7 @@ const AddParticipantForm = ({
       {!isAddParticipantFormShown && (
         <Button
           type="primary"
-          text="Add Participant"
+          text={t("addParticipant")}
           icon={faUserPlus}
           onClick={() => toggleShowParticipantForm()}
         />
@@ -84,25 +87,25 @@ const AddParticipantForm = ({
             value={currentAddParticipantName}
             onChange={(e) => setCurrentAddParticipantName(e.target.value)}
             type="text"
-            placeholder="Name"
+            placeholder={t("namePlaceholder")}
           />
           <Input
             value={currentAddParticipantEmail}
             onChange={(e) => setCurrentAddParticipantEmail(e.target.value)}
             type="text"
-            placeholder="Email"
+            placeholder={t("emailPlaceholder")}
           />
           <div className="flex gap-2 self-end">
             {isAddParticipantFormShown && (
               <Button
                 type="primary"
-                text="Cancel"
+                text={tCommon("cancel")}
                 onClick={() => closeForm()}
               />
             )}
             <Button
               type="primary"
-              text="Send"
+              text={tCommon("send")}
               onClick={() => handleInviteMember()}
             />
           </div>

--- a/src/app/applications/[id]/EmailFormField.tsx
+++ b/src/app/applications/[id]/EmailFormField.tsx
@@ -6,6 +6,7 @@
 
 import GenericInputFormField from "./GenericInputFormField";
 import { RetrievedApplicationFormField } from "@/app/api/access-management/open-api/schemas";
+import { useTranslations } from "next-intl";
 
 type EmailFormFieldProps = {
   field: RetrievedApplicationFormField;
@@ -22,12 +23,13 @@ function EmailFormField({
   editable,
   validationWarning,
 }: EmailFormFieldProps) {
+  const t = useTranslations("application.fields");
   return (
     <GenericInputFormField
       field={field}
       formId={formId}
       type="email"
-      placeholder="Enter your email address"
+      placeholder={t("emailPlaceholder")}
       title={title}
       editable={editable}
       validationWarning={validationWarning}

--- a/src/app/applications/[id]/FileUploadFormField.tsx
+++ b/src/app/applications/[id]/FileUploadFormField.tsx
@@ -4,6 +4,7 @@
 
 import { useApplicationDetails } from "@/providers/application/ApplicationProvider";
 import { faPlusCircle } from "@fortawesome/free-solid-svg-icons";
+import { useTranslations } from "next-intl";
 import { FontAwesomeIcon } from "@fortawesome/react-fontawesome";
 import FileUploaded from "./FileUploaded";
 import { RetrievedApplicationFormField } from "@/app/api/access-management/open-api/schemas";
@@ -23,6 +24,7 @@ function FileUploadFormField({
   editable,
   validationWarning,
 }: FileUploadFormFieldProps) {
+  const t = useTranslations("application.fields");
   const { application, isLoading, addAttachment } = useApplicationDetails();
 
   async function onFileUpload(e: React.ChangeEvent<HTMLInputElement>) {
@@ -38,7 +40,7 @@ function FileUploadFormField({
       <div className="flex justify-between">
         <div>
           <h3 className="text-lg sm:text-xl">{`${title} ${
-            field.optional ? "(Optional)" : ""
+            field.optional ? t("optional") : ""
           }`}</h3>
         </div>
         <>
@@ -58,7 +60,7 @@ function FileUploadFormField({
             }`}
           >
             <FontAwesomeIcon icon={faPlusCircle} className="mr-2 text-sm" />
-            <span className="text-sm">Upload File</span>
+            <span className="text-sm">{t("uploadFile")}</span>
           </label>
         </>
       </div>

--- a/src/app/applications/[id]/GenericInputFormField.tsx
+++ b/src/app/applications/[id]/GenericInputFormField.tsx
@@ -5,6 +5,7 @@
 import { useEffect, useState } from "react";
 import { Input } from "@/components/shadcn/input";
 import { useApplicationDetails } from "@/providers/application/ApplicationProvider";
+import { useTranslations } from "next-intl";
 import { RetrievedApplicationFormField } from "@/app/api/access-management/open-api/schemas";
 
 type GenericInputFormFieldProps = {
@@ -30,6 +31,7 @@ function GenericInputFormField({
   children,
   validationWarning,
 }: GenericInputFormFieldProps) {
+  const t = useTranslations("application.fields");
   const { updateInputFields } = useApplicationDetails();
   const [inputValue, setInputValue] = useState(field.value!);
 
@@ -57,7 +59,7 @@ function GenericInputFormField({
       <div className="flex flex-col justify-between">
         <div>
           <h3 className="text-lg sm:text-xl">{`${title} ${
-            field.optional ? "(Optional)" : ""
+            field.optional ? t("optional") : ""
           }`}</h3>
         </div>
         <div className="mt-4 flex items-center">

--- a/src/app/applications/[id]/OptionFormField.tsx
+++ b/src/app/applications/[id]/OptionFormField.tsx
@@ -6,6 +6,7 @@
 
 import { useApplicationDetails } from "@/providers/application/ApplicationProvider";
 import { useState, useEffect } from "react";
+import { useTranslations } from "next-intl";
 import { FontAwesomeIcon } from "@fortawesome/react-fontawesome";
 import { faChevronDown, faCheck } from "@fortawesome/free-solid-svg-icons";
 import { Listbox } from "@headlessui/react";
@@ -30,6 +31,7 @@ function OptionFormField({
   editable,
   validationWarning,
 }: OptionFormFieldProps) {
+  const t = useTranslations("application.fields");
   const { updateInputFields } = useApplicationDetails();
   const [selectedOption, setSelectedOption] = useState(field.value || "");
 
@@ -53,7 +55,7 @@ function OptionFormField({
     <div className="flex flex-col py-2">
       <div className="flex flex-col justify-between">
         <h3 className="text-lg sm:text-xl">
-          {title} {field.optional ? "(Optional)" : ""}
+          {title} {field.optional ? t("optional") : ""}
         </h3>
         <div className="relative">
           <Listbox
@@ -74,8 +76,8 @@ function OptionFormField({
                       (option: FormFieldOption) => option.key === selectedOption
                     )
                     ?.label.find((label: Label) => label.language === "en")
-                    ?.name || "Select an option"
-                : "Select an option"}
+                    ?.name || t("selectAnOption")
+                : t("selectAnOption")}
               <FontAwesomeIcon
                 icon={faChevronDown}
                 className={`absolute right-3 top-1/2 transform -translate-y-1/5 ${
@@ -113,7 +115,7 @@ function OptionFormField({
                   </Listbox.Option>
                 ))
               ) : (
-                <div className="text-center py-2">No options available</div>
+                <div className="text-center py-2">{t("noOptionsAvailable")}</div>
               )}
             </Listbox.Options>
           </Listbox>

--- a/src/app/applications/[id]/OptionFormField.tsx
+++ b/src/app/applications/[id]/OptionFormField.tsx
@@ -115,7 +115,9 @@ function OptionFormField({
                   </Listbox.Option>
                 ))
               ) : (
-                <div className="text-center py-2">{t("noOptionsAvailable")}</div>
+                <div className="text-center py-2">
+                  {t("noOptionsAvailable")}
+                </div>
               )}
             </Listbox.Options>
           </Listbox>

--- a/src/app/applications/[id]/TableFormField.tsx
+++ b/src/app/applications/[id]/TableFormField.tsx
@@ -6,6 +6,7 @@
 
 import { useApplicationDetails } from "@/providers/application/ApplicationProvider";
 import { useState } from "react";
+import { useTranslations } from "next-intl";
 import { FontAwesomeIcon } from "@fortawesome/react-fontawesome";
 import { faXmark } from "@fortawesome/free-solid-svg-icons";
 import {
@@ -28,6 +29,7 @@ function TableFormField({
   editable,
   validationWarning,
 }: TableFormFieldProps) {
+  const t = useTranslations("application.fields");
   const { updateInputFields } = useApplicationDetails();
   const [tableValues, setTableValues] = useState<FormFieldTableValue[][]>(
     field.tableValues || [[]]
@@ -74,14 +76,14 @@ function TableFormField({
     <div className="flex flex-col py-2">
       <div className="flex justify-between items-center">
         <h3 className="text-lg sm:text-xl">
-          {title} {field.optional ? "(Optional)" : ""}
+          {title} {field.optional ? t("optional") : ""}
         </h3>
         <button
           onClick={addRow}
           disabled={isDisabled}
           className="ml-4 mt-2 py-2 px-4 bg-primary text-white rounded-md disabled:cursor-not-allowed disabled:opacity-50"
         >
-          Add Row
+          {t("addRow")}
         </button>
       </div>
       <table className="mt-4 border-collapse">

--- a/src/app/applications/[id]/TermsAcceptance.tsx
+++ b/src/app/applications/[id]/TermsAcceptance.tsx
@@ -7,6 +7,7 @@
 import Alert, { AlertState } from "@/components/Alert";
 import Button from "@/components/Button";
 import { useApplicationDetails } from "@/providers/application/ApplicationProvider";
+import { useTranslations } from "next-intl";
 import { getLabelName } from "@/utils/getLabelName";
 import {
   faArrowUpRightFromSquare,
@@ -16,6 +17,7 @@ import { FontAwesomeIcon } from "@fortawesome/react-fontawesome";
 import { useState } from "react";
 
 export default function TermsAcceptance() {
+  const t = useTranslations("application.terms");
   const [alert, setAlert] = useState<AlertState | null>(null);
   const { application, acceptTerms, clearError } = useApplicationDetails();
   const [expandedLicenseId, setExpandedLicenseId] = useState<string | null>(
@@ -53,7 +55,7 @@ export default function TermsAcceptance() {
   };
 
   if (!application?.licenses || application?.licenses.length === 0) {
-    return <p>No terms and conditions have been defined.</p>;
+    return <p>{t("noTermsDefined")}</p>;
   }
 
   return (
@@ -90,7 +92,7 @@ export default function TermsAcceptance() {
                 target="_blank"
                 rel="noopener noreferrer"
               >
-                Read more
+                {t("readMore")}
                 <FontAwesomeIcon
                   className="ml-2"
                   icon={faArrowUpRightFromSquare}
@@ -99,9 +101,9 @@ export default function TermsAcceptance() {
             )}
             <p>
               {license.acceptedByCurrentUser ? (
-                <span className="text-green-600">Accepted</span>
+                <span className="text-green-600">{t("accepted")}</span>
               ) : (
-                <span className="text-red-600">Not Accepted</span>
+                <span className="text-red-600">{t("notAccepted")}</span>
               )}
             </p>
           </div>
@@ -111,7 +113,7 @@ export default function TermsAcceptance() {
         <div className="flex justify-end mt-4">
           <Button
             type="primary"
-            text="Accept All"
+            text={t("acceptAll")}
             icon={faCheckCircle}
             onClick={handleAcceptTerms}
           />

--- a/src/app/datasets/ActiveFilters.tsx
+++ b/src/app/datasets/ActiveFilters.tsx
@@ -13,8 +13,10 @@ import {
   ActiveFilter,
   ActiveFilterEntry,
 } from "@/providers/filters/FilterProvider.types";
+import { useTranslations } from "next-intl";
 
 export default function ActiveFilters() {
+  const t = useTranslations("datasets");
   const { activeFilters, addActiveFilter, removeActiveFilter } = useFilters();
 
   if (!activeFilters.length) {
@@ -47,7 +49,7 @@ export default function ActiveFilters() {
   return (
     <div className="mb-4">
       <div className="flex justify-between items-center mb-4">
-        <h3 className="text-lg font-subheading">Active Filters</h3>
+        <h3 className="text-lg font-subheading">{t("activeFilters")}</h3>
         <ClearFilterButton />
       </div>
       <div className="flex flex-wrap gap-2">

--- a/src/app/datasets/BeaconErrorAlert.tsx
+++ b/src/app/datasets/BeaconErrorAlert.tsx
@@ -6,12 +6,14 @@
 
 import { faExclamationTriangle } from "@fortawesome/free-solid-svg-icons";
 import { FontAwesomeIcon } from "@fortawesome/react-fontawesome";
+import { useTranslations } from "next-intl";
 
 type BeaconErrorAlertProps = {
   error: string;
 };
 
 export default function BeaconErrorAlert({ error }: BeaconErrorAlertProps) {
+  const t = useTranslations("datasets");
   const formattedError = error.trim();
   const needsPeriod = !/[.!?]$/.test(formattedError);
 
@@ -24,7 +26,7 @@ export default function BeaconErrorAlert({ error }: BeaconErrorAlertProps) {
         />
         <div className="flex-1">
           <div className="font-semibold text-base mb-1">
-            Individual-level data discovery unavailable
+            {t("beaconErrorTitle")}
           </div>
           <p className="text-sm text-gray-700">
             {formattedError}

--- a/src/app/datasets/DatasetCard.tsx
+++ b/src/app/datasets/DatasetCard.tsx
@@ -38,6 +38,7 @@ function DatasetCard({
   displayBasketButton = true,
 }: Readonly<DatasetCardProps>) {
   const t = useTranslations("basket");
+  const tDetail = useTranslations("datasets.detail");
   const screenSize = useWindowSize();
   const truncatedDesc = dataset.description
     ? truncateDescription(dataset.description, screenSize)
@@ -113,7 +114,7 @@ function DatasetCard({
                 }}
                 className="text-xs sm:text-base text-primary hover:text-info underline hover:no-underline font-semibold transition-colors duration-200 cursor-pointer shrink-0 inline-flex items-center gap-1"
               >
-                <span>Access external dataset</span>
+                <span>{tDetail("accessExternalDataset")}</span>
                 <FontAwesomeIcon icon={faArrowRight} className="text-xs" />
               </button>
             )}
@@ -127,7 +128,7 @@ function DatasetCard({
             }}
             className="text-xs sm:text-base text-gray-400 cursor-not-allowed inline-flex items-center gap-1"
           >
-            <span>External link not available</span>
+            <span>{tDetail("externalLinkNotAvailable")}</span>
             <FontAwesomeIcon icon={faArrowRight} className="text-xs" />
           </button>
         )}
@@ -165,14 +166,14 @@ function DatasetCard({
     () => dataset.keywords?.filter((kw): kw is string => !!kw),
     [dataset.keywords]
   );
-  const entityLabel = dataset.isSeries ? "Dataset series" : undefined;
+  const entityLabel = dataset.isSeries ? tDetail("datasetSeriesTag") : undefined;
 
   return (
     <Card
       url={`/datasets/${dataset.id}`}
       title={dataset.title}
       subTitles={subTitles}
-      description={truncatedDesc || "No description available"}
+      description={truncatedDesc || tDetail("noDescriptionAvailable")}
       cardItems={cardItems}
       keywords={keywords}
       externalUrl={isExternal ? externalAccessUrl : undefined}

--- a/src/app/datasets/DatasetCard.tsx
+++ b/src/app/datasets/DatasetCard.tsx
@@ -166,7 +166,9 @@ function DatasetCard({
     () => dataset.keywords?.filter((kw): kw is string => !!kw),
     [dataset.keywords]
   );
-  const entityLabel = dataset.isSeries ? tDetail("datasetSeriesTag") : undefined;
+  const entityLabel = dataset.isSeries
+    ? tDetail("datasetSeriesTag")
+    : undefined;
 
   return (
     <Card

--- a/src/app/datasets/FilterList/ClearFilterButton.tsx
+++ b/src/app/datasets/FilterList/ClearFilterButton.tsx
@@ -6,14 +6,16 @@
 
 import Button from "@/components/Button";
 import { useFilters } from "@/providers/filters/FilterProvider";
+import { useTranslations } from "next-intl";
 
 export default function ClearFilterButton() {
+  const t = useTranslations("datasets.filters");
   const { clearActiveFilters } = useFilters();
 
   return (
     <div className="flex justify-end">
       <Button
-        text="Clear Filters"
+        text={t("clearFilters")}
         type="warning"
         onClick={clearActiveFilters}
       />

--- a/src/app/datasets/FilterList/DateTimeFilterContent.tsx
+++ b/src/app/datasets/FilterList/DateTimeFilterContent.tsx
@@ -175,9 +175,7 @@ export default function DateTimeFilterContent({
           </div>
         ))}
         {showError && (
-          <span className="text-red-500">
-            {t("dateAndOperatorError")}
-          </span>
+          <span className="text-red-500">{t("dateAndOperatorError")}</span>
         )}
         <div className="flex w-full justify-between">
           <Button

--- a/src/app/datasets/FilterList/DateTimeFilterContent.tsx
+++ b/src/app/datasets/FilterList/DateTimeFilterContent.tsx
@@ -9,6 +9,7 @@ import { DisclosurePanel } from "@headlessui/react";
 import { useEffect, useState } from "react";
 import { FilterItemProps } from "./FilterItem";
 import { useFilters } from "@/providers/filters/FilterProvider";
+import { useTranslations } from "next-intl";
 import { Operator } from "@/app/api/discovery/open-api/schemas";
 import { ActiveFilter } from "@/providers/filters/FilterProvider.types";
 
@@ -26,6 +27,7 @@ const initialDateTimeFormItem = {
 export default function DateTimeFilterContent({
   filter,
 }: DateTimeFilterContentProps) {
+  const t = useTranslations("datasets.filters");
   const { activeFilters, addActiveFilter } = useFilters();
   const [openedDropdown, setOpenedDropdown] = useState<number | null>(null);
   const [items, setItems] = useState<DateTimeFormItem[]>([
@@ -115,7 +117,7 @@ export default function DateTimeFilterContent({
             className="flex flex-col gap-y-3"
           >
             <div className="flex gap-x-8 justify-between items-center w-full">
-              <label className="w-24">Date</label>
+              <label className="w-24">{t("dateLabel")}</label>
               <input
                 type="date"
                 id={`${filter.key}-${index}-value`}
@@ -134,7 +136,7 @@ export default function DateTimeFilterContent({
               />
             </div>
             <div className="flex items-center w-full gap-x-8 justify-between">
-              <label className="w-24">Operator</label>
+              <label className="w-24">{t("operatorLabel")}</label>
               <div className="relative w-full">
                 <div
                   onClick={() => toggleDropdown(index)}
@@ -146,7 +148,7 @@ export default function DateTimeFilterContent({
                     id={`${filter.key}-${index}-operator-display`}
                     className={item.operator ? "" : "text-[#a0a0a0]"}
                   >
-                    {item.operator || "Select an operator"}
+                    {item.operator || t("operatorPlaceholder")}
                   </span>
                 </div>
                 {index === openedDropdown && (
@@ -174,12 +176,12 @@ export default function DateTimeFilterContent({
         ))}
         {showError && (
           <span className="text-red-500">
-            Date and operator must not be empty
+            {t("dateAndOperatorError")}
           </span>
         )}
         <div className="flex w-full justify-between">
           <Button
-            text="Add filter"
+            text={t("addFilter")}
             icon={faPlusCircle}
             type="primary"
             flex={true}
@@ -192,7 +194,7 @@ export default function DateTimeFilterContent({
             className="bg-primary text-white hover:bg-secondary rounded-md px-4 py-2 font-bold transition-colors duration-200 tracking-wide cursor-pointer flex items-center justify-between text-[14px]"
           >
             <FontAwesomeIcon icon={faCheck} className="mr-2" />
-            <span>Apply</span>
+            <span>{t("apply")}</span>
           </button>
         </div>
       </form>

--- a/src/app/datasets/FilterList/DropdownFilterContent.tsx
+++ b/src/app/datasets/FilterList/DropdownFilterContent.tsx
@@ -5,12 +5,14 @@
 import { useFilters } from "@/providers/filters/FilterProvider";
 import { DisclosurePanel } from "@headlessui/react";
 import { FilterItemProps } from "./FilterItem";
+import { useTranslations } from "next-intl";
 
 type DropdownFilterContentProps = FilterItemProps;
 
 export default function DropdownFilterContent({
   filter,
 }: DropdownFilterContentProps) {
+  const t = useTranslations("datasets.filters");
   const { activeFilters, addActiveFilter, removeActiveFilter } = useFilters();
 
   const correspondingActiveFilter = activeFilters.find(
@@ -100,7 +102,7 @@ export default function DropdownFilterContent({
             </div>
           ))
       ) : (
-        <div className="text-center">No results found.</div>
+        <div className="text-center">{t("noResultsFound")}</div>
       )}
     </DisclosurePanel>
   );

--- a/src/app/datasets/FilterList/EntriesFilterContent.tsx
+++ b/src/app/datasets/FilterList/EntriesFilterContent.tsx
@@ -4,6 +4,7 @@
 
 import Button from "@/components/Button";
 import { useFilters } from "@/providers/filters/FilterProvider";
+import { useTranslations } from "next-intl";
 import { faCheck, faXmarkCircle } from "@fortawesome/free-solid-svg-icons";
 import { FontAwesomeIcon } from "@fortawesome/react-fontawesome";
 import { DisclosurePanel } from "@headlessui/react";
@@ -21,6 +22,7 @@ type EntryFormItem = {
 export default function EntriesFilterContent({
   filter,
 }: EntriesFilterContentProps) {
+  const t = useTranslations("datasets.filters");
   const { activeFilters, addActiveFilter, removeActiveFilter } = useFilters();
 
   const correspondingActiveFilter = activeFilters.find(
@@ -92,7 +94,7 @@ export default function EntriesFilterContent({
               <label className="w-56">{entry.label}</label>
               <input
                 className="border rounded-md p-2 w-full"
-                placeholder="Enter a value"
+                placeholder={t("valuePlaceholder")}
                 value={entry.value}
                 onChange={(event) =>
                   setEntries(
@@ -108,11 +110,11 @@ export default function EntriesFilterContent({
           ))}
         </div>
         {showError && (
-          <span className="text-red-500">All fields must be filled</span>
+          <span className="text-red-500">{t("allFieldsError")}</span>
         )}
         <div className="flex w-full justify-between">
           <Button
-            text="Remove filter "
+            text={t("removeFilter")}
             icon={faXmarkCircle}
             type="primary"
             flex={true}
@@ -124,7 +126,7 @@ export default function EntriesFilterContent({
             className="bg-primary text-white hover:bg-secondary rounded-md px-4 py-2 font-bold transition-colors duration-200 tracking-wide cursor-pointer flex items-center justify-between text-[14px]"
           >
             <FontAwesomeIcon icon={faCheck} className="mr-2" />
-            <span>Apply</span>
+            <span>{t("apply")}</span>
           </button>
         </div>
       </form>

--- a/src/app/datasets/FilterList/FilterItem.tsx
+++ b/src/app/datasets/FilterList/FilterItem.tsx
@@ -7,6 +7,7 @@ import { FilterType } from "@/app/api/discovery/additional-types";
 import { Filter } from "@/app/api/discovery/open-api/schemas";
 import { useFilters } from "@/providers/filters/FilterProvider";
 import { faChevronDown } from "@fortawesome/free-solid-svg-icons";
+import { useTranslations } from "next-intl";
 import { FontAwesomeIcon } from "@fortawesome/react-fontawesome";
 import { Disclosure } from "@headlessui/react";
 import { default as DropdownFilterContent } from "./DropdownFilterContent";
@@ -20,6 +21,7 @@ export type FilterItemProps = {
 };
 
 function FilterItem({ filter }: FilterItemProps) {
+  const t = useTranslations("datasets.filters");
   const { activeFilters } = useFilters();
 
   const correspondingActiveFilter = activeFilters.find(
@@ -60,7 +62,7 @@ function FilterItem({ filter }: FilterItemProps) {
                   <span className="text-base px-1.5">{filter.label}</span>
                   <span className="text-base text-info">
                     {isFilterActive &&
-                      `(${nbActiveValues} ${nbActiveValues > 1 ? "filters" : "filter"} active)`}
+                      t("activeCount", { count: nbActiveValues })}
                   </span>
                 </div>
                 <FontAwesomeIcon

--- a/src/app/datasets/FilterList/FreeTextFilterContent.tsx
+++ b/src/app/datasets/FilterList/FreeTextFilterContent.tsx
@@ -9,6 +9,7 @@ import { DisclosurePanel } from "@headlessui/react";
 import { useEffect, useState } from "react";
 import { FilterItemProps } from "./FilterItem";
 import { useFilters } from "@/providers/filters/FilterProvider";
+import { useTranslations } from "next-intl";
 import { Operator } from "@/app/api/discovery/open-api/schemas";
 import { ActiveFilter } from "@/providers/filters/FilterProvider.types";
 
@@ -26,6 +27,7 @@ const initialFreeTextFormItem = {
 export default function FreeTextFilterContent({
   filter,
 }: FreeTextFilterContentProps) {
+  const t = useTranslations("datasets.filters");
   const { activeFilters, addActiveFilter } = useFilters();
   const [openedDropdown, setOpenedDropdown] = useState<number | null>(null);
   const [items, setItems] = useState<FreeTextFormItem[]>([
@@ -115,12 +117,12 @@ export default function FreeTextFilterContent({
             className="flex flex-col gap-y-3"
           >
             <div className="flex gap-x-8 justify-between items-center w-full">
-              <label className="w-24">Value</label>
+              <label className="w-24">{t("valueLabel")}</label>
               <input
                 id={`${filter.key}-${index}-value`}
                 name={`${filter.key}-${index}-value`}
                 className="border rounded-md p-2 w-full"
-                placeholder="Enter a value"
+                placeholder={t("valuePlaceholder")}
                 value={item.value}
                 onChange={(event) => {
                   setItems((items) =>
@@ -134,7 +136,7 @@ export default function FreeTextFilterContent({
               />
             </div>
             <div className="flex items-center w-full gap-x-8 justify-between">
-              <label className="w-24">Operator</label>
+              <label className="w-24">{t("operatorLabel")}</label>
               <div className="relative w-full">
                 <div
                   onClick={() => toggleDropdown(index)}
@@ -146,7 +148,7 @@ export default function FreeTextFilterContent({
                     id={`${filter.key}-${index}-operator-display`}
                     className={item.operator ? "" : "text-[#a0a0a0]"}
                   >
-                    {item.operator || "Select an operator"}
+                    {item.operator || t("operatorPlaceholder")}
                   </span>
                 </div>
                 {index === openedDropdown && (
@@ -174,12 +176,12 @@ export default function FreeTextFilterContent({
         ))}
         {showError && (
           <span className="text-red-500">
-            Value and operator must not be empty
+            {t("valueAndOperatorError")}
           </span>
         )}
         <div className="flex w-full justify-between">
           <Button
-            text="Add filter"
+            text={t("addFilter")}
             icon={faPlusCircle}
             type="primary"
             flex={true}
@@ -192,7 +194,7 @@ export default function FreeTextFilterContent({
             className="bg-primary text-white hover:bg-secondary rounded-md px-4 py-2 font-bold transition-colors duration-200 tracking-wide cursor-pointer flex items-center justify-between text-[14px]"
           >
             <FontAwesomeIcon icon={faCheck} className="mr-2" />
-            <span>Apply</span>
+            <span>{t("apply")}</span>
           </button>
         </div>
       </form>

--- a/src/app/datasets/FilterList/FreeTextFilterContent.tsx
+++ b/src/app/datasets/FilterList/FreeTextFilterContent.tsx
@@ -175,9 +175,7 @@ export default function FreeTextFilterContent({
           </div>
         ))}
         {showError && (
-          <span className="text-red-500">
-            {t("valueAndOperatorError")}
-          </span>
+          <span className="text-red-500">{t("valueAndOperatorError")}</span>
         )}
         <div className="flex w-full justify-between">
           <Button

--- a/src/app/datasets/FilterList/NumberFilterContent.tsx
+++ b/src/app/datasets/FilterList/NumberFilterContent.tsx
@@ -9,6 +9,7 @@ import { DisclosurePanel } from "@headlessui/react";
 import { useEffect, useState } from "react";
 import { FilterItemProps } from "./FilterItem";
 import { useFilters } from "@/providers/filters/FilterProvider";
+import { useTranslations } from "next-intl";
 import { Operator } from "@/app/api/discovery/open-api/schemas";
 import { ActiveFilter } from "@/providers/filters/FilterProvider.types";
 
@@ -26,6 +27,7 @@ const initialNumberFormItem = {
 export default function NumberFilterContent({
   filter,
 }: NumberFilterContentProps) {
+  const t = useTranslations("datasets.filters");
   const { activeFilters, addActiveFilter } = useFilters();
   const [openedDropdown, setOpenedDropdown] = useState<number | null>(null);
   const [items, setItems] = useState<NumberFormItem[]>([initialNumberFormItem]);
@@ -113,13 +115,13 @@ export default function NumberFilterContent({
             className="flex flex-col gap-y-3"
           >
             <div className="flex gap-x-8 justify-between items-center w-full">
-              <label className="w-24">Number</label>
+              <label className="w-24">{t("numberLabel")}</label>
               <input
                 type="number"
                 id={`${filter.key}-${index}-value`}
                 name={`${filter.key}-${index}-value`}
                 className="border rounded-md p-2 w-full"
-                placeholder="Enter a number"
+                placeholder={t("numberPlaceholder")}
                 value={item.value}
                 onChange={(event) => {
                   setItems((items) =>
@@ -133,7 +135,7 @@ export default function NumberFilterContent({
               />
             </div>
             <div className="flex items-center w-full gap-x-8 justify-between">
-              <label className="w-24">Operator</label>
+              <label className="w-24">{t("operatorLabel")}</label>
               <div className="relative w-full">
                 <div
                   onClick={() => toggleDropdown(index)}
@@ -145,7 +147,7 @@ export default function NumberFilterContent({
                     id={`${filter.key}-${index}-operator-display`}
                     className={item.operator ? "" : "text-[#a0a0a0]"}
                   >
-                    {item.operator || "Select an operator"}
+                    {item.operator || t("operatorPlaceholder")}
                   </span>
                 </div>
                 {index === openedDropdown && (
@@ -173,12 +175,12 @@ export default function NumberFilterContent({
         ))}
         {showError && (
           <span className="text-red-500">
-            Number and operator must not be empty
+            {t("numberAndOperatorError")}
           </span>
         )}
         <div className="flex w-full justify-between">
           <Button
-            text="Add filter"
+            text={t("addFilter")}
             icon={faPlusCircle}
             type="primary"
             flex={true}
@@ -191,7 +193,7 @@ export default function NumberFilterContent({
             className="bg-primary text-white hover:bg-secondary rounded-md px-4 py-2 font-bold transition-colors duration-200 tracking-wide cursor-pointer flex items-center justify-between text-[14px]"
           >
             <FontAwesomeIcon icon={faCheck} className="mr-2" />
-            <span>Apply</span>
+            <span>{t("apply")}</span>
           </button>
         </div>
       </form>

--- a/src/app/datasets/FilterList/NumberFilterContent.tsx
+++ b/src/app/datasets/FilterList/NumberFilterContent.tsx
@@ -174,9 +174,7 @@ export default function NumberFilterContent({
           </div>
         ))}
         {showError && (
-          <span className="text-red-500">
-            {t("numberAndOperatorError")}
-          </span>
+          <span className="text-red-500">{t("numberAndOperatorError")}</span>
         )}
         <div className="flex w-full justify-between">
           <Button

--- a/src/app/requests/loading.tsx
+++ b/src/app/requests/loading.tsx
@@ -3,9 +3,11 @@
 // SPDX-License-Identifier: Apache-2.0
 
 import LoadingContainer from "@/components/LoadingContainer";
+import { getTranslations } from "next-intl/server";
 
-function Loading() {
-  return <LoadingContainer text="Loading..." />;
+async function Loading() {
+  const t = await getTranslations("common");
+  return <LoadingContainer text={t("loading")} />;
 }
 
 export default Loading;

--- a/src/components/AuthErrorBanner.tsx
+++ b/src/components/AuthErrorBanner.tsx
@@ -2,24 +2,25 @@
 //
 // SPDX-License-Identifier: Apache-2.0
 
+"use client";
+
+import { useTranslations } from "next-intl";
+
 type AuthErrorBannerProps = {
   authError?: string;
 };
 
-const authErrorMessages: Record<string, { title: string; message: string }> = {
-  "missing-terms": {
-    title: "Login blocked",
-    message:
-      "You must accept the terms and conditions before you can access the portal.",
-  },
-};
+const KNOWN_AUTH_ERRORS = ["missing-terms"];
 
 const AuthErrorBanner = ({ authError }: AuthErrorBannerProps) => {
-  if (!authError || !(authError in authErrorMessages)) {
+  const t = useTranslations("auth");
+
+  if (!authError || !KNOWN_AUTH_ERRORS.includes(authError)) {
     return null;
   }
 
-  const { title, message } = authErrorMessages[authError];
+  const title = t(`${authError}.title`);
+  const message = t(`${authError}.message`);
 
   return (
     <div

--- a/src/components/ExternalDatasetCardLink.tsx
+++ b/src/components/ExternalDatasetCardLink.tsx
@@ -15,6 +15,7 @@ import {
   DialogHeader,
   DialogTitle,
 } from "@/components/shadcn/dialog";
+import { useTranslations } from "next-intl";
 
 type ExternalDatasetConfirmationDialogProps = {
   url: string;
@@ -29,6 +30,7 @@ export function ExternalDatasetConfirmationDialog({
   onOpenChange,
   children,
 }: ExternalDatasetConfirmationDialogProps) {
+  const t = useTranslations("common");
   const [showDialog, setShowDialog] = useState(false);
 
   const handleConfirm = () => {
@@ -54,22 +56,20 @@ export function ExternalDatasetConfirmationDialog({
       >
         <DialogContent className="sm:max-w-md bg-white">
           <DialogHeader>
-            <DialogTitle>External Dataset</DialogTitle>
+            <DialogTitle>{t("externalDataset")}</DialogTitle>
             <DialogDescription className="pt-2">
-              You are about to be redirected to an external website. This
-              dataset is not available for direct access through the GDI User
-              Portal and must be requested through the external data provider.
+              {t("externalDatasetWarning")}
             </DialogDescription>
           </DialogHeader>
           <DialogFooter className="flex gap-2 sm:justify-end">
             <Button
-              text="Cancel"
+              text={t("cancel")}
               onClick={() => setShowDialog(false)}
               type="secondary"
               className="mt-2"
             />
             <Button
-              text="Continue to External Site"
+              text={t("continueToExternalSite")}
               onClick={handleConfirm}
               type="primary"
               icon={faExternalLinkAlt}
@@ -92,6 +92,7 @@ type ExternalDatasetCardLinkProps = {
 export default function ExternalDatasetCardLink({
   url,
 }: ExternalDatasetCardLinkProps) {
+  const t = useTranslations("common");
   return (
     <ExternalDatasetConfirmationDialog url={url}>
       {({ onClick }) => (
@@ -99,7 +100,7 @@ export default function ExternalDatasetCardLink({
           onClick={onClick}
           className="text-xs rounded-md px-3 py-1.5 font-semibold bg-info text-white hover:bg-secondary transition-colors duration-200 shrink-0 whitespace-nowrap cursor-pointer"
         >
-          View External →
+          {t("viewExternal")}
         </button>
       )}
     </ExternalDatasetConfirmationDialog>

--- a/src/components/PhoneInput.tsx
+++ b/src/components/PhoneInput.tsx
@@ -9,6 +9,7 @@ import {
 } from "@fortawesome/free-solid-svg-icons";
 import { FontAwesomeIcon } from "@fortawesome/react-fontawesome";
 import React, { forwardRef, useCallback } from "react";
+import { useTranslations } from "next-intl";
 import * as RPNInput from "react-phone-number-input";
 import flags from "react-phone-number-input/flags";
 import { Button } from "./shadcn/button";
@@ -83,6 +84,7 @@ const CountrySelect = ({
   onChange,
   options,
 }: CountrySelectProps) => {
+  const t = useTranslations("common");
   const handleSelect = useCallback(
     (country: RPNInput.Country) => {
       onChange(country);
@@ -115,8 +117,8 @@ const CountrySelect = ({
         <Command>
           <CommandList>
             <ScrollArea className="h-72">
-              <CommandInput placeholder="Search country..." />
-              <CommandEmpty>No country found.</CommandEmpty>
+              <CommandInput placeholder={t("searchCountry")} />
+              <CommandEmpty>{t("noCountryFound")}</CommandEmpty>
               <CommandGroup>
                 {options
                   .filter((x) => x.value)

--- a/src/i18n/messages.json
+++ b/src/i18n/messages.json
@@ -263,6 +263,14 @@
     "en": "Access External Dataset",
     "fr": "Accéder au jeu de données externe"
   },
+  "datasets.detail.externalLinkNotAvailable": {
+    "en": "External link not available",
+    "fr": "Lien externe non disponible"
+  },
+  "datasets.detail.noDescriptionAvailable": {
+    "en": "No description available",
+    "fr": "Aucune description disponible"
+  },
   "datasets.detail.notProvided": {
     "en": "Not provided",
     "fr": "Non renseigné"
@@ -1114,5 +1122,377 @@
   "contact.validation.message": {
     "en": "Please enter a message.",
     "fr": "Veuillez saisir un message."
+  },
+  "common.loading": {
+    "en": "Loading...",
+    "fr": "Chargement..."
+  },
+  "common.cancel": {
+    "en": "Cancel",
+    "fr": "Annuler"
+  },
+  "common.send": {
+    "en": "Send",
+    "fr": "Envoyer"
+  },
+  "common.externalDataset": {
+    "en": "External Dataset",
+    "fr": "Jeu de données externe"
+  },
+  "common.externalDatasetWarning": {
+    "en": "You are about to be redirected to an external website. This dataset is not available for direct access through the GDI User Portal and must be requested through the external data provider.",
+    "fr": "Vous êtes sur le point d'être redirigé vers un site web externe. Ce jeu de données n'est pas accessible directement via le portail utilisateur GDI et doit être demandé auprès du fournisseur de données externe."
+  },
+  "common.continueToExternalSite": {
+    "en": "Continue to External Site",
+    "fr": "Accéder au site externe"
+  },
+  "common.viewExternal": {
+    "en": "View External →",
+    "fr": "Voir l'externe →"
+  },
+  "datasets.filters.noResultsFound": {
+    "en": "No results found.",
+    "fr": "Aucun résultat trouvé."
+  },
+  "datasets.activeFilters": {
+    "en": "Active Filters",
+    "fr": "Filtres actifs"
+  },
+  "datasets.beaconErrorTitle": {
+    "en": "Individual-level data discovery unavailable",
+    "fr": "Découverte de données au niveau individuel indisponible"
+  },
+  "application.addParticipant": {
+    "en": "Add Participant",
+    "fr": "Ajouter un participant"
+  },
+  "application.namePlaceholder": {
+    "en": "Name",
+    "fr": "Nom"
+  },
+  "application.emailPlaceholder": {
+    "en": "Email",
+    "fr": "E-mail"
+  },
+  "application.invitationSentSuccessfully": {
+    "en": "Invitation sent successfully",
+    "fr": "Invitation envoyée avec succès"
+  },
+  "application.failedToInviteMember": {
+    "en": "Failed to invite member",
+    "fr": "Échec de l'invitation du membre"
+  },
+  "alleleFrequency.searching": {
+    "en": "Searching and preparing results...",
+    "fr": "Recherche et préparation des résultats..."
+  },
+  "alleleFrequency.noResults": {
+    "en": "No results found",
+    "fr": "Aucun résultat trouvé"
+  },
+  "alleleFrequency.searchForYourVariant": {
+    "en": "Search for your variant:",
+    "fr": "Recherchez votre variant :"
+  },
+  "alleleFrequency.refGenome": {
+    "en": "Ref Genome",
+    "fr": "Génome de référence"
+  },
+  "alleleFrequency.selectReferenceGenome": {
+    "en": "Select reference genome",
+    "fr": "Sélectionner le génome de référence"
+  },
+  "alleleFrequency.variant": {
+    "en": "Variant",
+    "fr": "Variant"
+  },
+  "alleleFrequency.variantPlaceholder": {
+    "en": "e.g. 21-9411449 or 21-9411449-G-T",
+    "fr": "ex. 21-9411449 ou 21-9411449-G-T"
+  },
+  "alleleFrequency.variantTooltip": {
+    "en": "Supported formats: chromosome-position (e.g. 21-9411449) or chromosome-position-reference-alternate (e.g. 21-9411449-G-T). Position is interpreted as 1-based.",
+    "fr": "Formats supportés : chromosome-position (ex. 21-9411449) ou chromosome-position-référence-alternatif (ex. 21-9411449-G-T). La position est interprétée en base 1."
+  },
+  "alleleFrequency.sex": {
+    "en": "Sex",
+    "fr": "Sexe"
+  },
+  "alleleFrequency.selectSex": {
+    "en": "Select sex",
+    "fr": "Sélectionner le sexe"
+  },
+  "alleleFrequency.male": {
+    "en": "Male",
+    "fr": "Masculin"
+  },
+  "alleleFrequency.female": {
+    "en": "Female",
+    "fr": "Féminin"
+  },
+  "alleleFrequency.countryOfBirth": {
+    "en": "Country of Birth",
+    "fr": "Pays de naissance"
+  },
+  "alleleFrequency.selectCountry": {
+    "en": "Select country",
+    "fr": "Sélectionner un pays"
+  },
+  "alleleFrequency.datasetType": {
+    "en": "Dataset Type",
+    "fr": "Type de jeu de données"
+  },
+  "alleleFrequency.search": {
+    "en": "Search",
+    "fr": "Rechercher"
+  },
+  "alleleFrequency.disabledSearchTooltip": {
+    "en": "First select the reference genome, then provide the variant. Position is entered as 1-based and converted to 0-based for the query.",
+    "fr": "Sélectionnez d'abord le génome de référence, puis indiquez le variant. La position est saisie en base 1 et convertie en base 0 pour la requête."
+  },
+  "alleleFrequency.incorrectVariant": {
+    "en": "Incorrect variant information",
+    "fr": "Informations de variant incorrectes"
+  },
+  "alleleFrequency.variantExample": {
+    "en": "Variant Example: ",
+    "fr": "Exemple de variant : "
+  },
+  "alleleFrequency.notAvailable": {
+    "en": "not available",
+    "fr": "non disponible"
+  },
+  "alleleFrequency.summaryForCurrentFilter": {
+    "en": "Summary for current filter",
+    "fr": "Résumé du filtre actuel"
+  },
+  "alleleFrequency.scope": {
+    "en": "Scope",
+    "fr": "Portée"
+  },
+  "alleleFrequency.population": {
+    "en": "Population",
+    "fr": "Population"
+  },
+  "alleleFrequency.alleleCount": {
+    "en": "Allele Count",
+    "fr": "Nombre d'allèles"
+  },
+  "alleleFrequency.alleleNumber": {
+    "en": "Allele Number",
+    "fr": "Numéro d'allèle"
+  },
+  "alleleFrequency.frequency": {
+    "en": "Frequency",
+    "fr": "Fréquence"
+  },
+  "alleleFrequency.allVisibleDatasets": {
+    "en": "All visible matching datasets",
+    "fr": "Tous les jeux de données correspondants visibles"
+  },
+  "alleleFrequency.detailedResults": {
+    "en": "Detailed results",
+    "fr": "Résultats détaillés"
+  },
+  "alleleFrequency.variantLabel": {
+    "en": "Variant: ",
+    "fr": "Variant : "
+  },
+  "alleleFrequency.dataset": {
+    "en": "Dataset",
+    "fr": "Jeu de données"
+  },
+  "alleleFrequency.homozygous": {
+    "en": "Homozygous",
+    "fr": "Homozygote"
+  },
+  "alleleFrequency.heterozygous": {
+    "en": "Heterozygous",
+    "fr": "Hétérozygote"
+  },
+  "alleleFrequency.hemizygous": {
+    "en": "Hemizygous",
+    "fr": "Hémizygote"
+  },
+  "alleleFrequency.actions": {
+    "en": "Actions",
+    "fr": "Actions"
+  },
+  "alleleFrequency.beacon": {
+    "en": "Beacon: ",
+    "fr": "Beacon : "
+  },
+  "alleleFrequency.accessExternalDataset": {
+    "en": "Access external dataset",
+    "fr": "Accéder au jeu de données externe"
+  },
+  "alleleFrequency.externalLinkNotAvailable": {
+    "en": "External link not available",
+    "fr": "Lien externe non disponible"
+  },
+  "datasets.filters.clearFilters": {
+    "en": "Clear Filters",
+    "fr": "Effacer les filtres"
+  },
+  "datasets.filters.activeCount": {
+    "en": "({count, plural, one {# filter active} other {# filters active}})",
+    "fr": "({count, plural, one {# filtre actif} other {# filtres actifs}})"
+  },
+  "datasets.filters.valueLabel": {
+    "en": "Value",
+    "fr": "Valeur"
+  },
+  "datasets.filters.operatorLabel": {
+    "en": "Operator",
+    "fr": "Opérateur"
+  },
+  "datasets.filters.dateLabel": {
+    "en": "Date",
+    "fr": "Date"
+  },
+  "datasets.filters.numberLabel": {
+    "en": "Number",
+    "fr": "Nombre"
+  },
+  "datasets.filters.valuePlaceholder": {
+    "en": "Enter a value",
+    "fr": "Saisir une valeur"
+  },
+  "datasets.filters.numberPlaceholder": {
+    "en": "Enter a number",
+    "fr": "Saisir un nombre"
+  },
+  "datasets.filters.operatorPlaceholder": {
+    "en": "Select an operator",
+    "fr": "Sélectionner un opérateur"
+  },
+  "datasets.filters.addFilter": {
+    "en": "Add filter",
+    "fr": "Ajouter un filtre"
+  },
+  "datasets.filters.removeFilter": {
+    "en": "Remove filter",
+    "fr": "Supprimer le filtre"
+  },
+  "datasets.filters.apply": {
+    "en": "Apply",
+    "fr": "Appliquer"
+  },
+  "datasets.filters.valueAndOperatorError": {
+    "en": "Value and operator must not be empty",
+    "fr": "La valeur et l'opérateur ne doivent pas être vides"
+  },
+  "datasets.filters.dateAndOperatorError": {
+    "en": "Date and operator must not be empty",
+    "fr": "La date et l'opérateur ne doivent pas être vides"
+  },
+  "datasets.filters.numberAndOperatorError": {
+    "en": "Number and operator must not be empty",
+    "fr": "Le nombre et l'opérateur ne doivent pas être vides"
+  },
+  "datasets.filters.allFieldsError": {
+    "en": "All fields must be filled",
+    "fr": "Tous les champs doivent être remplis"
+  },
+  "application.fields.optional": {
+    "en": "(Optional)",
+    "fr": "(Facultatif)"
+  },
+  "application.fields.emailPlaceholder": {
+    "en": "Enter your email address",
+    "fr": "Saisir votre adresse e-mail"
+  },
+  "application.fields.uploadFile": {
+    "en": "Upload File",
+    "fr": "Téléverser un fichier"
+  },
+  "application.terms.noTermsDefined": {
+    "en": "No terms and conditions have been defined.",
+    "fr": "Aucune condition générale n'a été définie."
+  },
+  "application.terms.readMore": {
+    "en": "Read more",
+    "fr": "Lire la suite"
+  },
+  "application.terms.accepted": {
+    "en": "Accepted",
+    "fr": "Accepté"
+  },
+  "application.terms.notAccepted": {
+    "en": "Not Accepted",
+    "fr": "Non accepté"
+  },
+  "application.terms.acceptAll": {
+    "en": "Accept All",
+    "fr": "Tout accepter"
+  },
+  "common.searchCountry": {
+    "en": "Search country...",
+    "fr": "Rechercher un pays..."
+  },
+  "common.noCountryFound": {
+    "en": "No country found.",
+    "fr": "Aucun pays trouvé."
+  },
+  "application.fields.addRow": {
+    "en": "Add Row",
+    "fr": "Ajouter une ligne"
+  },
+  "application.fields.selectAnOption": {
+    "en": "Select an option",
+    "fr": "Sélectionner une option"
+  },
+  "application.fields.noOptionsAvailable": {
+    "en": "No options available",
+    "fr": "Aucune option disponible"
+  },
+  "auth.missing-terms.title": {
+    "en": "Login blocked",
+    "fr": "Connexion bloquée"
+  },
+  "auth.missing-terms.message": {
+    "en": "You must accept the terms and conditions before you can access the portal.",
+    "fr": "Vous devez accepter les conditions générales avant de pouvoir accéder au portail."
+  },
+  "datasets.card.createdOn": {
+    "en": "Created on {date}",
+    "fr": "Créé le {date}"
+  },
+  "datasets.card.modifiedOn": {
+    "en": "Modified on {date}",
+    "fr": "Modifié le {date}"
+  },
+  "datasets.card.publishedBy": {
+    "en": "Published by {names}",
+    "fr": "Publié par {names}"
+  },
+  "datasets.card.distributionCount": {
+    "en": "{count, plural, one {# Distribution} other {# Distributions}}",
+    "fr": "{count, plural, one {# distribution} other {# distributions}}"
+  },
+  "datasets.card.datasetSeriesCount": {
+    "en": "{count, plural, one {# Dataset series} other {# Dataset series}}",
+    "fr": "{count, plural, one {# Série de données} other {# Séries de données}}"
+  },
+  "datasets.card.recordsCount": {
+    "en": "{count, plural, one {# Record} other {# Records}}",
+    "fr": "{count, plural, one {# Enregistrement} other {# Enregistrements}}"
+  },
+  "datasets.card.temporalCoveragePresent": {
+    "en": "Present",
+    "fr": "Présent"
+  },
+  "datasets.card.temporalCoverageNA": {
+    "en": "N/A",
+    "fr": "N/D"
+  },
+  "datasets.card.entitlementStart": {
+    "en": "Start: {date}",
+    "fr": "Début : {date}"
+  },
+  "datasets.card.entitlementEnd": {
+    "en": "End: {date}",
+    "fr": "Fin : {date}"
   }
 }


### PR DESCRIPTION
## Summary by Sourcery

Localize allele frequency, datasets, applications, auth, and common UI texts using next-intl translation keys instead of hard-coded English strings.

New Features:
- Add translation-driven labels, placeholders, tooltips, and messages to allele frequency search and results views, including support for localized 'not available' content.
- Enable localized messaging for auth error banners, application participant invitations, and application form fields (options, tables, file upload, email).
- Introduce localization for dataset cards, filters, external dataset dialogs, and phone country search UI, including support for external dataset access texts.

Enhancements:
- Refactor multiple components to consistently use next-intl hooks for user-facing copy, improving internationalization and French language support.