### PR TITLE
fix: make numberOfUniqueIndivuduals in rdf encoded as non negative in…

### DIFF
--- a/src/app/api/discovery/harvester/__tests__/dcat-dataset-rdf-generator.test.ts
+++ b/src/app/api/discovery/harvester/__tests__/dcat-dataset-rdf-generator.test.ts
@@ -198,6 +198,31 @@ describe("DCAT dataset export generators", () => {
     ).toBe(true);
   });
 
+  test("encodes numberOfUniqueIndividuals as xsd:nonNegativeInteger", async () => {
+    const XSD_NON_NEGATIVE_INTEGER =
+      "http://www.w3.org/2001/XMLSchema#nonNegativeInteger";
+    const HEALTH_NUMBER_OF_UNIQUE_INDIVIDUALS =
+      "http://healthdataportal.eu/ns/health#numberOfUniqueIndividuals";
+
+    const dataset = buildLocalDiscoveryDataset({
+      id: "https://example.org/datasets/export-1",
+      numberOfUniqueIndividuals: 25000,
+    });
+
+    const rdfXml = await serializeDatasetAsRdfXml(dataset);
+    const quads = await parseRdfXmlToQuads(rdfXml);
+
+    const quad = quads.find(
+      (q) => q.predicate.value === HEALTH_NUMBER_OF_UNIQUE_INDIVIDUALS
+    );
+    expect(quad).toBeDefined();
+    expect(quad!.object.termType).toBe("Literal");
+    expect(quad!.object.value).toBe("25000");
+    expect((quad!.object as any).datatype?.value).toBe(
+      XSD_NON_NEGATIVE_INTEGER
+    );
+  });
+
   test("facade dispatches serializers and MIME types for all supported formats", async () => {
     const dataset = buildLocalDiscoveryDataset({
       id: "https://example.org/datasets/export-1",

--- a/src/app/api/discovery/harvester/rdf/context.ts
+++ b/src/app/api/discovery/harvester/rdf/context.ts
@@ -66,6 +66,12 @@ export const createLanguageLiteral = (value: string, language: string) =>
 export const createIntegerLiteral = (value: number) =>
   createLiteral(String(value), `${DATASET_EXPORT_PREFIXES.xsd}integer`);
 
+export const createNonNegativeIntegerLiteral = (value: number) =>
+  createLiteral(
+    String(value),
+    `${DATASET_EXPORT_PREFIXES.xsd}nonNegativeInteger`
+  );
+
 export const createDecimalLiteral = (value: number) =>
   createLiteral(String(value), `${DATASET_EXPORT_PREFIXES.xsd}decimal`);
 

--- a/src/app/api/discovery/harvester/rdf/mappers/dataset-coverage-quad-mapper.ts
+++ b/src/app/api/discovery/harvester/rdf/mappers/dataset-coverage-quad-mapper.ts
@@ -10,6 +10,7 @@ import {
   createDurationLiteral,
   createIntegerLiteral,
   createNamedNode,
+  createNonNegativeIntegerLiteral,
   createNestedNode,
   isNonEmptyString,
   ns,
@@ -31,7 +32,7 @@ export const addDatasetCoverageQuads = ({
     store.add(
       datasetNode,
       ns.health("numberOfUniqueIndividuals"),
-      createIntegerLiteral(dataset.numberOfUniqueIndividuals)
+      createNonNegativeIntegerLiteral(dataset.numberOfUniqueIndividuals)
     );
   }
   if (typeof dataset.maxTypicalAge === "number") {


### PR DESCRIPTION
The field numberOfUniqueIndividuals is supposed to be non negative integer in RDF exports.
This is how it looks like after this fix:

`<healthdcatap:numberOfUniqueIndividuals rdf:datatype="http://www.w3.org/2001/XMLSchema#nonNegativeInteger">6</healthdcatap:numberOfUniqueIndividuals>`

## Summary by Sourcery

Ensure RDF exports encode numberOfUniqueIndividuals as a non-negative integer literal.

Bug Fixes:
- Encode numberOfUniqueIndividuals in RDF as an xsd:nonNegativeInteger literal instead of a generic integer.

Tests:
- Add a regression test verifying numberOfUniqueIndividuals is serialized as an xsd:nonNegativeInteger literal in RDF XML exports.