### PR TITLE
refactor(GVariantsSearchBar): update sex and countryOfBirth defaults to "All" and improve country filter options; enhance GVariantsTableUtils to promote aggregate totals

### DIFF
--- a/src/app/allele-frequency/GVariantsSearchBar.tsx
+++ b/src/app/allele-frequency/GVariantsSearchBar.tsx
@@ -111,10 +111,13 @@ export default function GVariantsSearchBar({
   ];
 
   const SEX_OPTIONS = [
-    { value: "", label: t("selectSex") },
-    { value: "All", label: "All" },
+    { value: "All", label: "Total" },
     { value: "M", label: t("male") },
     { value: "F", label: t("female") },
+  ];
+  const COUNTRY_FILTER_OPTIONS = [
+    { value: "All", label: "All" },
+    ...COUNTRY_OPTIONS,
   ];
 
   const DISABLED_SEARCH_TOOLTIP = t("disabledSearchTooltip");
@@ -122,8 +125,8 @@ export default function GVariantsSearchBar({
   const [searchFilterInput, setSearchFilterInput] = useState<SearchInputData>({
     variant: "",
     refGenome: "",
-    sex: "",
-    countryOfBirth: "",
+    sex: "All",
+    countryOfBirth: "All",
     datasetType: "All",
   });
   const [errorMessage, setErrorMessage] = useState("");
@@ -160,14 +163,14 @@ export default function GVariantsSearchBar({
 
       if (field === "refGenome" && !value) {
         updatedState.variant = "";
-        updatedState.sex = "";
-        updatedState.countryOfBirth = "";
+        updatedState.sex = "All";
+        updatedState.countryOfBirth = "All";
         updatedState.datasetType = "All";
       }
 
       if (field === "variant" && (!normalizedVariant || variantIsAllKeyword)) {
-        updatedState.sex = "";
-        updatedState.countryOfBirth = "";
+        updatedState.sex = "All";
+        updatedState.countryOfBirth = "All";
       }
 
       setErrorMessage(() =>
@@ -248,11 +251,7 @@ export default function GVariantsSearchBar({
             type="select"
             value={searchFilterInput.countryOfBirth}
             onChange={(value) => updateData("countryOfBirth", value)}
-            options={[
-              { value: "", label: t("selectCountry") },
-              { value: "All", label: "All" },
-              ...COUNTRY_OPTIONS,
-            ]}
+            options={COUNTRY_FILTER_OPTIONS}
           />
         )}
 

--- a/src/utils/GVariantsTableUtils.ts
+++ b/src/utils/GVariantsTableUtils.ts
@@ -95,7 +95,7 @@ export class GVariantsTableUtils {
   static groupByBeacon(
     sortedResults: GVariantsSearchResponse[]
   ): Record<string, BeaconGroup> {
-    return sortedResults.reduce(
+    const grouped = sortedResults.reduce(
       (acc, variant) => {
         const datasetId = GVariantsTableUtils.getDisplayText(variant.datasetId);
         const beaconId = GVariantsTableUtils.getDisplayText(variant.beacon);
@@ -125,6 +125,8 @@ export class GVariantsTableUtils {
       },
       {} as Record<string, BeaconGroup>
     );
+
+    return GVariantsTableUtils.promoteAggregateTotals(grouped);
   }
 
   static getSortedBeaconIds(groupedByBeacon: Record<string, BeaconGroup>) {
@@ -245,6 +247,61 @@ export class GVariantsTableUtils {
 
   private static isNumber(value: unknown): value is number {
     return typeof value === "number" && Number.isFinite(value);
+  }
+
+  private static promoteAggregateTotals(
+    groupedByBeacon: Record<string, BeaconGroup>
+  ): Record<string, BeaconGroup> {
+    Object.values(groupedByBeacon).forEach((beaconGroup) => {
+      Object.values(beaconGroup.datasets).forEach((datasetGroup) => {
+        if (datasetGroup.totalVariant) {
+          return;
+        }
+
+        const countrySexRows = datasetGroup.variants.filter(
+          (variant) =>
+            GVariantsTableUtils.populationShape(variant.population) ===
+            "country-sex"
+        );
+        if (countrySexRows.length === 0) {
+          return;
+        }
+
+        const aggregateRows = datasetGroup.variants.filter((variant) => {
+          const shape = GVariantsTableUtils.populationShape(variant.population);
+          return shape === "country-only" || shape === "sex-only";
+        });
+
+        if (aggregateRows.length !== 1) {
+          return;
+        }
+
+        const aggregateVariant = aggregateRows[0];
+        datasetGroup.totalVariant = aggregateVariant;
+        datasetGroup.variants = datasetGroup.variants.filter(
+          (variant) => variant !== aggregateVariant
+        );
+      });
+    });
+
+    return groupedByBeacon;
+  }
+
+  private static populationShape(
+    population: string | undefined
+  ): "country-sex" | "country-only" | "sex-only" | "other" {
+    const normalized =
+      GVariantsTableUtils.getDisplayText(population).toUpperCase();
+    if (/^(M|F|MALE|FEMALE)$/.test(normalized)) {
+      return "sex-only";
+    }
+    if (/^[A-Z]{2}$/.test(normalized)) {
+      return "country-only";
+    }
+    if (/^[A-Z]{2}_(M|F|MALE|FEMALE)$/.test(normalized)) {
+      return "country-sex";
+    }
+    return "other";
   }
 
   private static formatPopulationSummary(populations: string[]): string {

--- a/src/utils/__tests__/GVariantsTableUtils.test.ts
+++ b/src/utils/__tests__/GVariantsTableUtils.test.ts
@@ -91,6 +91,33 @@ describe("GVariantsTableUtils", () => {
         grouped["Beacon B"].datasets["DS-3"].totalVariant?.population
       ).toBe("total");
     });
+
+    test("promotes a single country/sex aggregate row to totalVariant", () => {
+      const grouped = GVariantsTableUtils.groupByBeacon([
+        variant({ beacon: "Beacon A", datasetId: "DS-1", population: "M" }),
+        variant({ beacon: "Beacon A", datasetId: "DS-1", population: "ES_M" }),
+        variant({ beacon: "Beacon A", datasetId: "DS-1", population: "FR_M" }),
+      ]);
+
+      expect(
+        grouped["Beacon A"].datasets["DS-1"].totalVariant?.population
+      ).toBe("M");
+      expect(
+        grouped["Beacon A"].datasets["DS-1"].variants.map((it) => it.population)
+      ).toEqual(["ES_M", "FR_M"]);
+    });
+
+    test("does not promote aggregate row when multiple aggregate candidates exist", () => {
+      const grouped = GVariantsTableUtils.groupByBeacon([
+        variant({ beacon: "Beacon A", datasetId: "DS-1", population: "M" }),
+        variant({ beacon: "Beacon A", datasetId: "DS-1", population: "F" }),
+        variant({ beacon: "Beacon A", datasetId: "DS-1", population: "ES_M" }),
+        variant({ beacon: "Beacon A", datasetId: "DS-1", population: "ES_F" }),
+      ]);
+
+      expect(grouped["Beacon A"].datasets["DS-1"].totalVariant).toBeUndefined();
+      expect(grouped["Beacon A"].datasets["DS-1"].variants).toHaveLength(4);
+    });
   });
 
   describe("getSortedBeaconIds", () => {


### PR DESCRIPTION
## Summary by Sourcery

Promote aggregate population totals in beacon grouping and align search bar defaults and filters for sex and country of birth.

New Features:
- Automatically promote a single aggregate sex or country-only variant to the dataset total when grouping beacon results.
- Expose an explicit "All" option in the country of birth filter alongside existing country choices.

Enhancements:
- Refine population handling by classifying population strings into country/sex shapes for better aggregate detection.
- Set sex and country of birth filters to default to "All" and label the aggregate sex option as "Total" in the variants search bar.

Tests:
- Add tests verifying promotion of a single aggregate population row to totalVariant and guarding against promotion when multiple aggregate candidates exist.