### PR TITLE
Add local-index keyword filter

### DIFF
--- a/src/app/api/discovery/local-store/__tests__/opensearch-store.test.ts
+++ b/src/app/api/discovery/local-store/__tests__/opensearch-store.test.ts
@@ -157,6 +157,35 @@ describe("OpenSearchDiscoveryStore", () => {
     ]);
   });
 
+  test("retrieveFilterValues returns aggregated keyword values", async () => {
+    const store = createStore();
+    mockClient.post.mockResolvedValueOnce({
+      data: {
+        aggregations: {
+          values: {
+            buckets: [{ key: "oncology", doc_count: 4 }],
+          },
+        },
+      },
+    });
+
+    await expect(store.retrieveFilterValues("keywords")).resolves.toEqual([
+      { value: "oncology", label: "oncology", count: 4 },
+    ]);
+    expect(mockClient.post).toHaveBeenCalledWith(
+      "/discovery_datasets/_search",
+      expect.objectContaining({
+        aggs: {
+          values: {
+            terms: expect.objectContaining({
+              field: "keywords",
+            }),
+          },
+        },
+      })
+    );
+  });
+
   test("hasFilterValues returns true when the field exists in indexed documents", async () => {
     const store = createStore();
     mockClient.post.mockResolvedValueOnce({

--- a/src/app/api/discovery/local-store/filter-registry.ts
+++ b/src/app/api/discovery/local-store/filter-registry.ts
@@ -116,6 +116,13 @@ const localFilterDefinitions: LocalFilterDefinition[] = [
     field: "catalogue",
   }),
   createDropdownFilter({
+    group: "Catalogue",
+    key: "keywords",
+    label: "Keywords",
+    field: "keywords",
+    mapBucket: mapBucketToValueLabel,
+  }),
+  createDropdownFilter({
     group: "Access",
     key: "accessRights",
     label: "Access rights",

--- a/src/app/api/discovery/providers/__tests__/local-index-discovery-provider.test.ts
+++ b/src/app/api/discovery/providers/__tests__/local-index-discovery-provider.test.ts
@@ -84,6 +84,10 @@ describe("LocalIndexDiscoveryProvider", () => {
         return [{ value: "Health", label: "Health", count: 3 }];
       }
 
+      if (key === "keywords") {
+        return [{ value: "oncology", label: "oncology", count: 4 }];
+      }
+
       if (key === "publisherName") {
         return [{ value: "LNDS", label: "LNDS", count: 2 }];
       }
@@ -110,6 +114,12 @@ describe("LocalIndexDiscoveryProvider", () => {
         }),
         expect.objectContaining({
           source: "local-index",
+          key: "keywords",
+          type: "DROPDOWN",
+          values: [{ value: "oncology", label: "oncology", count: 4 }],
+        }),
+        expect.objectContaining({
+          source: "local-index",
           key: "modified",
           type: "DATETIME",
           operators: ["=", ">", "<", ">=", "<=", "!"],
@@ -126,6 +136,10 @@ describe("LocalIndexDiscoveryProvider", () => {
     mockStore.retrieveFilterValues.mockImplementation(async (key) => {
       if (key === "theme") {
         return [{ value: "Health", label: "Health", count: 2 }];
+      }
+
+      if (key === "keywords") {
+        return [{ value: "oncology", label: "oncology", count: 1 }];
       }
 
       if (key === "publisherName") {
@@ -177,6 +191,12 @@ describe("LocalIndexDiscoveryProvider", () => {
           key: "publisherName",
           type: "DROPDOWN",
           values: [{ value: "LNDS", label: "LNDS", count: 2 }],
+        }),
+        expect.objectContaining({
+          source: "local-index",
+          key: "keywords",
+          type: "DROPDOWN",
+          values: [{ value: "oncology", label: "oncology", count: 1 }],
         }),
       ]),
       results: [


### PR DESCRIPTION
This PR adds the missing `keywords` filter for `DISCOVERY_PROVIDER=local-index`.

  The local index already stores and aggregates dataset keywords in OpenSearch, but the filter was never registered in the local filter registry. As a result, the discovery API did not expose a `keywords` facet and the UI could not render
  it.

  ## Changes

  - add a `keywords` dropdown filter to the local filter registry
  - verify the local-index provider returns the `keywords` filter when values exist
  - verify the OpenSearch store returns aggregated keyword values for the `keywords` field

  ## Why

  Datasets already contain `keywords`, and the OpenSearch index already supports:
  - `keywords` mapping
  - keyword existence checks
  - keyword term aggregations

## Summary by Sourcery

Add support for a `keywords` dropdown facet to the local-index discovery provider backed by OpenSearch aggregations.

New Features:
- Expose a `keywords` dropdown filter in the local filter registry for the local-index discovery provider.

Tests:
- Add tests to ensure the OpenSearch store aggregates keyword values for the `keywords` field and the local-index provider returns the corresponding filter when values exist.