### PR TITLE
chore: temporarily disable ORT checks

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -28,11 +28,12 @@ jobs:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
         with:
           persist-credentials: false
-      - uses: oss-review-toolkit/ort-ci-github-action@086d928d24ef1653dc0777296b312fda5faaaf52 # v1
-        with:
-          allow-dynamic-versions: "true"
-          fail-on: "issues"
-          run: "cache-dependencies,cache-scan-results,labels,analyzer,evaluator,advisor,reporter,upload-results"
+      # Temporarily disabled while the upstream ORT image is failing at startup.
+      # - uses: oss-review-toolkit/ort-ci-github-action@086d928d24ef1653dc0777296b312fda5faaaf52 # v1
+      #   with:
+      #     allow-dynamic-versions: "true"
+      #     fail-on: "issues"
+      #     run: "cache-dependencies,cache-scan-results,labels,analyzer,evaluator,advisor,reporter,upload-results"
 
   build-and-push-image:
     runs-on: ubuntu-latest

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -32,11 +32,12 @@ jobs:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
         with:
           persist-credentials: false
-      - uses: oss-review-toolkit/ort-ci-github-action@086d928d24ef1653dc0777296b312fda5faaaf52 # v1
-        with:
-          allow-dynamic-versions: "true"
-          fail-on: "issues"
-          run: "cache-dependencies,cache-scan-results,labels,analyzer,evaluator,advisor,reporter,upload-results"
+      # Temporarily disabled while the upstream ORT image is failing at startup.
+      # - uses: oss-review-toolkit/ort-ci-github-action@086d928d24ef1653dc0777296b312fda5faaaf52 # v1
+      #   with:
+      #     allow-dynamic-versions: "true"
+      #     fail-on: "issues"
+      #     run: "cache-dependencies,cache-scan-results,labels,analyzer,evaluator,advisor,reporter,upload-results"
 
   e2e-tests:
     runs-on: ubuntu-latest

--- a/.github/workflows/weekly_vuln_scan.yml
+++ b/.github/workflows/weekly_vuln_scan.yml
@@ -76,8 +76,9 @@ jobs:
           repository: ${{ github.repository }}
           persist-credentials: false
 
-      - uses: oss-review-toolkit/ort-ci-github-action@086d928d24ef1653dc0777296b312fda5faaaf52 # v1
-        with:
-          allow-dynamic-versions: "true"
-          fail-on: "issues"
-          run: "cache-dependencies,cache-scan-results,labels,analyzer,evaluator,advisor,reporter,upload-results"
+      # Temporarily disabled while the upstream ORT image is failing at startup.
+      # - uses: oss-review-toolkit/ort-ci-github-action@086d928d24ef1653dc0777296b312fda5faaaf52 # v1
+      #   with:
+      #     allow-dynamic-versions: "true"
+      #     fail-on: "issues"
+      #     run: "cache-dependencies,cache-scan-results,labels,analyzer,evaluator,advisor,reporter,upload-results"


### PR DESCRIPTION
## Summary by Sourcery

Build:
- Comment out ORT CI GitHub Action steps in main, release, and weekly vulnerability scan workflows to prevent failing runs while the upstream image is broken.