### PR TITLE
fix: fix text sentence under the title and in the about of homepage

### DIFF
--- a/src/app/Footer.tsx
+++ b/src/app/Footer.tsx
@@ -44,24 +44,55 @@ function Footer() {
           {/* First column: About the project */}
           <div className="flex flex-col items-start gap-4 w-full md:w-3/5">
             <div className="flex items-center gap-4">
-              <Image
-                src={"/footer-logo.png"}
-                alt="Footer logo"
-                width={150}
-                height={100}
-              />
+              {contentConfig.websiteUrl ? (
+                <a
+                  href={contentConfig.websiteUrl}
+                  target="_blank"
+                  rel="noopener noreferrer"
+                >
+                  <Image
+                    src={"/footer-logo.png"}
+                    alt="Footer logo"
+                    width={150}
+                    height={100}
+                  />
+                </a>
+              ) : (
+                <Image
+                  src={"/footer-logo.png"}
+                  alt="Footer logo"
+                  width={150}
+                  height={100}
+                />
+              )}
               {contentConfig.footerLogos &&
                 contentConfig.footerLogos.length > 0 && (
                   <div className="flex gap-4 items-center">
-                    {contentConfig.footerLogos.map((logo) => (
-                      <div key={logo.alt} className="flex items-center">
+                    {contentConfig.footerLogos.map((logo) => {
+                      const image = (
                         <Image
                           src={logo.src}
                           alt={logo.alt}
                           className="object-contain"
                         />
-                      </div>
-                    ))}
+                      );
+
+                      return (
+                        <div key={logo.alt} className="flex items-center">
+                          {logo.url ? (
+                            <a
+                              href={logo.url}
+                              target="_blank"
+                              rel="noopener noreferrer"
+                            >
+                              {image}
+                            </a>
+                          ) : (
+                            image
+                          )}
+                        </div>
+                      );
+                    })}
                   </div>
                 )}
               <Image

--- a/src/app/Footer.tsx
+++ b/src/app/Footer.tsx
@@ -73,6 +73,8 @@ function Footer() {
                         <Image
                           src={logo.src}
                           alt={logo.alt}
+                          width={100}
+                          height={70}
                           className="object-contain"
                         />
                       );

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -24,6 +24,7 @@ import {
 } from "@/app/api/discovery/open-api/schemas";
 import { FilterValueType } from "@/app/api/discovery/additional-types";
 import { UrlSearchParams } from "@/app/params";
+import contentConfig from "@/config/contentConfig";
 
 type HomePageProps = {
   searchParams: Promise<UrlSearchParams>;
@@ -88,7 +89,9 @@ const HomePage = ({ searchParams }: HomePageProps) => {
     >
       <div className="my-8">
         <h1 className="font-bold text-4xl font-title">{t("home.title")}</h1>
-        <h2 className="text-xl mt-4 font-body">{t("home.subtitle")}</h2>
+        <h2 className="text-xl mt-4 font-body">
+          {contentConfig.homepageSubtitle}
+        </h2>
       </div>
       {process.env.NEXT_PUBLIC_HOME_NOTICE_ENABLED?.toLowerCase() ===
         "true" && (
@@ -140,7 +143,7 @@ const HomePage = ({ searchParams }: HomePageProps) => {
           <p
             className="text-lg"
             dangerouslySetInnerHTML={{
-              __html: t("home.aboutContent").replace(/\n/g, "<br />"),
+              __html: contentConfig.aboutContent.replace(/\n/g, "<br />"),
             }}
           />
           <br />

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -90,7 +90,9 @@ const HomePage = ({ searchParams }: HomePageProps) => {
       <div className="my-8">
         <h1 className="font-bold text-4xl font-title">{t("home.title")}</h1>
         <h2 className="text-xl mt-4 font-body">
-          {contentConfig.homepageSubtitle}
+          {contentConfig.multilingualEnabled
+            ? t("home.subtitle")
+            : contentConfig.homepageSubtitle}
         </h2>
       </div>
       {process.env.NEXT_PUBLIC_HOME_NOTICE_ENABLED?.toLowerCase() ===
@@ -140,12 +142,19 @@ const HomePage = ({ searchParams }: HomePageProps) => {
         ></div>
         <div className="relative z-10 w-full md:w-3/4 lg:w-2/3 xl:w-3/5">
           <h3 className="mb-4 text-2xl">{t("home.aboutPortal")}</h3>
-          <p
-            className="text-lg"
-            dangerouslySetInnerHTML={{
-              __html: contentConfig.aboutContent.replace(/\n/g, "<br />"),
-            }}
-          />
+          <p className="text-lg">
+            {(contentConfig.multilingualEnabled
+              ? t("home.aboutContent")
+              : contentConfig.aboutContent
+            )
+              .split("\n")
+              .map((line, index, lines) => (
+                <span key={index}>
+                  {line}
+                  {index < lines.length - 1 && <br />}
+                </span>
+              ))}
+          </p>
           <br />
           <Link
             className="link-arrow text-primary hover:text-hover-color"

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -90,9 +90,7 @@ const HomePage = ({ searchParams }: HomePageProps) => {
       <div className="my-8">
         <h1 className="font-bold text-4xl font-title">{t("home.title")}</h1>
         <h2 className="text-xl mt-4 font-body">
-          {contentConfig.multilingualEnabled
-            ? t("home.subtitle")
-            : contentConfig.homepageSubtitle}
+          {contentConfig.homepageSubtitle || t("home.subtitle")}
         </h2>
       </div>
       {process.env.NEXT_PUBLIC_HOME_NOTICE_ENABLED?.toLowerCase() ===
@@ -143,10 +141,7 @@ const HomePage = ({ searchParams }: HomePageProps) => {
         <div className="relative z-10 w-full md:w-3/4 lg:w-2/3 xl:w-3/5">
           <h3 className="mb-4 text-2xl">{t("home.aboutPortal")}</h3>
           <p className="text-lg">
-            {(contentConfig.multilingualEnabled
-              ? t("home.aboutContent")
-              : contentConfig.aboutContent
-            )
+            {(contentConfig.aboutContent || t("home.aboutContent"))
               .split("\n")
               .map((line, index, lines) => (
                 <span key={index}>

--- a/src/config/contentConfig.ts
+++ b/src/config/contentConfig.ts
@@ -12,11 +12,11 @@ interface ContentConfig {
   email?: string;
   footerText: string;
   homepageTitle: string;
-  homepageSubtitle: string;
+  homepageSubtitle?: string;
   homeNoticeEnabled: boolean;
   homeNoticeTitle?: string;
   homeNoticeMessage?: string;
-  aboutContent: string;
+  aboutContent?: string;
   bannerLink: string;
   siteTitle: string;
   siteDescription: string;
@@ -43,9 +43,7 @@ const contentConfig: ContentConfig = {
     env("NEXT_PUBLIC_FOOTER_TEXT") ||
     "GDI project receives funding from the European Union's Digital Europe \n Programme under grant agreement number 101081813.",
   homepageTitle: env("NEXT_PUBLIC_HOMEPAGE_TITLE") || "WELCOME TO GDI",
-  homepageSubtitle:
-    env("NEXT_PUBLIC_HOMEPAGE_SUBTITLE") ||
-    "The Genomic Data Infrastructure (GDI) project is enabling access to genomic and related phenotypic and clinical data across Europe.",
+  homepageSubtitle: env("NEXT_PUBLIC_HOMEPAGE_SUBTITLE") || undefined,
   homeNoticeEnabled:
     env("NEXT_PUBLIC_HOME_NOTICE_ENABLED")?.toLowerCase() === "true",
   homeNoticeTitle:
@@ -53,9 +51,7 @@ const contentConfig: ContentConfig = {
   homeNoticeMessage:
     env("NEXT_PUBLIC_HOME_NOTICE_MESSAGE") ||
     "Because of scheduled migration in our provider, the User portal could get service disruption on 19 February between 11:00 and 14:00.",
-  aboutContent:
-    env("NEXT_PUBLIC_HOMEPAGE_ABOUT_CONTENT") ||
-    "The Genomic Data Infrastructure (GDI) homepage is your gateway to an extensive network of genomic data designed to revolutionize research, policymaking, and healthcare in Europe. The GDI project aims to provide seamless access to over one million genome sequences, facilitating groundbreaking advancements in personalized medicine for various diseases, including cancer and rare conditions. By integrating genomic, phenotypic, and clinical data, GDI supports precise diagnostics, treatments, and clinical decision-making. Explore our user-friendly platform to connect with crucial datasets, and join our mission to enhance healthcare outcomes and foster innovation across Europe. Visit the GDI website for more information.",
+  aboutContent: env("NEXT_PUBLIC_HOMEPAGE_ABOUT_CONTENT") || undefined,
   bannerLink: env("NEXT_PUBLIC_BANNER_LINK") || "/howto",
   siteTitle: env("NEXT_PUBLIC_SITE_TITLE") || "GDI - User Portal",
   siteDescription:

--- a/src/config/contentConfig.ts
+++ b/src/config/contentConfig.ts
@@ -27,7 +27,7 @@ interface ContentConfig {
   enableAllVariantSearch: boolean;
   contactUsEnabled: boolean;
   showApplicationOptions: boolean;
-  footerLogos?: Array<{ src: string; alt: string }>;
+  footerLogos?: Array<{ src: string; alt: string; url?: string }>;
   favicon: string;
   headerLogoUrl: string;
 }


### PR DESCRIPTION
<img width="1543" height="836" alt="Screenshot 2026-07-20 at 15 08 09" src="https://github.com/user-attachments/assets/c15877cd-a292-417f-95f4-da8a835e43bb" />

## Summary by Sourcery

Update homepage copy to use centralized content configuration for subtitle and about text.

Bug Fixes:
- Correct homepage subtitle text under the main title by sourcing it from the shared content configuration.
- Correct homepage about section text by sourcing it from the shared content configuration.

Enhancements:
- Align homepage text rendering with contentConfig to centralize marketing copy management.