### PR TITLE
feat:ART-27431 filter helper text tooltip

### DIFF
--- a/src/app/api/discovery/open-api/discovery.yml
+++ b/src/app/api/discovery/open-api/discovery.yml
@@ -1030,6 +1030,9 @@ components:
         label:
           type: string
           title: Label
+        helpText:
+          type: string
+          title: Help text
         values:
           type: array
           items:

--- a/src/app/datasets/FilterList/FilterItem.tsx
+++ b/src/app/datasets/FilterList/FilterItem.tsx
@@ -70,7 +70,7 @@ function FilterItem({ filter }: FilterItemProps) {
                       >
                         <FontAwesomeIcon
                           icon={faInfoCircle}
-                          className="h-4 w-4 text-gray-500"
+                          className="h-4 w-4 text-info"
                         />
                         <Tooltip message={filter.helpText} />
                       </span>

--- a/src/app/datasets/FilterList/FilterItem.tsx
+++ b/src/app/datasets/FilterList/FilterItem.tsx
@@ -6,11 +6,12 @@
 import { FilterType } from "@/app/api/discovery/additional-types";
 import { Filter } from "@/app/api/discovery/open-api/schemas";
 import { useFilters } from "@/providers/filters/FilterProvider";
-import { faChevronDown } from "@fortawesome/free-solid-svg-icons";
+import { faChevronDown, faInfoCircle } from "@fortawesome/free-solid-svg-icons";
 import { useTranslations } from "next-intl";
 import { FontAwesomeIcon } from "@fortawesome/react-fontawesome";
 import { Disclosure } from "@headlessui/react";
 import { default as DropdownFilterContent } from "./DropdownFilterContent";
+import Tooltip from "@/app/datasets/[id]/Tooltip";
 import EntriesFilterContent from "./EntriesFilterContent";
 import FreeTextFilterContent from "./FreeTextFilterContent";
 import DateTimeFilterContent from "./DateTimeFilterContent";
@@ -59,7 +60,22 @@ function FilterItem({ filter }: FilterItemProps) {
             <>
               <Disclosure.Button className="flex w-full justify-between px-4 py-2 text-left">
                 <div>
-                  <span className="text-base px-1.5">{filter.label}</span>
+                  <span className="relative inline-flex items-center gap-x-2 group">
+                    <span className="text-base px-1.5">{filter.label}</span>
+                    {filter.helpText && (
+                      <span
+                        tabIndex={0}
+                        aria-label={filter.helpText}
+                        className="relative group inline-flex items-center rounded focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-info"
+                      >
+                        <FontAwesomeIcon
+                          icon={faInfoCircle}
+                          className="h-4 w-4 text-gray-500"
+                        />
+                        <Tooltip message={filter.helpText} />
+                      </span>
+                    )}
+                  </span>
                   <span className="text-base text-info">
                     {isFilterActive &&
                       t("activeCount", { count: nbActiveValues })}

--- a/src/app/datasets/[id]/Tooltip.tsx
+++ b/src/app/datasets/[id]/Tooltip.tsx
@@ -12,7 +12,7 @@ interface TooltipProps {
 
 const Tooltip: React.FC<TooltipProps> = ({ message }) => {
   return (
-    <div className="absolute left-0 top-full mt-1 hidden group-hover:flex items-center bg-info text-white text-xs rounded-2xl py-1 px-2 z-10 whitespace-nowrap">
+    <div className="absolute left-0 top-full mt-1 hidden group-hover:flex group-focus:flex items-center bg-info text-white text-xs rounded-2xl py-1 px-2 z-10 whitespace-nowrap">
       <FontAwesomeIcon icon={faInfoCircle} className="mr-1" />
       {message}
     </div>


### PR DESCRIPTION
## Summary by Sourcery

Add contextual help tooltips to dataset filter items and support help text in the discovery API filter schema.

New Features:
- Display an info icon next to filter labels that exposes helper text via a tooltip when available.
- Extend the discovery API filter schema with an optional helpText field for providing filter helper text.

Enhancements:
- Update the generic Tooltip component to also appear on keyboard focus for improved accessibility.