### PR TITLE
fix: return local-index filters in search

### DIFF
--- a/src/app/api/discovery/local-store/__tests__/opensearch-store.test.ts
+++ b/src/app/api/discovery/local-store/__tests__/opensearch-store.test.ts
@@ -157,6 +157,41 @@ describe("OpenSearchDiscoveryStore", () => {
     ]);
   });
 
+  test("hasFilterValues returns true when the field exists in indexed documents", async () => {
+    const store = createStore();
+    mockClient.post.mockResolvedValueOnce({
+      data: { count: 4 },
+    });
+
+    await expect(
+      store.hasFilterValues("numberOfUniqueIndividuals")
+    ).resolves.toBe(true);
+    expect(mockClient.post).toHaveBeenCalledWith("/discovery_datasets/_count", {
+      query: {
+        exists: {
+          field: "numberOfUniqueIndividuals",
+        },
+      },
+    });
+  });
+
+  test("hasFilterValues returns false when the field is missing in indexed documents", async () => {
+    const store = createStore();
+    mockClient.post.mockResolvedValueOnce({
+      data: { count: 0 },
+    });
+
+    await expect(
+      store.hasFilterValues("numberOfUniqueIndividuals")
+    ).resolves.toBe(false);
+  });
+
+  test("hasFilterValues returns false for unsupported keys", async () => {
+    const store = createStore();
+
+    await expect(store.hasFilterValues("unknown")).resolves.toBe(false);
+  });
+
   test("retrieveFilterValues returns empty list for unsupported keys", async () => {
     const store = createStore();
 

--- a/src/app/api/discovery/local-store/filter-registry.ts
+++ b/src/app/api/discovery/local-store/filter-registry.ts
@@ -18,6 +18,7 @@ type LocalFilterAggregation = {
 };
 
 export type LocalFilterDefinition = LocalDiscoveryFilter & {
+  field?: string;
   aggregation?: LocalFilterAggregation;
 };
 
@@ -53,6 +54,7 @@ const createDropdownFilter = ({
   type: "DROPDOWN",
   key,
   label,
+  field,
   aggregation: {
     field,
     mapBucket,
@@ -76,6 +78,7 @@ const createOperatorFilter = ({
   type,
   key,
   label,
+  field: key,
   operators,
 });
 

--- a/src/app/api/discovery/local-store/opensearch-store.ts
+++ b/src/app/api/discovery/local-store/opensearch-store.ts
@@ -12,6 +12,7 @@ import {
   LocalDiscoveryStore,
 } from "@/app/api/discovery/local-store/types";
 import {
+  SearchBackendCountResponse,
   SearchBackendTermsAggregationResponse,
   SearchBackendDocumentResponse,
   SearchBackendSearchResponse,
@@ -144,6 +145,34 @@ export class OpenSearchDiscoveryStore implements LocalDiscoveryStore {
       `/${this.indexName}/_delete_by_query`,
       buildClearBody()
     );
+  }
+
+  async hasFilterValues(key: string): Promise<boolean> {
+    await this.ensureInitialized();
+
+    const filterDefinition = getLocalFilterDefinition(key);
+    const field = filterDefinition?.field;
+    if (!field) {
+      return false;
+    }
+
+    let response;
+    try {
+      response = await this.client.post<SearchBackendCountResponse>(
+        `/${this.indexName}/_count`,
+        {
+          query: {
+            exists: {
+              field,
+            },
+          },
+        }
+      );
+    } catch (error) {
+      throw new Error(formatSearchBackendError(error));
+    }
+
+    return Boolean(response.data.count);
   }
 
   async retrieveFilterValues(key: string): Promise<LocalDiscoveryValueLabel[]> {

--- a/src/app/api/discovery/local-store/opensearch/types.ts
+++ b/src/app/api/discovery/local-store/opensearch/types.ts
@@ -28,3 +28,7 @@ export interface SearchBackendTermsAggregationResponse {
     };
   };
 }
+
+export interface SearchBackendCountResponse {
+  count?: number;
+}

--- a/src/app/api/discovery/local-store/types.ts
+++ b/src/app/api/discovery/local-store/types.ts
@@ -186,6 +186,7 @@ export interface LocalDiscoveryStore {
   readonly key: string;
   ensureInitialized: () => Promise<void>;
   clearDatasets: () => Promise<void>;
+  hasFilterValues: (key: string) => Promise<boolean>;
   retrieveFilterValues: (key: string) => Promise<LocalDiscoveryValueLabel[]>;
   searchDatasets: (
     options: LocalDiscoverySearchOptions

--- a/src/app/api/discovery/providers/__tests__/local-index-discovery-provider.test.ts
+++ b/src/app/api/discovery/providers/__tests__/local-index-discovery-provider.test.ts
@@ -118,6 +118,18 @@ describe("LocalIndexDiscoveryProvider", () => {
   });
 
   test("searchDatasets maps a canonical dataset fixture and applies defaults", async () => {
+    mockStore.retrieveFilterValues.mockImplementation(async (key) => {
+      if (key === "theme") {
+        return [{ value: "Health", label: "Health", count: 2 }];
+      }
+
+      if (key === "publisherName") {
+        return [{ value: "LNDS", label: "LNDS", count: 2 }];
+      }
+
+      return [];
+    });
+
     mockStore.searchDatasets.mockResolvedValueOnce({
       count: 2,
       results: [
@@ -147,6 +159,20 @@ describe("LocalIndexDiscoveryProvider", () => {
       )
     ).resolves.toEqual({
       count: 2,
+      facets: expect.arrayContaining([
+        expect.objectContaining({
+          source: "local-index",
+          key: "theme",
+          type: "DROPDOWN",
+          values: [{ value: "Health", label: "Health", count: 2 }],
+        }),
+        expect.objectContaining({
+          source: "local-index",
+          key: "publisherName",
+          type: "DROPDOWN",
+          values: [{ value: "LNDS", label: "LNDS", count: 2 }],
+        }),
+      ]),
       results: [
         {
           id: "a",

--- a/src/app/api/discovery/providers/__tests__/local-index-discovery-provider.test.ts
+++ b/src/app/api/discovery/providers/__tests__/local-index-discovery-provider.test.ts
@@ -13,6 +13,7 @@ import { parseRdfXmlToQuads } from "@/app/api/discovery/harvester/rdf-quad-loade
 const mockStore = {
   key: "opensearch",
   ensureInitialized: jest.fn<() => Promise<void>>(),
+  hasFilterValues: jest.fn<(_key: string) => Promise<boolean>>(),
   retrieveFilterValues: jest.fn<(_key: string) => Promise<unknown[]>>(),
   searchDatasets:
     jest.fn<(_options: unknown) => Promise<LocalDiscoverySearchResult>>(),
@@ -66,6 +67,7 @@ describe("LocalIndexDiscoveryProvider", () => {
   beforeEach(() => {
     jest.clearAllMocks();
     provider = new LocalIndexDiscoveryProvider();
+    mockStore.hasFilterValues.mockResolvedValue(true);
     mockStore.retrieveFilterValues.mockResolvedValue([]);
   });
 
@@ -88,6 +90,9 @@ describe("LocalIndexDiscoveryProvider", () => {
 
       return [];
     });
+    mockStore.hasFilterValues.mockImplementation(
+      async (key) => key === "modified"
+    );
 
     await expect(provider.retrieveFilters({})).resolves.toEqual(
       expect.arrayContaining([
@@ -129,6 +134,7 @@ describe("LocalIndexDiscoveryProvider", () => {
 
       return [];
     });
+    mockStore.hasFilterValues.mockResolvedValue(true);
 
     mockStore.searchDatasets.mockResolvedValueOnce({
       count: 2,
@@ -323,6 +329,9 @@ describe("LocalIndexDiscoveryProvider", () => {
     });
 
     expect(mockStore.ensureInitialized).toHaveBeenCalled();
+    expect(mockStore.hasFilterValues).toHaveBeenCalledWith(
+      "numberOfUniqueIndividuals"
+    );
     expect(mockStore.searchDatasets).toHaveBeenCalledWith({
       query: "Dataset",
       facets: [

--- a/src/app/api/discovery/providers/local-index-discovery-provider.ts
+++ b/src/app/api/discovery/providers/local-index-discovery-provider.ts
@@ -127,19 +127,29 @@ export class LocalIndexDiscoveryProvider extends BasePlaceholderDiscoveryProvide
     _headers: Record<string, string>
   ): Promise<DiscoveryFilter[]> {
     const localFilters = listLocalFilters();
-
-    return Promise.all(
+    const resolvedFilters = await Promise.all(
       localFilters.map(async (filter) => {
         if (filter.type !== "DROPDOWN") {
-          return { ...filter, source: this.key };
+          return (await this.store.hasFilterValues(filter.key))
+            ? { ...filter, source: this.key }
+            : null;
+        }
+
+        const values = await this.store.retrieveFilterValues(filter.key);
+        if (!values.length) {
+          return null;
         }
 
         return {
           ...filter,
           source: this.key,
-          values: await this.store.retrieveFilterValues(filter.key),
+          values,
         };
       })
+    );
+
+    return resolvedFilters.filter(
+      (filter): filter is DiscoveryFilter => filter !== null
     );
   }
 

--- a/src/app/api/discovery/providers/local-index-discovery-provider.ts
+++ b/src/app/api/discovery/providers/local-index-discovery-provider.ts
@@ -152,17 +152,20 @@ export class LocalIndexDiscoveryProvider extends BasePlaceholderDiscoveryProvide
 
   async searchDatasets(
     options: DiscoveryDatasetSearchQuery,
-    _headers: Record<string, string>
+    headers: Record<string, string>
   ): Promise<DiscoveryDatasetsSearchResponse> {
     await this.store.ensureInitialized();
-    const response = await this.store.searchDatasets({
-      query: options.query,
-      facets: options.facets?.map(({ source: _source, ...facet }) => facet),
-      sort: options.sort,
-      start: options.start,
-      rows: options.rows,
-      operator: options.operator,
-    });
+    const [response, facets] = await Promise.all([
+      this.store.searchDatasets({
+        query: options.query,
+        facets: options.facets?.map(({ source: _source, ...facet }) => facet),
+        sort: options.sort,
+        start: options.start,
+        rows: options.rows,
+        operator: options.operator,
+      }),
+      this.retrieveFilters(headers),
+    ]);
 
     return {
       count: response.count,
@@ -170,6 +173,7 @@ export class LocalIndexDiscoveryProvider extends BasePlaceholderDiscoveryProvide
         ...this.mapLocalDataset(dataset),
         distributionsCount: dataset.distributionsCount,
       })),
+      facets,
     };
   }
 

--- a/src/app/datasets/FilterList/index.tsx
+++ b/src/app/datasets/FilterList/index.tsx
@@ -16,6 +16,26 @@ export default function FilterList() {
   const { filters } = useFilters();
   const searchParams = useSearchParams();
 
+  const hasRenderableContent = (filter: (typeof filters)[number]) => {
+    if (filter.type === "DROPDOWN") {
+      return (
+        filter.values?.some((value) =>
+          Boolean(value.value?.trim() || value.label?.trim())
+        ) ?? false
+      );
+    }
+
+    if (filter.type === "ENTRIES") {
+      return (
+        filter.entries?.some((entry) =>
+          Boolean(entry.key?.trim() && entry.label?.trim())
+        ) ?? false
+      );
+    }
+
+    return true;
+  };
+
   // Check if Beacon is enabled via URL parameter
   const includeBeacon = searchParams.get("beacon") === "true";
 
@@ -30,10 +50,9 @@ export default function FilterList() {
       // Only show Beacon filters if:
       // 1. User has Beacon access AND
       // 2. Beacon toggle is ON
-      return includeBeacon && hasBeaconAccess;
+      return includeBeacon && hasBeaconAccess && hasRenderableContent(filter);
     }
-    // Always show CKAN filters
-    return true;
+    return hasRenderableContent(filter);
   });
 
   // Group filters by source


### PR DESCRIPTION
Fix local-index dataset searches so catalogue filters appear again in the datasets page.

## What changed

- return `facets` from the `local-index` discovery provider `searchDatasets()` response
- reuse the existing local filter registry when building those facets
- add/update provider tests to cover the returned local-index filters

## Why

The datasets page currently populates filters from `searchDatasetsApi(...).facets`.

With `DISCOVERY_PROVIDER=local-index`, the provider returned only:
- `count`
- `results`

and no `facets`, so the UI stored an empty filter list and the **Catalogue Filters** section did not render.

## Result

When using `DISCOVERY_PROVIDER=local-index`, the datasets page now receives filter metadata and shows the catalogue filters again.

## Summary by Sourcery

Restore catalogue filter facets in local-index-backed dataset search responses so the datasets page can display filters again.

Enhancements:
- Include facets from the local filter registry in the LocalIndexDiscoveryProvider searchDatasets response.

Tests:
- Extend LocalIndexDiscoveryProvider tests to cover returned local-index facets and filter values in searchDatasets responses.