### PR TITLE
feat: add applications options menu

### DIFF
--- a/src/app/applications/[id]/ApplicationOptionsMenu.tsx
+++ b/src/app/applications/[id]/ApplicationOptionsMenu.tsx
@@ -1,0 +1,86 @@
+// SPDX-FileCopyrightText: 2025 PNED G.I.E.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+"use client";
+
+import {
+  DropdownMenu,
+  DropdownMenuContent,
+  DropdownMenuGroup,
+  DropdownMenuItem,
+  DropdownMenuTrigger,
+} from "@/components/shadcn/dropdown-menu";
+import { cn } from "@/utils/tailwindMerge";
+import {
+  faEllipsisVertical,
+  faFileWord,
+  faRotateLeft,
+  faTrash,
+} from "@fortawesome/free-solid-svg-icons";
+import { FontAwesomeIcon } from "@fortawesome/react-fontawesome";
+import { useTranslations } from "next-intl";
+
+interface ApplicationOptionsMenuProps {
+  disabled?: boolean;
+  onExportToWord?: () => void;
+  onDiscardChanges?: () => void;
+  onDiscardApplication?: () => void;
+}
+
+const ApplicationOptionsMenu: React.FC<ApplicationOptionsMenuProps> = ({
+  disabled,
+  onExportToWord,
+  onDiscardChanges,
+  onDiscardApplication,
+}) => {
+  const t = useTranslations();
+
+  return (
+    <DropdownMenu>
+      <DropdownMenuTrigger asChild>
+        <button
+          type="button"
+          disabled={disabled}
+          aria-label={t("application.options.label")}
+          className={cn(
+            "flex items-center justify-center rounded-md border-2 border-primary px-4 h-10 text-sm text-primary transition-colors duration-200 hover:bg-secondary hover:text-white hover:border-transparent",
+            disabled && "opacity-60 cursor-not-allowed hover:bg-transparent"
+          )}
+        >
+          <FontAwesomeIcon icon={faEllipsisVertical} />
+          <span className="ml-2 font-bold tracking-wide">
+            {t("application.options.label")}
+          </span>
+        </button>
+      </DropdownMenuTrigger>
+      <DropdownMenuContent className="bg-white" align="end">
+        <DropdownMenuGroup>
+          <DropdownMenuItem
+            className="flex items-center gap-x-2 cursor-pointer"
+            onClick={onExportToWord}
+          >
+            <FontAwesomeIcon icon={faFileWord} className="text-lg" />
+            <span>{t("application.options.exportToWord")}</span>
+          </DropdownMenuItem>
+          <DropdownMenuItem
+            className="flex items-center gap-x-2 cursor-pointer"
+            onClick={onDiscardChanges}
+          >
+            <FontAwesomeIcon icon={faRotateLeft} className="text-lg" />
+            <span>{t("application.options.discardChanges")}</span>
+          </DropdownMenuItem>
+          <DropdownMenuItem
+            className="flex items-center gap-x-2 cursor-pointer"
+            onClick={onDiscardApplication}
+          >
+            <FontAwesomeIcon icon={faTrash} className="text-lg" />
+            <span>{t("application.options.discardApplication")}</span>
+          </DropdownMenuItem>
+        </DropdownMenuGroup>
+      </DropdownMenuContent>
+    </DropdownMenu>
+  );
+};
+
+export default ApplicationOptionsMenu;

--- a/src/app/applications/[id]/page.tsx
+++ b/src/app/applications/[id]/page.tsx
@@ -14,6 +14,7 @@ import PageContainer from "@/components/PageContainer";
 import PageHeading from "@/components/PageHeading";
 import Sidebar from "@/components/Sidebar";
 import { useRouter } from "@/i18n/navigation";
+import contentConfig from "@/config/contentConfig";
 import { useApplicationDetails } from "@/providers/application/ApplicationProvider";
 import {
   formatApplicationProp,
@@ -30,6 +31,7 @@ import {
 import { FontAwesomeIcon } from "@fortawesome/react-fontawesome";
 import { useTranslations } from "next-intl";
 import { use, useEffect, useState } from "react";
+import ApplicationOptionsMenu from "./ApplicationOptionsMenu";
 import FormContainer from "./FormContainer";
 import { createApplicationSidebarItems } from "./sidebarItems";
 import { UrlSearchParams } from "@/app/params";
@@ -144,7 +146,7 @@ export default function ApplicationDetailsPage({
                 />
               )}
             </div>
-            <div className="mt-4 flex gap-x-3 sm:mt-0">
+            <div className="mt-4 flex items-center gap-x-3 sm:mt-0">
               {isDraft && (
                 <Button
                   type="warning"
@@ -152,6 +154,8 @@ export default function ApplicationDetailsPage({
                   icon={faXmarkCircle}
                   disabled={isLoading}
                   onClick={handleDelete}
+                  flex={true}
+                  className="h-10 text-sm"
                 />
               )}
               {editable && (
@@ -161,7 +165,12 @@ export default function ApplicationDetailsPage({
                   icon={faPaperPlane}
                   disabled={isLoading}
                   onClick={handleSubmission}
+                  flex={true}
+                  className="h-10 text-sm"
                 />
+              )}
+              {contentConfig.showApplicationOptions && (
+                <ApplicationOptionsMenu disabled={isLoading} />
               )}
             </div>
           </div>

--- a/src/config/contentConfig.ts
+++ b/src/config/contentConfig.ts
@@ -26,6 +26,7 @@ interface ContentConfig {
   multilingualEnabled: boolean;
   enableAllVariantSearch: boolean;
   contactUsEnabled: boolean;
+  showApplicationOptions: boolean;
   footerLogos?: Array<{ src: string; alt: string }>;
   favicon: string;
   headerLogoUrl: string;
@@ -70,6 +71,8 @@ const contentConfig: ContentConfig = {
     env("NEXT_PUBLIC_ENABLE_ALL_VARIANT_SEARCH")?.toLowerCase() === "true",
   contactUsEnabled:
     env("NEXT_PUBLIC_FEATURE_CONTACT_US")?.toLowerCase() === "true",
+  showApplicationOptions:
+    env("NEXT_PUBLIC_FEATURE_APPLICATION_OPTIONS")?.toLowerCase() === "true",
   footerLogos: env("NEXT_PUBLIC_FOOTER_LOGOS")
     ? JSON.parse(env("NEXT_PUBLIC_FOOTER_LOGOS") || "[]")
     : undefined,

--- a/src/i18n/messages.json
+++ b/src/i18n/messages.json
@@ -983,6 +983,22 @@
     "en": "Submit",
     "fr": "Soumettre"
   },
+  "application.options.label": {
+    "en": "Options",
+    "fr": "Options"
+  },
+  "application.options.exportToWord": {
+    "en": "Export to Word",
+    "fr": "Exporter vers Word"
+  },
+  "application.options.discardChanges": {
+    "en": "Discard changes",
+    "fr": "Annuler les modifications"
+  },
+  "application.options.discardApplication": {
+    "en": "Discard application",
+    "fr": "Supprimer la demande"
+  },
   "application.savingChanges": {
     "en": "Saving Changes...",
     "fr": "Enregistrement des modifications..."


### PR DESCRIPTION
this feature is hidden by default, the Options menu won't render unless the env var is set to "true".

NEXT_PUBLIC_FEATURE_APPLICATION_OPTIONS=true

<img width="1350" height="337" alt="Screenshot 2026-07-14 at 14 47 50" src="https://github.com/user-attachments/assets/67a74b68-40e1-4d9d-b7e6-73f6249dcb57" />

## Summary by Sourcery

Add a configurable options menu to the application details page, gated by an environment-based content configuration flag.

New Features:
- Introduce an ApplicationOptionsMenu dropdown on the application details page for actions such as exporting to Word and discarding changes or the application, controlled by NEXT_PUBLIC_FEATURE_APPLICATION_OPTIONS.

Enhancements:
- Adjust application action buttons layout and sizing for better alignment with the new options menu.