### PR TITLE
fix: correct dataset page title, tooltip clipping, and scroll-to-top …

### DIFF
--- a/src/app/datasets/[id]/DataSeriesAccordion.tsx
+++ b/src/app/datasets/[id]/DataSeriesAccordion.tsx
@@ -37,6 +37,7 @@ export default function DataSeriesAccordion({
 }: DataSeriesAccordionProps) {
   const t = useTranslations("datasets.detail");
   const [openIndex, setOpenIndex] = useState<null | number>(null);
+  const [fullyOpenIndex, setFullyOpenIndex] = useState<null | number>(null);
   const contentRefs = useRef<(HTMLDivElement | null)[]>([]);
   const notAvailableLabel = t("notAvailable");
 
@@ -46,6 +47,7 @@ export default function DataSeriesAccordion({
 
   const toggleItem = (index: number) => {
     setOpenIndex((current) => (current === index ? null : index));
+    setFullyOpenIndex(null);
   };
 
   return (
@@ -101,15 +103,17 @@ export default function DataSeriesAccordion({
               ref={(el: HTMLDivElement | null) => {
                 contentRefs.current[index] = el;
               }}
+              onTransitionEnd={() => {
+                if (openIndex === index) setFullyOpenIndex(index);
+              }}
               style={{
                 maxHeight:
                   openIndex === index
                     ? `${contentRefs.current[index]?.scrollHeight}px`
                     : "0",
-                overflow: "hidden",
+                overflow: fullyOpenIndex === index ? "visible" : "hidden",
                 transition: "max-height 0.5s ease",
               }}
-              className="overflow-hidden"
             >
               <div className="px-2 pb-4 text-sm">
                 <div className="ml-3 border-l-2 border-primary/20 pl-4">

--- a/src/app/datasets/[id]/DistributionAccordion.tsx
+++ b/src/app/datasets/[id]/DistributionAccordion.tsx
@@ -30,6 +30,7 @@ const DistributionAccordion = ({
 }: DistributionAccordionProps) => {
   const t = useTranslations("datasets.detail");
   const [openIndex, setOpenIndex] = useState<null | number>(null);
+  const [fullyOpenIndex, setFullyOpenIndex] = useState<null | number>(null);
   const contentRefs = useRef<(HTMLDivElement | null)[]>([]);
   const notAvailableLabel = t("notAvailable");
 
@@ -48,6 +49,7 @@ const DistributionAccordion = ({
     } else {
       setOpenIndex(index);
     }
+    setFullyOpenIndex(null);
   };
 
   return (
@@ -80,15 +82,17 @@ const DistributionAccordion = ({
             ref={(el: HTMLDivElement | null) => {
               contentRefs.current[index] = el;
             }}
+            onTransitionEnd={() => {
+              if (openIndex === index) setFullyOpenIndex(index);
+            }}
             style={{
               maxHeight:
                 openIndex === index
                   ? `${contentRefs.current[index]?.scrollHeight}px`
                   : "0",
-              overflow: "hidden",
+              overflow: fullyOpenIndex === index ? "visible" : "hidden",
               transition: "max-height 0.5s ease",
             }}
-            className="overflow-hidden"
           >
             <div className="px-2 pb-4">
               <div className="ml-3 border-l-2 border-primary/20 pl-4">

--- a/src/app/datasets/[id]/Tooltip.tsx
+++ b/src/app/datasets/[id]/Tooltip.tsx
@@ -13,7 +13,7 @@ interface TooltipProps {
 const Tooltip: React.FC<TooltipProps> = ({ message }) => {
   if (!message) return null;
   return (
-    <div className="absolute left-0 top-full mt-1 hidden group-hover:flex group-focus:flex items-center bg-info text-white text-xs rounded-2xl py-1 px-2 z-10 whitespace-nowrap">
+    <div className="absolute left-0 top-full mt-1 hidden group-hover:flex group-focus:flex items-center bg-info text-white text-xs rounded-2xl py-1 px-2 z-50 whitespace-nowrap">
       <FontAwesomeIcon icon={faInfoCircle} className="mr-1" />
       {message}
     </div>

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -4,6 +4,7 @@
 
 import Header from "@/components/Header";
 import Navbar from "@/components/Navbar";
+import ScrollToTop from "@/components/ScrollToTop";
 import { routing, type AppLocale } from "@/i18n/routing";
 import { DatasetBasketProvider } from "@/providers/DatasetBasketProvider";
 import { AlertProvider } from "@/providers/AlertProvider";
@@ -18,7 +19,7 @@ import "./globals.css";
 config.autoAddCss = false;
 import contentConfig from "@/config/contentConfig";
 import { FilterProvider } from "@/providers/filters/FilterProvider";
-import { getFlatMessages, getMessages } from "@/i18n/messages";
+import { getMessages } from "@/i18n/messages";
 
 function isValidLocale(locale: string): locale is AppLocale {
   return (routing.locales as readonly string[]).includes(locale);
@@ -36,17 +37,13 @@ export default async function RootLayout({
       ? headerLocale
       : routing.defaultLocale;
   const messages = getMessages(locale);
-  const flatMessages = getFlatMessages(locale);
 
   return (
     <html lang={locale}>
       <head>
-        <title>{flatMessages["metadata.siteTitle"]}</title>
+        <title>{contentConfig.siteTitle}</title>
         <meta name="viewport" content="width=device-width, initial-scale=1" />
-        <meta
-          name="description"
-          content={flatMessages["metadata.siteDescription"]}
-        />
+        <meta name="description" content={contentConfig.siteDescription} />
         <link rel="icon" href={contentConfig.favicon} />
         <link rel="preconnect" href="https://fonts.googleapis.com" />
         <link
@@ -63,6 +60,7 @@ export default async function RootLayout({
         <link rel="stylesheet" href={"/fonts.css"} />
       </head>
       <body>
+        <ScrollToTop />
         <NextIntlClientProvider locale={locale} messages={messages}>
           <AlertProvider>
             <DatasetBasketProvider>

--- a/src/components/ScrollToTop.tsx
+++ b/src/components/ScrollToTop.tsx
@@ -1,0 +1,19 @@
+// SPDX-FileCopyrightText: 2026 PNED G.I.E.
+//
+// SPDX-License-Identifier: Apache-2.0
+"use client";
+
+import { useEffect } from "react";
+import { usePathname } from "next/navigation";
+
+function ScrollToTop() {
+  const pathname = usePathname();
+
+  useEffect(() => {
+    window.scrollTo(0, 0);
+  }, [pathname]);
+
+  return null;
+}
+
+export default ScrollToTop;


### PR DESCRIPTION
The changes on this pr are regarding some bug fixes.
This includes:
-> Changing the title in the top tab from Gdi to Luxembourg AI Factory. A logic is added to take the name from NEXT_PUBLIC_SITE_TITLE.
-> Fixed the scrolling which for some datasets was starting from the bottom and not the top.
-> Fixed position of tooltips information in dataset Details
<img width="228" height="51" alt="Screenshot 2026-07-14 at 18 21 52" src="https://github.com/user-attachments/assets/f1662507-d737-4bb7-baa2-bb5bac4268a7" />
<img width="1130" height="440" alt="Screenshot 2026-07-14 at 18 21 46" src="https://github.com/user-attachments/assets/7fb5e1a2-5963-46a7-a79a-5ac0bfcde115" />

## Summary by Sourcery

Fix dataset page UX issues by correcting site metadata, resetting scroll position on navigation, and improving tooltip visibility within accordion sections.

Bug Fixes:
- Update the document title and meta description to use site configuration values rather than translation messages.
- Ensure the page scroll position resets to the top when navigating between routes.
- Prevent dataset accordion content from clipping tooltips by allowing overflow once expansion animation completes.
- Increase tooltip z-index in dataset details to avoid it being hidden behind other elements.