### PR TITLE
feat: Extract distribution descriptions for local-index datasets

### DIFF
--- a/src/app/api/discovery/harvester/__tests__/dcat-harvester-service.test.ts
+++ b/src/app/api/discovery/harvester/__tests__/dcat-harvester-service.test.ts
@@ -215,6 +215,7 @@ describe("DcatHarvesterService", () => {
           {
             id: "distribution-1",
             title: "Population Registry CSV",
+            description: "Distribution-level CSV extract for registry data",
             format: {
               value:
                 "http://publications.europa.eu/resource/authority/file-type/CSV",

--- a/src/app/api/discovery/harvester/dcat-distribution-mapper.ts
+++ b/src/app/api/discovery/harvester/dcat-distribution-mapper.ts
@@ -14,6 +14,8 @@ const DCAT_DOWNLOAD_URL = "http://www.w3.org/ns/dcat#downloadURL"; // NOSONAR
 const DCT_IDENTIFIER = "http://purl.org/dc/terms/identifier"; // NOSONAR
 const DCT_TITLE = "http://purl.org/dc/terms/title"; // NOSONAR
 const DC_TITLE = "http://purl.org/dc/elements/1.1/title"; // NOSONAR
+const DCT_DESCRIPTION = "http://purl.org/dc/terms/description"; // NOSONAR
+const DC_DESCRIPTION = "http://purl.org/dc/elements/1.1/description"; // NOSONAR
 const DCT_FORMAT = "http://purl.org/dc/terms/format"; // NOSONAR
 const DCAT_MEDIA_TYPE = "http://www.w3.org/ns/dcat#mediaType"; // NOSONAR
 const DCT_LICENSE = "http://purl.org/dc/terms/license"; // NOSONAR
@@ -80,6 +82,7 @@ const mapDistribution = (
   return {
     id: id || `${datasetId}-distribution-${index + 1}`,
     title,
+    description: getDistributionDescription(distributionSubject, graph),
     format: getDistributionFormat(distributionSubject, graph),
     mediaType: getDistributionMediaType(distributionSubject, graph),
     license: getDistributionLicense(distributionSubject, graph),
@@ -113,6 +116,18 @@ const getDistributionTitle = (
   accessUrl ||
   downloadUrl ||
   "";
+
+const getDistributionDescription = (
+  distributionSubject: RDF.Term,
+  graph: RdfGraph
+): string | undefined => {
+  const description = graph.getFirstLiteral(distributionSubject, [
+    DCT_DESCRIPTION,
+    DC_DESCRIPTION,
+  ]);
+
+  return description || undefined;
+};
 
 const getDistributionFormat = (
   distributionSubject: RDF.Term,

--- a/src/app/api/discovery/local-store/types.ts
+++ b/src/app/api/discovery/local-store/types.ts
@@ -24,6 +24,7 @@ export interface LocalAgent {
 export interface LocalDiscoveryDistribution {
   id: string;
   title: string;
+  description?: string;
   format?: { value: string; label: string };
   mediaType?: { value: string; label: string };
   license?: { value: string; label: string };

--- a/src/app/api/discovery/providers/__tests__/local-index-discovery-provider.test.ts
+++ b/src/app/api/discovery/providers/__tests__/local-index-discovery-provider.test.ts
@@ -586,7 +586,7 @@ describe("LocalIndexDiscoveryProvider", () => {
         {
           id: "distribution-1",
           title: "Population Registry CSV",
-          description: "",
+          description: "Distribution-level CSV extract for registry data",
           format: {
             value:
               "http://publications.europa.eu/resource/authority/file-type/CSV",
@@ -804,7 +804,7 @@ describe("LocalIndexDiscoveryProvider", () => {
         {
           id: "distribution-1",
           title: "Population Registry CSV",
-          description: "",
+          description: "Distribution-level CSV extract for registry data",
           format: {
             value:
               "http://publications.europa.eu/resource/authority/file-type/CSV",

--- a/src/app/api/discovery/providers/local-index-discovery-provider.ts
+++ b/src/app/api/discovery/providers/local-index-discovery-provider.ts
@@ -111,7 +111,7 @@ export class LocalIndexDiscoveryProvider extends BasePlaceholderDiscoveryProvide
     return dataset.distributions?.map((distribution) => ({
       id: distribution.id,
       title: distribution.title,
-      description: "",
+      description: distribution.description ?? "",
       format: distribution.format,
       mediaType: distribution.mediaType,
       license: distribution.license,

--- a/src/app/api/discovery/test-utils/fixtures.ts
+++ b/src/app/api/discovery/test-utils/fixtures.ts
@@ -189,6 +189,7 @@ export const canonicalDiscoveryRdf = `
         <dcat:Distribution rdf:about="https://example.org/distributions/population-registry-csv">
           <dct:identifier>distribution-1</dct:identifier>
           <dct:title>Population Registry CSV</dct:title>
+          <dct:description>Distribution-level CSV extract for registry data</dct:description>
           <dct:format rdf:resource="http://publications.europa.eu/resource/authority/file-type/CSV" />
           <dcat:mediaType>
             <dct:MediaType rdf:about="http://www.iana.org/assignments/media-types/text/csv">
@@ -324,6 +325,7 @@ export const buildLocalDiscoveryDataset = (
     {
       id: "distribution-1",
       title: "Population Registry CSV",
+      description: "Distribution-level CSV extract for registry data",
       format: {
         value: "http://publications.europa.eu/resource/authority/file-type/CSV", // NOSONAR
         label: "CSV",


### PR DESCRIPTION
## Summary

  This change fixes missing distribution descriptions when `DISCOVERY_PROVIDER=local-index`.

  The dataset detail UI already renders `distribution.description`, but the local-index pipeline was dropping that field before it reached the page. This PR extracts distribution
  descriptions from RDF, stores them in the local discovery model, and maps them through the local-index provider response.

  ## Changes

  - add `description?: string` to `LocalDiscoveryDistribution`
  - extract distribution descriptions from RDF using `dct:description` and `dc:description`
  - pass distribution descriptions through the local-index provider instead of hardcoding an empty string
  - update canonical discovery fixtures to include a distribution description
  - extend tests to verify distribution descriptions survive:
    - RDF harvesting/parsing
    - local-index provider retrieval mapping

## Summary by Sourcery

Preserve and surface distribution descriptions for datasets in the local-index discovery pipeline.

New Features:
- Support optional descriptions on local discovery distributions and expose them via the local-index discovery provider.

Bug Fixes:
- Ensure distribution descriptions harvested from RDF are no longer dropped when using the local-index discovery provider.

Enhancements:
- Extract distribution descriptions from RDF (dct:description/dc:description) into the local discovery model and pass them through provider responses.
- Update RDF fixtures and harvester/provider tests to cover distribution descriptions end-to-end.