### PR TITLE
fix: pin ORT image in release and vuln scan

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -32,10 +32,11 @@ jobs:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
         with:
           persist-credentials: false
-      - uses: oss-review-toolkit/ort-ci-github-action@086d928d24ef1653dc0777296b312fda5faaaf52 # v1
+      - uses: oss-review-toolkit/ort-ci-github-action@086d928d24ef1653dc0777296b312fda5faaaf52 # v1.2.0
         with:
           allow-dynamic-versions: "true"
           fail-on: "issues"
+          image: "ghcr.io/oss-review-toolkit/ort:89.2.0"
           run: "cache-dependencies,cache-scan-results,labels,analyzer,evaluator,advisor,reporter,upload-results"
 
   e2e-tests:

--- a/.github/workflows/weekly_vuln_scan.yml
+++ b/.github/workflows/weekly_vuln_scan.yml
@@ -76,8 +76,9 @@ jobs:
           repository: ${{ github.repository }}
           persist-credentials: false
 
-      - uses: oss-review-toolkit/ort-ci-github-action@086d928d24ef1653dc0777296b312fda5faaaf52 # v1
+      - uses: oss-review-toolkit/ort-ci-github-action@086d928d24ef1653dc0777296b312fda5faaaf52 # v1.2.0
         with:
           allow-dynamic-versions: "true"
           fail-on: "issues"
+          image: "ghcr.io/oss-review-toolkit/ort:89.2.0"
           run: "cache-dependencies,cache-scan-results,labels,analyzer,evaluator,advisor,reporter,upload-results"


### PR DESCRIPTION
## Summary by Sourcery

Pin the OSS Review Toolkit CI action and container image versions used in release and weekly vulnerability scan workflows.

CI:
- Update release workflow to use oss-review-toolkit/ort-ci-github-action v1.2.0 with a pinned ORT container image.
- Update weekly vulnerability scan workflow to use oss-review-toolkit/ort-ci-github-action v1.2.0 with a pinned ORT container image.