### PR TITLE
fix: make accessRight value an instance of RightStatements according …

### DIFF
--- a/src/app/api/discovery/harvester/__tests__/dcat-dataset-rdf-generator.test.ts
+++ b/src/app/api/discovery/harvester/__tests__/dcat-dataset-rdf-generator.test.ts
@@ -539,14 +539,19 @@ describe("DCAT dataset export generators", () => {
     expect(turtle).toContain("wikidata.org/entity/Q9006342");
     expect(turtle).toContain("wikidata.org/entity/Q5969475");
 
-    // RDF/XML must use the nested typed-node form, not rdf:resource shorthand
+    // rdflib emits the Standard nodes as separate top-level blocks
     expect(rdfXml).toContain(
-      '<healthdcatap:hasCodingSystem>\n      <dct:Standard rdf:about="https://www.wikidata.org/entity/Q9006342"/>\n    </healthdcatap:hasCodingSystem>'
+      '<healthdcatap:hasCodingSystem rdf:resource="https://www.wikidata.org/entity/Q9006342"/>'
     );
     expect(rdfXml).toContain(
-      '<healthdcatap:hasCodingSystem>\n      <dct:Standard rdf:about="https://www.wikidata.org/entity/Q5969475"/>\n    </healthdcatap:hasCodingSystem>'
+      '<healthdcatap:hasCodingSystem rdf:resource="https://www.wikidata.org/entity/Q5969475"/>'
     );
-    expect(rdfXml).not.toContain("<healthdcatap:hasCodingSystem rdf:resource=");
+    expect(rdfXml).toContain(
+      '<dct:Standard rdf:about="https://www.wikidata.org/entity/Q9006342">'
+    );
+    expect(rdfXml).toContain(
+      '<dct:Standard rdf:about="https://www.wikidata.org/entity/Q5969475">'
+    );
 
     // Each value must be typed as dct:Standard when round-tripped
     const quads = await parseRdfXmlToQuads(rdfXml);

--- a/src/app/api/discovery/harvester/__tests__/rdfxml-post-processor.test.ts
+++ b/src/app/api/discovery/harvester/__tests__/rdfxml-post-processor.test.ts
@@ -1,0 +1,157 @@
+// SPDX-FileCopyrightText: 2026 PNED G.I.E.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+import {
+  rewriteCodingSystemNodes,
+  rewriteDocumentationNodes,
+  rewriteAccessRightsNodes,
+  applyRdfXmlPostProcessing,
+} from "@/app/api/discovery/harvester/rdfxml-post-processor";
+
+describe("rewriteCodingSystemNodes", () => {
+  test("rewrites shorthand into nested dct:Standard element", () => {
+    const input = `<healthdcatap:hasCodingSystem rdf:resource="https://example.org/coding/ICD-10"/>`;
+    expect(rewriteCodingSystemNodes(input)).toBe(
+      `<healthdcatap:hasCodingSystem>\n      <dct:Standard rdf:about="https://example.org/coding/ICD-10"/>\n    </healthdcatap:hasCodingSystem>`
+    );
+  });
+
+  test("rewrites multiple occurrences independently", () => {
+    const input = [
+      `<healthdcatap:hasCodingSystem rdf:resource="https://example.org/coding/ICD-10"/>`,
+      `<healthdcatap:hasCodingSystem rdf:resource="https://example.org/coding/SNOMED"/>`,
+    ].join("\n");
+    const result = rewriteCodingSystemNodes(input);
+    expect(result).toContain(
+      `<dct:Standard rdf:about="https://example.org/coding/ICD-10"/>`
+    );
+    expect(result).toContain(
+      `<dct:Standard rdf:about="https://example.org/coding/SNOMED"/>`
+    );
+  });
+
+  test("leaves unrelated XML unchanged", () => {
+    const input = `<dct:title>Test</dct:title>`;
+    expect(rewriteCodingSystemNodes(input)).toBe(input);
+  });
+});
+
+describe("rewriteDocumentationNodes", () => {
+  test("rewrites shorthand into nested foaf:Document element", () => {
+    const input = `<foaf:page rdf:resource="https://example.org/docs/guide"/>`;
+    expect(rewriteDocumentationNodes(input)).toBe(
+      `<foaf:page>\n      <foaf:Document rdf:about="https://example.org/docs/guide"/>\n    </foaf:page>`
+    );
+  });
+
+  test("rewrites multiple occurrences independently", () => {
+    const input = [
+      `<foaf:page rdf:resource="https://example.org/docs/guide"/>`,
+      `<foaf:page rdf:resource="https://example.org/docs/reference"/>`,
+    ].join("\n");
+    const result = rewriteDocumentationNodes(input);
+    expect(result).toContain(
+      `<foaf:Document rdf:about="https://example.org/docs/guide"/>`
+    );
+    expect(result).toContain(
+      `<foaf:Document rdf:about="https://example.org/docs/reference"/>`
+    );
+  });
+
+  test("leaves unrelated XML unchanged", () => {
+    const input = `<dct:title>Test</dct:title>`;
+    expect(rewriteDocumentationNodes(input)).toBe(input);
+  });
+});
+
+describe("rewriteAccessRightsNodes", () => {
+  test("inlines label from detached RightsStatement block", () => {
+    const uri =
+      "http://publications.europa.eu/resource/authority/access-right/NON_PUBLIC";
+    const input = `
+<dcat:Dataset rdf:about="https://example.org/datasets/1">
+  <dct:accessRights rdf:resource="${uri}"/>
+</dcat:Dataset>
+<dct:RightsStatement rdf:about="${uri}">
+  <skos:prefLabel xml:lang="eng">Non public</skos:prefLabel>
+</dct:RightsStatement>
+    `.trim();
+
+    const result = rewriteAccessRightsNodes(input);
+
+    expect(result).toContain(`<dct:accessRights>`);
+    expect(result).toContain(`<dct:RightsStatement rdf:about="${uri}">`);
+    expect(result).toContain(
+      `<skos:prefLabel xml:lang="eng">Non public</skos:prefLabel>`
+    );
+    expect(result).toContain(`</dct:RightsStatement>`);
+    expect(result).not.toContain(`rdf:resource="${uri}"`);
+    expect(result).not.toContain(
+      `<dct:RightsStatement rdf:about="${uri}">\n  <skos:prefLabel`
+    );
+  });
+
+  test("removes the detached RightsStatement top-level block", () => {
+    const uri =
+      "http://publications.europa.eu/resource/authority/access-right/PUBLIC";
+    const input = `
+<dct:accessRights rdf:resource="${uri}"/>
+<dct:RightsStatement rdf:about="${uri}">
+  <skos:prefLabel xml:lang="eng">Public</skos:prefLabel>
+</dct:RightsStatement>
+    `.trim();
+
+    const result = rewriteAccessRightsNodes(input);
+    // The detached block should not appear as a standalone top-level element
+    const topLevelBlockCount = (
+      result.match(/<dct:RightsStatement rdf:about=/g) ?? []
+    ).length;
+    expect(topLevelBlockCount).toBe(1); // only the inlined one
+  });
+
+  test("produces inline element without label when no detached block exists", () => {
+    const uri =
+      "http://publications.europa.eu/resource/authority/access-right/PUBLIC";
+    const input = `<dct:accessRights rdf:resource="${uri}"/>`;
+
+    const result = rewriteAccessRightsNodes(input);
+
+    expect(result).toContain(`<dct:RightsStatement rdf:about="${uri}">`);
+    expect(result).not.toContain(`skos:prefLabel`);
+  });
+
+  test("leaves unrelated XML unchanged", () => {
+    const input = `<dct:title>Test</dct:title>`;
+    expect(rewriteAccessRightsNodes(input)).toBe(input);
+  });
+});
+
+describe("applyRdfXmlPostProcessing", () => {
+  test("applies all rewrites in a single pass", () => {
+    const accessUri =
+      "http://publications.europa.eu/resource/authority/access-right/PUBLIC";
+    const codingUri = "https://example.org/coding/ICD-10";
+    const docUri = "https://example.org/docs/guide";
+
+    const input = `
+<dcat:Dataset rdf:about="https://example.org/datasets/1">
+  <dct:accessRights rdf:resource="${accessUri}"/>
+  <healthdcatap:hasCodingSystem rdf:resource="${codingUri}"/>
+  <foaf:page rdf:resource="${docUri}"/>
+</dcat:Dataset>
+<dct:RightsStatement rdf:about="${accessUri}">
+  <skos:prefLabel xml:lang="eng">Public</skos:prefLabel>
+</dct:RightsStatement>
+    `.trim();
+
+    const result = applyRdfXmlPostProcessing(input);
+
+    expect(result).toContain(`<dct:RightsStatement rdf:about="${accessUri}">`);
+    expect(result).toContain(
+      `<skos:prefLabel xml:lang="eng">Public</skos:prefLabel>`
+    );
+    expect(result).toContain(`<dct:Standard rdf:about="${codingUri}"/>`);
+    expect(result).toContain(`<foaf:Document rdf:about="${docUri}"/>`);
+  });
+});

--- a/src/app/api/discovery/harvester/__tests__/rdfxml-post-processor.test.ts
+++ b/src/app/api/discovery/harvester/__tests__/rdfxml-post-processor.test.ts
@@ -3,38 +3,9 @@
 // SPDX-License-Identifier: Apache-2.0
 
 import {
-  rewriteCodingSystemNodes,
   rewriteDocumentationNodes,
   applyRdfXmlPostProcessing,
 } from "@/app/api/discovery/harvester/rdfxml-post-processor";
-
-describe("rewriteCodingSystemNodes", () => {
-  test("rewrites shorthand into nested dct:Standard element", () => {
-    const input = `<healthdcatap:hasCodingSystem rdf:resource="https://example.org/coding/ICD-10"/>`;
-    expect(rewriteCodingSystemNodes(input)).toBe(
-      `<healthdcatap:hasCodingSystem>\n      <dct:Standard rdf:about="https://example.org/coding/ICD-10"/>\n    </healthdcatap:hasCodingSystem>`
-    );
-  });
-
-  test("rewrites multiple occurrences independently", () => {
-    const input = [
-      `<healthdcatap:hasCodingSystem rdf:resource="https://example.org/coding/ICD-10"/>`,
-      `<healthdcatap:hasCodingSystem rdf:resource="https://example.org/coding/SNOMED"/>`,
-    ].join("\n");
-    const result = rewriteCodingSystemNodes(input);
-    expect(result).toContain(
-      `<dct:Standard rdf:about="https://example.org/coding/ICD-10"/>`
-    );
-    expect(result).toContain(
-      `<dct:Standard rdf:about="https://example.org/coding/SNOMED"/>`
-    );
-  });
-
-  test("leaves unrelated XML unchanged", () => {
-    const input = `<dct:title>Test</dct:title>`;
-    expect(rewriteCodingSystemNodes(input)).toBe(input);
-  });
-});
 
 describe("rewriteDocumentationNodes", () => {
   test("rewrites shorthand into nested foaf:Document element", () => {
@@ -65,20 +36,10 @@ describe("rewriteDocumentationNodes", () => {
 });
 
 describe("applyRdfXmlPostProcessing", () => {
-  test("applies all rewrites in a single pass", () => {
-    const codingUri = "https://example.org/coding/ICD-10";
+  test("rewrites foaf:page nodes", () => {
     const docUri = "https://example.org/docs/guide";
-
-    const input = `
-<dcat:Dataset rdf:about="https://example.org/datasets/1">
-  <healthdcatap:hasCodingSystem rdf:resource="${codingUri}"/>
-  <foaf:page rdf:resource="${docUri}"/>
-</dcat:Dataset>
-    `.trim();
-
+    const input = `<foaf:page rdf:resource="${docUri}"/>`;
     const result = applyRdfXmlPostProcessing(input);
-
-    expect(result).toContain(`<dct:Standard rdf:about="${codingUri}"/>`);
     expect(result).toContain(`<foaf:Document rdf:about="${docUri}"/>`);
   });
 });

--- a/src/app/api/discovery/harvester/__tests__/rdfxml-post-processor.test.ts
+++ b/src/app/api/discovery/harvester/__tests__/rdfxml-post-processor.test.ts
@@ -5,7 +5,6 @@
 import {
   rewriteCodingSystemNodes,
   rewriteDocumentationNodes,
-  rewriteAccessRightsNodes,
   applyRdfXmlPostProcessing,
 } from "@/app/api/discovery/harvester/rdfxml-post-processor";
 
@@ -65,92 +64,20 @@ describe("rewriteDocumentationNodes", () => {
   });
 });
 
-describe("rewriteAccessRightsNodes", () => {
-  test("inlines label from detached RightsStatement block", () => {
-    const uri =
-      "http://publications.europa.eu/resource/authority/access-right/NON_PUBLIC";
-    const input = `
-<dcat:Dataset rdf:about="https://example.org/datasets/1">
-  <dct:accessRights rdf:resource="${uri}"/>
-</dcat:Dataset>
-<dct:RightsStatement rdf:about="${uri}">
-  <skos:prefLabel xml:lang="eng">Non public</skos:prefLabel>
-</dct:RightsStatement>
-    `.trim();
-
-    const result = rewriteAccessRightsNodes(input);
-
-    expect(result).toContain(`<dct:accessRights>`);
-    expect(result).toContain(`<dct:RightsStatement rdf:about="${uri}">`);
-    expect(result).toContain(
-      `<skos:prefLabel xml:lang="eng">Non public</skos:prefLabel>`
-    );
-    expect(result).toContain(`</dct:RightsStatement>`);
-    expect(result).not.toContain(`rdf:resource="${uri}"`);
-    expect(result).not.toContain(
-      `<dct:RightsStatement rdf:about="${uri}">\n  <skos:prefLabel`
-    );
-  });
-
-  test("removes the detached RightsStatement top-level block", () => {
-    const uri =
-      "http://publications.europa.eu/resource/authority/access-right/PUBLIC";
-    const input = `
-<dct:accessRights rdf:resource="${uri}"/>
-<dct:RightsStatement rdf:about="${uri}">
-  <skos:prefLabel xml:lang="eng">Public</skos:prefLabel>
-</dct:RightsStatement>
-    `.trim();
-
-    const result = rewriteAccessRightsNodes(input);
-    // The detached block should not appear as a standalone top-level element
-    const topLevelBlockCount = (
-      result.match(/<dct:RightsStatement rdf:about=/g) ?? []
-    ).length;
-    expect(topLevelBlockCount).toBe(1); // only the inlined one
-  });
-
-  test("produces inline element without label when no detached block exists", () => {
-    const uri =
-      "http://publications.europa.eu/resource/authority/access-right/PUBLIC";
-    const input = `<dct:accessRights rdf:resource="${uri}"/>`;
-
-    const result = rewriteAccessRightsNodes(input);
-
-    expect(result).toContain(`<dct:RightsStatement rdf:about="${uri}">`);
-    expect(result).not.toContain(`skos:prefLabel`);
-  });
-
-  test("leaves unrelated XML unchanged", () => {
-    const input = `<dct:title>Test</dct:title>`;
-    expect(rewriteAccessRightsNodes(input)).toBe(input);
-  });
-});
-
 describe("applyRdfXmlPostProcessing", () => {
   test("applies all rewrites in a single pass", () => {
-    const accessUri =
-      "http://publications.europa.eu/resource/authority/access-right/PUBLIC";
     const codingUri = "https://example.org/coding/ICD-10";
     const docUri = "https://example.org/docs/guide";
 
     const input = `
 <dcat:Dataset rdf:about="https://example.org/datasets/1">
-  <dct:accessRights rdf:resource="${accessUri}"/>
   <healthdcatap:hasCodingSystem rdf:resource="${codingUri}"/>
   <foaf:page rdf:resource="${docUri}"/>
 </dcat:Dataset>
-<dct:RightsStatement rdf:about="${accessUri}">
-  <skos:prefLabel xml:lang="eng">Public</skos:prefLabel>
-</dct:RightsStatement>
     `.trim();
 
     const result = applyRdfXmlPostProcessing(input);
 
-    expect(result).toContain(`<dct:RightsStatement rdf:about="${accessUri}">`);
-    expect(result).toContain(
-      `<skos:prefLabel xml:lang="eng">Public</skos:prefLabel>`
-    );
     expect(result).toContain(`<dct:Standard rdf:about="${codingUri}"/>`);
     expect(result).toContain(`<foaf:Document rdf:about="${docUri}"/>`);
   });

--- a/src/app/api/discovery/harvester/dcat-dataset-rdfxml-generator.ts
+++ b/src/app/api/discovery/harvester/dcat-dataset-rdfxml-generator.ts
@@ -4,36 +4,11 @@
 
 import { LocalDiscoveryDataset } from "@/app/api/discovery/local-store/types";
 import { serializeDatasetStore } from "@/app/api/discovery/harvester/dcat-dataset-rdf-serializer";
-
-/**
- * rdflib serializes named nodes used as objects of a predicate as
- * `<predicate rdf:resource="URI"/>`. The HealthDCAT-AP spec requires
- * `hasCodingSystem` to nest a typed `dct:Standard` element inline:
- *
- *   <healthdcatap:hasCodingSystem>
- *     <dct:Standard rdf:about="URI"/>
- *   </healthdcatap:hasCodingSystem>
- *
- * We post-process the serialized RDF/XML to rewrite the shorthand form
- * into the nested typed-node form.
- */
-const rewriteCodingSystemNodes = (xml: string): string =>
-  xml.replace(
-    /<healthdcatap:hasCodingSystem rdf:resource="([^"]+)"\/>/g,
-    (_, uri) =>
-      `<healthdcatap:hasCodingSystem>\n      <dct:Standard rdf:about="${uri}"/>\n    </healthdcatap:hasCodingSystem>`
-  );
-
-const rewriteDocumentationNodes = (xml: string): string =>
-  xml.replace(
-    /<foaf:page rdf:resource="([^"]+)"\/>/g,
-    (_, uri) =>
-      `<foaf:page>\n      <foaf:Document rdf:about="${uri}"/>\n    </foaf:page>`
-  );
+import { applyRdfXmlPostProcessing } from "@/app/api/discovery/harvester/rdfxml-post-processor";
 
 export const serializeDatasetAsRdfXml = async (
   dataset: LocalDiscoveryDataset
 ): Promise<string> => {
   const xml = await serializeDatasetStore(dataset, "rdf");
-  return rewriteDocumentationNodes(rewriteCodingSystemNodes(xml));
+  return applyRdfXmlPostProcessing(xml);
 };

--- a/src/app/api/discovery/harvester/rdf/mappers/dataset-classification-quad-mapper.ts
+++ b/src/app/api/discovery/harvester/rdf/mappers/dataset-classification-quad-mapper.ts
@@ -5,7 +5,9 @@
 import {
   DatasetRdfContext,
   addConcept,
+  createLanguageLiteral,
   createLiteral,
+  createNamedNode,
   ns,
 } from "@/app/api/discovery/harvester/rdf/context";
 
@@ -48,13 +50,19 @@ export const addDatasetClassificationQuads = ({
     )
   );
   if (dataset.accessRights) {
-    addConcept(
-      store,
-      datasetNode,
-      ns.dct("accessRights"),
-      dataset.accessRights.value,
-      dataset.accessRights.label
-    );
+    const { value, label } = dataset.accessRights;
+    if (value) {
+      const rightsNode = createNamedNode(value);
+      store.add(datasetNode, ns.dct("accessRights"), rightsNode);
+      store.add(rightsNode, ns.rdf("type"), ns.dct("RightsStatement"));
+      if (label) {
+        store.add(
+          rightsNode,
+          ns.skos("prefLabel"),
+          createLanguageLiteral(label, "eng")
+        );
+      }
+    }
   }
   dataset.conformsTo?.forEach((entry) =>
     addConcept(

--- a/src/app/api/discovery/harvester/rdfxml-post-processor.ts
+++ b/src/app/api/discovery/harvester/rdfxml-post-processor.ts
@@ -43,62 +43,7 @@ export const rewriteDocumentationNodes = (xml: string): string =>
   );
 
 /**
- * Rewrites `dct:accessRights` shorthand references into fully nested
- * `dct:RightsStatement` elements with an inline `skos:prefLabel`.
- *
- * rdflib emits two separate fragments:
- *   1. <dct:accessRights rdf:resource="URI"/>   ← inside the dataset block
- *   2. <dct:RightsStatement rdf:about="URI">    ← top-level detached block
- *        <skos:prefLabel xml:lang="eng">…</skos:prefLabel>
- *      </dct:RightsStatement>
- *
- * This function:
- *   1. Collects labels from all detached `<dct:RightsStatement>` blocks and
- *      removes them from the document.
- *   2. Replaces each `rdf:resource` shorthand with the nested inline form:
- *
- *   After:  <dct:accessRights>
- *             <dct:RightsStatement rdf:about="URI">
- *               <skos:prefLabel xml:lang="eng">Non public</skos:prefLabel>
- *             </dct:RightsStatement>
- *           </dct:accessRights>
- */
-export const rewriteAccessRightsNodes = (xml: string): string => {
-  const labelByUri = new Map<string, string>();
-
-  // Pass 1 – harvest labels from detached blocks and remove those blocks.
-  const stripped = xml.replace(
-    /<dct:RightsStatement rdf:about="([^"]+)">([\s\S]*?)<\/dct:RightsStatement>/g,
-    (_match, uri: string, inner: string) => {
-      const labelMatch = inner.match(
-        /<skos:prefLabel[^>]*>([^<]*)<\/skos:prefLabel>/
-      );
-      if (labelMatch) labelByUri.set(uri, labelMatch[1]);
-      return "";
-    }
-  );
-
-  // Pass 2 – replace the shorthand with the fully inlined nested element.
-  return stripped.replace(
-    /<dct:accessRights rdf:resource="([^"]+)"\/>/g,
-    (_match, uri: string) => {
-      const label = labelByUri.get(uri);
-      const labelXml = label
-        ? `\n        <skos:prefLabel xml:lang="eng">${label}</skos:prefLabel>\n      `
-        : "";
-      return (
-        `<dct:accessRights>\n` +
-        `      <dct:RightsStatement rdf:about="${uri}">${labelXml}</dct:RightsStatement>\n` +
-        `    </dct:accessRights>`
-      );
-    }
-  );
-};
-
-/**
  * Applies all RDF/XML post-processing rewrites in the correct order.
  */
 export const applyRdfXmlPostProcessing = (xml: string): string =>
-  rewriteAccessRightsNodes(
-    rewriteDocumentationNodes(rewriteCodingSystemNodes(xml))
-  );
+  rewriteDocumentationNodes(rewriteCodingSystemNodes(xml));

--- a/src/app/api/discovery/harvester/rdfxml-post-processor.ts
+++ b/src/app/api/discovery/harvester/rdfxml-post-processor.ts
@@ -1,0 +1,104 @@
+// SPDX-FileCopyrightText: 2026 PNED G.I.E.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+/**
+ * Post-processing helpers for rdflib's RDF/XML serialization.
+ *
+ * rdflib always serializes named-node objects as the shorthand attribute form:
+ *   <predicate rdf:resource="URI"/>
+ *
+ * Several HealthDCAT-AP predicates require a *typed nested element* instead.
+ * These functions rewrite the serialized XML string into the required shape.
+ */
+
+/**
+ * Rewrites `hasCodingSystem` shorthand references into typed nested elements:
+ *
+ *   Before: <healthdcatap:hasCodingSystem rdf:resource="URI"/>
+ *   After:  <healthdcatap:hasCodingSystem>
+ *             <dct:Standard rdf:about="URI"/>
+ *           </healthdcatap:hasCodingSystem>
+ */
+export const rewriteCodingSystemNodes = (xml: string): string =>
+  xml.replace(
+    /<healthdcatap:hasCodingSystem rdf:resource="([^"]+)"\/>/g,
+    (_, uri) =>
+      `<healthdcatap:hasCodingSystem>\n      <dct:Standard rdf:about="${uri}"/>\n    </healthdcatap:hasCodingSystem>`
+  );
+
+/**
+ * Rewrites `foaf:page` shorthand references into typed nested elements:
+ *
+ *   Before: <foaf:page rdf:resource="URI"/>
+ *   After:  <foaf:page>
+ *             <foaf:Document rdf:about="URI"/>
+ *           </foaf:page>
+ */
+export const rewriteDocumentationNodes = (xml: string): string =>
+  xml.replace(
+    /<foaf:page rdf:resource="([^"]+)"\/>/g,
+    (_, uri) =>
+      `<foaf:page>\n      <foaf:Document rdf:about="${uri}"/>\n    </foaf:page>`
+  );
+
+/**
+ * Rewrites `dct:accessRights` shorthand references into fully nested
+ * `dct:RightsStatement` elements with an inline `skos:prefLabel`.
+ *
+ * rdflib emits two separate fragments:
+ *   1. <dct:accessRights rdf:resource="URI"/>   ← inside the dataset block
+ *   2. <dct:RightsStatement rdf:about="URI">    ← top-level detached block
+ *        <skos:prefLabel xml:lang="eng">…</skos:prefLabel>
+ *      </dct:RightsStatement>
+ *
+ * This function:
+ *   1. Collects labels from all detached `<dct:RightsStatement>` blocks and
+ *      removes them from the document.
+ *   2. Replaces each `rdf:resource` shorthand with the nested inline form:
+ *
+ *   After:  <dct:accessRights>
+ *             <dct:RightsStatement rdf:about="URI">
+ *               <skos:prefLabel xml:lang="eng">Non public</skos:prefLabel>
+ *             </dct:RightsStatement>
+ *           </dct:accessRights>
+ */
+export const rewriteAccessRightsNodes = (xml: string): string => {
+  const labelByUri = new Map<string, string>();
+
+  // Pass 1 – harvest labels from detached blocks and remove those blocks.
+  const stripped = xml.replace(
+    /<dct:RightsStatement rdf:about="([^"]+)">([\s\S]*?)<\/dct:RightsStatement>/g,
+    (_match, uri: string, inner: string) => {
+      const labelMatch = inner.match(
+        /<skos:prefLabel[^>]*>([^<]*)<\/skos:prefLabel>/
+      );
+      if (labelMatch) labelByUri.set(uri, labelMatch[1]);
+      return "";
+    }
+  );
+
+  // Pass 2 – replace the shorthand with the fully inlined nested element.
+  return stripped.replace(
+    /<dct:accessRights rdf:resource="([^"]+)"\/>/g,
+    (_match, uri: string) => {
+      const label = labelByUri.get(uri);
+      const labelXml = label
+        ? `\n        <skos:prefLabel xml:lang="eng">${label}</skos:prefLabel>\n      `
+        : "";
+      return (
+        `<dct:accessRights>\n` +
+        `      <dct:RightsStatement rdf:about="${uri}">${labelXml}</dct:RightsStatement>\n` +
+        `    </dct:accessRights>`
+      );
+    }
+  );
+};
+
+/**
+ * Applies all RDF/XML post-processing rewrites in the correct order.
+ */
+export const applyRdfXmlPostProcessing = (xml: string): string =>
+  rewriteAccessRightsNodes(
+    rewriteDocumentationNodes(rewriteCodingSystemNodes(xml))
+  );

--- a/src/app/api/discovery/harvester/rdfxml-post-processor.ts
+++ b/src/app/api/discovery/harvester/rdfxml-post-processor.ts
@@ -10,22 +10,11 @@
  *
  * Several HealthDCAT-AP predicates require a *typed nested element* instead.
  * These functions rewrite the serialized XML string into the required shape.
- */
-
-/**
- * Rewrites `hasCodingSystem` shorthand references into typed nested elements:
  *
- *   Before: <healthdcatap:hasCodingSystem rdf:resource="URI"/>
- *   After:  <healthdcatap:hasCodingSystem>
- *             <dct:Standard rdf:about="URI"/>
- *           </healthdcatap:hasCodingSystem>
+ * Note: predicates whose object nodes already carry outgoing triples (e.g. a
+ * rdf:type triple) are inlined by rdflib automatically and do NOT need a
+ * post-processing rewrite (e.g. hasCodingSystem → dct:Standard).
  */
-export const rewriteCodingSystemNodes = (xml: string): string =>
-  xml.replace(
-    /<healthdcatap:hasCodingSystem rdf:resource="([^"]+)"\/>/g,
-    (_, uri) =>
-      `<healthdcatap:hasCodingSystem>\n      <dct:Standard rdf:about="${uri}"/>\n    </healthdcatap:hasCodingSystem>`
-  );
 
 /**
  * Rewrites `foaf:page` shorthand references into typed nested elements:
@@ -46,4 +35,4 @@ export const rewriteDocumentationNodes = (xml: string): string =>
  * Applies all RDF/XML post-processing rewrites in the correct order.
  */
 export const applyRdfXmlPostProcessing = (xml: string): string =>
-  rewriteDocumentationNodes(rewriteCodingSystemNodes(xml));
+  rewriteDocumentationNodes(xml);


### PR DESCRIPTION
Fix the encoding of accessRight such that it is compliant with the healthDcat encoding, it must be an instance of RightStatements. 
The right encoding looks that:

`<dct:accessRights>
      <dct:RightsStatement rdf:about="http://publications.europa.eu/resource/authority/access-right/NON_PUBLIC">
        <skos:prefLabel xml:lang="eng">Non public</skos:prefLabel>
      </dct:RightsStatement>
    </dct:accessRights>`

## Summary by Sourcery

Ensure RDF/XML serialization of dataset access rights and related metadata conforms to HealthDCAT-AP nested typed-element requirements.

Bug Fixes:
- Encode dataset accessRights as dct:RightsStatement resources with inline labels to comply with HealthDCAT-AP.

Enhancements:
- Centralize RDF/XML post-processing into a reusable utility applied during dataset serialization.
- Adjust dataset classification quad mapping to emit typed RightsStatement nodes with optional English prefLabels instead of generic concepts.

Tests:
- Add unit test coverage for RDF/XML post-processing of coding systems, documentation links, and access rights nodes, including combined application.