### PR TITLE
feat: allow the harvester to harvest turtle format too

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -18991,6 +18991,111 @@
         "type": "github",
         "url": "https://github.com/sponsors/wooorm"
       }
+    },
+    "node_modules/next-runtime-env/node_modules/@next/swc-darwin-x64": {
+      "version": "16.2.10",
+      "resolved": "https://registry.npmjs.org/@next/swc-darwin-x64/-/swc-darwin-x64-16.2.10.tgz",
+      "integrity": "sha512-17IS0jJRViROGmA9uGdNR8VPJpfbnaVG7E9qhso5jDLkmyd0lSDORWxbcKINzcFqzZqGwGtMSnrFRxBpuUYjLQ==",
+      "cpu": [
+        "x64"
+      ],
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/next-runtime-env/node_modules/@next/swc-linux-arm64-gnu": {
+      "version": "16.2.10",
+      "resolved": "https://registry.npmjs.org/@next/swc-linux-arm64-gnu/-/swc-linux-arm64-gnu-16.2.10.tgz",
+      "integrity": "sha512-GRQRsRtuciNJvB54AvvuQTiq0oZtFwa1owQqtZD8wwnGpM2L39MV22kpI72YSXLKIyY40LC66EiLFv4PiicXxg==",
+      "cpu": [
+        "arm64"
+      ],
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/next-runtime-env/node_modules/@next/swc-linux-arm64-musl": {
+      "version": "16.2.10",
+      "resolved": "https://registry.npmjs.org/@next/swc-linux-arm64-musl/-/swc-linux-arm64-musl-16.2.10.tgz",
+      "integrity": "sha512-zkN9MQYS7UQBro+FnISUq1itaQjXI9xqISzuQ+2bc921NcJ1x4yPCqrn77tVN6/dOOXaaWVX3k6/bR07pPwK+A==",
+      "cpu": [
+        "arm64"
+      ],
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/next-runtime-env/node_modules/@next/swc-linux-x64-gnu": {
+      "version": "16.2.10",
+      "resolved": "https://registry.npmjs.org/@next/swc-linux-x64-gnu/-/swc-linux-x64-gnu-16.2.10.tgz",
+      "integrity": "sha512-iCVJnwvrPYECvA6WM/7+oo+OiTvedIKLxtCLAZP4xZR3nXa1zmzZyLPbYCmWvpd4CvMYF1EMTafd0ii3DygLvA==",
+      "cpu": [
+        "x64"
+      ],
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/next-runtime-env/node_modules/@next/swc-linux-x64-musl": {
+      "version": "16.2.10",
+      "resolved": "https://registry.npmjs.org/@next/swc-linux-x64-musl/-/swc-linux-x64-musl-16.2.10.tgz",
+      "integrity": "sha512-ov2g4H0dHY9bPoOU83m91hWT7Iq5qy13bUnyyshLU3HGR1Ownn0X9QpmDPc5iIUaahTp7f7LeGAhV4DSFtackw==",
+      "cpu": [
+        "x64"
+      ],
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/next-runtime-env/node_modules/@next/swc-win32-arm64-msvc": {
+      "version": "16.2.10",
+      "resolved": "https://registry.npmjs.org/@next/swc-win32-arm64-msvc/-/swc-win32-arm64-msvc-16.2.10.tgz",
+      "integrity": "sha512-DwAnhLX76HQiFFQNgWlcK+JzlnD1rZ+UK/WY0ZMI/deXpvgnesjNYrqcfo1JzBuz4Kf7o3brIBL0glI1junatA==",
+      "cpu": [
+        "arm64"
+      ],
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/next-runtime-env/node_modules/@next/swc-win32-x64-msvc": {
+      "version": "16.2.10",
+      "resolved": "https://registry.npmjs.org/@next/swc-win32-x64-msvc/-/swc-win32-x64-msvc-16.2.10.tgz",
+      "integrity": "sha512-0JXq3b85Jk9Jg4ntLUbXSPvoDw3gpZou7twuKdoFG2jOw635v7+IiXfTaa0TxVMyx78pUjnrVYwLgjKfX4e6/A==",
+      "cpu": [
+        "x64"
+      ],
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
     }
   }
 }

--- a/src/app/api/discovery/harvester/__tests__/dcat-harvester-service.test.ts
+++ b/src/app/api/discovery/harvester/__tests__/dcat-harvester-service.test.ts
@@ -1020,7 +1020,7 @@ describe("DcatHarvesterService", () => {
     await expect(
       service.harvestFromUrl("https://example.org/catalogue.rdf")
     ).rejects.toThrow(
-      "Failed to parse RDF/XML from https://example.org/catalogue.rdf: invalid RDF payload"
+      "Failed to parse RDF from https://example.org/catalogue.rdf: invalid RDF payload"
     );
   });
 

--- a/src/app/api/discovery/harvester/dcat-harvester-service.ts
+++ b/src/app/api/discovery/harvester/dcat-harvester-service.ts
@@ -16,7 +16,10 @@ import {
   buildHarvestRequestInit,
   harvestFetch,
 } from "@/app/api/discovery/harvester/fetch-options";
-import { parseRdfXmlToQuads } from "@/app/api/discovery/harvester/rdf-quad-loader";
+import {
+  parseRdfToQuads,
+  detectContentTypeFromUrl,
+} from "@/app/api/discovery/harvester/rdf-quad-loader";
 import { RdfGraph } from "@/app/api/discovery/harvester/rdf-graph";
 
 type FetchLike = (input: string | URL, init?: RequestInit) => Promise<Response>;
@@ -32,10 +35,20 @@ export class DcatHarvesterService {
   }
 
   async parseDatasetsFromRdf(
-    xmlText: string,
-    sourceUrl?: string
+    rdfText: string,
+    sourceUrl?: string,
+    contentType?: string
   ): Promise<LocalDiscoveryDataset[]> {
-    const quads = await parseRdfXmlToQuads(xmlText, sourceUrl);
+    const resolvedContentType =
+      (contentType as Parameters<typeof parseRdfToQuads>[1]) ??
+      (sourceUrl
+        ? detectContentTypeFromUrl(sourceUrl)
+        : ("application/rdf+xml" as const));
+    const quads = await parseRdfToQuads(
+      rdfText,
+      resolvedContentType,
+      sourceUrl
+    );
     const graph = new RdfGraph(quads);
     const fallbackCatalogue = getFallbackCatalogue(graph);
 
@@ -105,10 +118,14 @@ export class DcatHarvesterService {
     }
 
     try {
-      return await this.parseDatasetsFromRdf(xmlText, url);
+      return await this.parseDatasetsFromRdf(
+        xmlText,
+        url,
+        detectContentTypeFromUrl(url)
+      );
     } catch (error) {
       throw wrapError(
-        `Failed to parse RDF/XML from ${url}: ${formatErrorDetails(error)}`,
+        `Failed to parse RDF from ${url}: ${formatErrorDetails(error)}`,
         error
       );
     }

--- a/src/app/api/discovery/harvester/rdf-quad-loader.ts
+++ b/src/app/api/discovery/harvester/rdf-quad-loader.ts
@@ -6,12 +6,27 @@ import { Readable } from "node:stream";
 import type * as RDF from "@rdfjs/types";
 import { rdfParser } from "rdf-parse";
 
-export const parseRdfXmlToQuads = async (
-  xmlText: string,
+export const RDF_CONTENT_TYPES = {
+  rdfxml: "application/rdf+xml",
+  turtle: "text/turtle",
+} as const;
+
+export type RdfContentType =
+  (typeof RDF_CONTENT_TYPES)[keyof typeof RDF_CONTENT_TYPES];
+
+export const detectContentTypeFromUrl = (url: string): RdfContentType => {
+  const pathname = new URL(url).pathname;
+  if (pathname.endsWith(".ttl")) return RDF_CONTENT_TYPES.turtle;
+  return RDF_CONTENT_TYPES.rdfxml;
+};
+
+export const parseRdfToQuads = async (
+  rdfText: string,
+  contentType: RdfContentType,
   baseIRI?: string
 ): Promise<RDF.Quad[]> => {
-  const quadStream = rdfParser.parse(Readable.from([xmlText]), {
-    contentType: "application/rdf+xml",
+  const quadStream = rdfParser.parse(Readable.from([rdfText]), {
+    contentType,
     baseIRI,
   });
 
@@ -26,3 +41,10 @@ export const parseRdfXmlToQuads = async (
 
   return quads;
 };
+
+/** @deprecated Use parseRdfToQuads with RDF_CONTENT_TYPES.rdfxml instead */
+export const parseRdfXmlToQuads = async (
+  xmlText: string,
+  baseIRI?: string
+): Promise<RDF.Quad[]> =>
+  parseRdfToQuads(xmlText, RDF_CONTENT_TYPES.rdfxml, baseIRI);


### PR DESCRIPTION
Allow the harvester to fetch turtle forma too:

npm run harvest:dcat -- --url http://localhost:8000/api/v1/catalogue.ttl

## Summary by Sourcery

Support harvesting DCAT catalogues in both RDF/XML and Turtle formats while keeping RDF/XML parsing backwards-compatible.

New Features:
- Enable parsing of generic RDF content with configurable content types.
- Automatically detect RDF content type from catalogue URL extensions to distinguish RDF/XML and Turtle inputs.

Enhancements:
- Refactor RDF XML parsing into a generic RDF parser with a deprecated wrapper for RDF/XML.
- Update DCAT harvester error messaging to be content-type agnostic.

Tests:
- Adjust DCAT harvester tests to reflect new, generic RDF parsing error messages.