### PR TITLE
fix: make number of recors as non negative integer

### DIFF
--- a/src/app/api/discovery/harvester/__tests__/dcat-dataset-rdf-generator.test.ts
+++ b/src/app/api/discovery/harvester/__tests__/dcat-dataset-rdf-generator.test.ts
@@ -162,7 +162,9 @@ describe("DCAT dataset export generators", () => {
     expect(turtle).toContain('dct:title "Population \\"Registry\\""');
     expect(turtle).toContain('dct:description "Line 1\\nLine 2"');
     expect(turtle).toContain("dct:provenance");
-    expect(turtle).toContain("healthdcatap:numberOfRecords 50000");
+    expect(turtle).toContain(
+      'healthdcatap:numberOfRecords "50000"^^xsd:nonNegativeInteger'
+    );
     expect(turtle).toContain(
       "<https://example.org/datasets/export-1#distribution-1>"
     );

--- a/src/app/api/discovery/harvester/rdf/mappers/dataset-coverage-quad-mapper.ts
+++ b/src/app/api/discovery/harvester/rdf/mappers/dataset-coverage-quad-mapper.ts
@@ -25,7 +25,7 @@ export const addDatasetCoverageQuads = ({
     store.add(
       datasetNode,
       ns.health("numberOfRecords"),
-      createIntegerLiteral(dataset.numberOfRecords)
+      createNonNegativeIntegerLiteral(dataset.numberOfRecords)
     );
   }
   if (typeof dataset.numberOfUniqueIndividuals === "number") {


### PR DESCRIPTION
The field numberOfRecords needs to be encoded as non negative integer, so that it looks that:

`<healthdcatap:numberOfRecords rdf:datatype="http://www.w3.org/2001/XMLSchema#nonNegativeInteger">7</healthdcatap:numberOfRecords>`

## Summary by Sourcery

Encode dataset numberOfRecords as a non-negative integer literal in generated RDF and update tests accordingly.

Bug Fixes:
- Ensure healthdcatap:numberOfRecords is serialized as an xsd:nonNegativeInteger literal instead of a plain integer in DCAT RDF output.

Tests:
- Adjust DCAT dataset RDF generator test to assert the nonNegativeInteger-typed numberOfRecords literal.