### PR TITLE
feat: add notification component using no operation notificatoin provider

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,6 +61,15 @@ OPENSEARCH_PASSWORD=<your-password>
 OPENSEARCH_TLS_INSECURE=true
 ```
 
+## Notification Provider Setup
+
+The notification bell in the header is backed by a `NotificationProvider` selected via `NOTIFICATION_PROVIDER` in `.env.local`.
+
+- `NOTIFICATION_PROVIDER=noop` (default) — no backend wired up; the bell is hidden.
+- Any other value must be registered in `src/app/api/notifications/providers/factory.ts`. Project-specific providers (e.g. a mirrored repo's own backend integration) are added there without changing the generic contract, the provider interface, or any React component.
+
+The bell only renders once a non-`noop` provider is configured — there is no separate feature flag to toggle.
+
 To run OpenSearch locally:
 
 ```bash

--- a/src/app/api/notifications/__tests__/index.test.ts
+++ b/src/app/api/notifications/__tests__/index.test.ts
@@ -1,0 +1,126 @@
+// SPDX-FileCopyrightText: 2026 PNED G.I.E.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+import { jest } from "@jest/globals";
+
+const mockGetNotificationProvider = jest.fn();
+const mockIsNotificationsFeatureEnabled = jest.fn();
+
+jest.mock("@/app/api/notifications/providers/factory", () => ({
+  getNotificationProvider: mockGetNotificationProvider,
+  isNotificationsFeatureEnabled: mockIsNotificationsFeatureEnabled,
+}));
+
+jest.mock("@/app/api/shared/headers", () => ({
+  createHeaders: jest.fn(async () => ({ Authorization: "Bearer token" })),
+}));
+
+describe("notifications server actions", () => {
+  const list = jest.fn<(...args: unknown[]) => Promise<unknown>>();
+  const unreadCount = jest.fn<(...args: unknown[]) => Promise<unknown>>();
+  const markRead = jest.fn<(...args: unknown[]) => Promise<unknown>>();
+  const remove = jest.fn<(...args: unknown[]) => Promise<unknown>>();
+
+  beforeEach(() => {
+    jest.resetModules();
+    jest.clearAllMocks();
+    mockIsNotificationsFeatureEnabled.mockReturnValue(true);
+    mockGetNotificationProvider.mockReturnValue({
+      key: "some-provider",
+      list,
+      unreadCount,
+      markRead,
+      delete: remove,
+    });
+  });
+
+  test("listNotificationsApi forwards params and headers to the provider", async () => {
+    list.mockResolvedValueOnce({ items: [], total: 0 });
+    const { listNotificationsApi } = await import("@/app/api/notifications");
+
+    const result = await listNotificationsApi({ page: 1 });
+
+    expect(list).toHaveBeenCalledWith(
+      { page: 1 },
+      { Authorization: "Bearer token" }
+    );
+    expect(result).toEqual({ items: [], total: 0 });
+  });
+
+  test("markNotificationsReadApi forwards ids and headers", async () => {
+    const { markNotificationsReadApi } =
+      await import("@/app/api/notifications");
+
+    await markNotificationsReadApi(["1", "2"]);
+
+    expect(markRead).toHaveBeenCalledWith(["1", "2"], {
+      Authorization: "Bearer token",
+    });
+  });
+
+  test("deleteNotificationsApi forwards ids and headers", async () => {
+    const { deleteNotificationsApi } = await import("@/app/api/notifications");
+
+    await deleteNotificationsApi(["1"]);
+
+    expect(remove).toHaveBeenCalledWith(["1"], {
+      Authorization: "Bearer token",
+    });
+  });
+
+  describe("getNotificationsSnapshotApi", () => {
+    test("returns a disabled empty snapshot without calling the provider", async () => {
+      mockIsNotificationsFeatureEnabled.mockReturnValue(false);
+      const { getNotificationsSnapshotApi } =
+        await import("@/app/api/notifications");
+
+      const snapshot = await getNotificationsSnapshotApi();
+
+      expect(snapshot).toEqual({
+        enabled: false,
+        list: { items: [] },
+        unreadCount: 0,
+      });
+      expect(list).not.toHaveBeenCalled();
+    });
+
+    test("uses the provider's unreadCount when available", async () => {
+      list.mockResolvedValueOnce({
+        items: [{ id: "1", read: false }],
+        total: 1,
+      });
+      unreadCount.mockResolvedValueOnce(5);
+      const { getNotificationsSnapshotApi } =
+        await import("@/app/api/notifications");
+
+      const snapshot = await getNotificationsSnapshotApi();
+
+      expect(snapshot.unreadCount).toBe(5);
+      expect(unreadCount).toHaveBeenCalledWith({
+        Authorization: "Bearer token",
+      });
+    });
+
+    test("falls back to counting unread items when unreadCount is not implemented", async () => {
+      list.mockResolvedValueOnce({
+        items: [
+          { id: "1", read: false },
+          { id: "2", read: true },
+          { id: "3", read: false },
+        ],
+        total: 3,
+      });
+      mockGetNotificationProvider.mockReturnValue({
+        key: "some-provider",
+        list,
+      });
+      const { getNotificationsSnapshotApi } =
+        await import("@/app/api/notifications");
+
+      const snapshot = await getNotificationsSnapshotApi();
+
+      expect(snapshot.unreadCount).toBe(2);
+    });
+  });
+});

--- a/src/app/api/notifications/index.ts
+++ b/src/app/api/notifications/index.ts
@@ -1,0 +1,69 @@
+// SPDX-FileCopyrightText: 2026 PNED G.I.E.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+"use server";
+
+import {
+  getNotificationProvider,
+  isNotificationsFeatureEnabled,
+} from "@/app/api/notifications/providers/factory";
+import { createHeaders } from "@/app/api/shared/headers";
+import {
+  ListNotificationsParams,
+  ListNotificationsResult,
+} from "@/lib/notifications/types";
+
+const notificationProvider = getNotificationProvider();
+
+const countUnread = (result: ListNotificationsResult): number =>
+  result.items.filter((notification) => !notification.read).length;
+
+export interface NotificationsSnapshot {
+  enabled: boolean;
+  list: ListNotificationsResult;
+  unreadCount: number;
+}
+
+/**
+ * Single entry point for the initial client fetch: resolves whether the
+ * feature is enabled and, if so, the notification list and unread count in
+ * one round trip. Falls back to counting unread items from `list` when the
+ * active provider doesn't implement `unreadCount`.
+ */
+export const getNotificationsSnapshotApi =
+  async (): Promise<NotificationsSnapshot> => {
+    const enabled = isNotificationsFeatureEnabled();
+    if (!enabled) {
+      return { enabled, list: { items: [] }, unreadCount: 0 };
+    }
+
+    const headers = await createHeaders();
+    const list = await notificationProvider.list({}, headers);
+    const unreadCount = notificationProvider.unreadCount
+      ? await notificationProvider.unreadCount(headers)
+      : countUnread(list);
+
+    return { enabled, list, unreadCount };
+  };
+
+export const listNotificationsApi = async (
+  params: ListNotificationsParams = {}
+): Promise<ListNotificationsResult> => {
+  const headers = await createHeaders();
+  return notificationProvider.list(params, headers);
+};
+
+export const markNotificationsReadApi = async (
+  ids: string[]
+): Promise<void> => {
+  if (!notificationProvider.markRead) return;
+  const headers = await createHeaders();
+  await notificationProvider.markRead(ids, headers);
+};
+
+export const deleteNotificationsApi = async (ids?: string[]): Promise<void> => {
+  if (!notificationProvider.delete) return;
+  const headers = await createHeaders();
+  await notificationProvider.delete(ids, headers);
+};

--- a/src/app/api/notifications/providers/__tests__/factory.test.ts
+++ b/src/app/api/notifications/providers/__tests__/factory.test.ts
@@ -1,0 +1,50 @@
+// SPDX-FileCopyrightText: 2026 PNED G.I.E.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+import {
+  getNotificationProvider,
+  isNotificationsFeatureEnabled,
+  resolveNotificationProviderKey,
+} from "@/app/api/notifications/providers/factory";
+
+describe("notification provider factory", () => {
+  const originalProviderEnv = process.env.NOTIFICATION_PROVIDER;
+
+  afterEach(() => {
+    process.env.NOTIFICATION_PROVIDER = originalProviderEnv;
+  });
+
+  test("defaults to noop when env is unset", () => {
+    expect(resolveNotificationProviderKey(undefined)).toBe("noop");
+  });
+
+  test("resolves supported keys case-insensitively", () => {
+    expect(resolveNotificationProviderKey("noop")).toBe("noop");
+    expect(resolveNotificationProviderKey("NOOP")).toBe("noop");
+  });
+
+  test("throws with supported values for unknown key", () => {
+    expect(() => resolveNotificationProviderKey("unknown")).toThrow(
+      /Unsupported NOTIFICATION_PROVIDER "unknown"/
+    );
+    expect(() => resolveNotificationProviderKey("unknown")).toThrow(
+      /Supported values:/
+    );
+  });
+
+  test("returns the selected provider instance", () => {
+    process.env.NOTIFICATION_PROVIDER = "noop";
+    expect(getNotificationProvider().key).toBe("noop");
+  });
+
+  test("feature flag is disabled when only the noop provider is configured", () => {
+    process.env.NOTIFICATION_PROVIDER = "noop";
+    expect(isNotificationsFeatureEnabled()).toBe(false);
+  });
+
+  test("feature flag defaults to disabled when unset", () => {
+    delete process.env.NOTIFICATION_PROVIDER;
+    expect(isNotificationsFeatureEnabled()).toBe(false);
+  });
+});

--- a/src/app/api/notifications/providers/__tests__/noop-notification-provider.test.ts
+++ b/src/app/api/notifications/providers/__tests__/noop-notification-provider.test.ts
@@ -1,0 +1,22 @@
+// SPDX-FileCopyrightText: 2026 PNED G.I.E.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+import { NoopNotificationProvider } from "@/app/api/notifications/providers/noop-notification-provider";
+
+describe("NoopNotificationProvider", () => {
+  const provider = new NoopNotificationProvider();
+
+  test("lists no notifications", async () => {
+    await expect(provider.list()).resolves.toEqual({ items: [], total: 0 });
+  });
+
+  test("reports zero unread notifications", async () => {
+    await expect(provider.unreadCount()).resolves.toBe(0);
+  });
+
+  test("markRead and delete are no-ops", async () => {
+    await expect(provider.markRead()).resolves.toBeUndefined();
+    await expect(provider.delete()).resolves.toBeUndefined();
+  });
+});

--- a/src/app/api/notifications/providers/factory.ts
+++ b/src/app/api/notifications/providers/factory.ts
@@ -1,0 +1,46 @@
+// SPDX-FileCopyrightText: 2026 PNED G.I.E.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+import { NoopNotificationProvider } from "@/app/api/notifications/providers/noop-notification-provider";
+import { NotificationProvider } from "@/app/api/notifications/providers/types";
+
+export type NotificationProviderKey = "noop";
+
+const NOOP_PROVIDER_KEY: NotificationProviderKey = "noop";
+
+const providersByKey: Record<NotificationProviderKey, NotificationProvider> = {
+  noop: new NoopNotificationProvider(),
+};
+
+export const resolveNotificationProviderKey = (
+  keyFromEnv: string | undefined
+): NotificationProviderKey => {
+  if (!keyFromEnv) return NOOP_PROVIDER_KEY;
+
+  const normalized = keyFromEnv.toLowerCase();
+  if (normalized in providersByKey) {
+    return normalized as NotificationProviderKey;
+  }
+
+  throw new Error(
+    `Unsupported NOTIFICATION_PROVIDER "${keyFromEnv}". Supported values: ${Object.keys(
+      providersByKey
+    ).join(", ")}`
+  );
+};
+
+export const getNotificationProvider = (): NotificationProvider => {
+  const providerKey = resolveNotificationProviderKey(
+    process.env.NOTIFICATION_PROVIDER
+  );
+  return providersByKey[providerKey];
+};
+
+/**
+ * The notification UI is only shown once a deployment configures a real
+ * (non-noop) provider, so this flag is derived automatically from
+ * NOTIFICATION_PROVIDER rather than toggled by a separate feature flag.
+ */
+export const isNotificationsFeatureEnabled = (): boolean =>
+  getNotificationProvider().key !== NOOP_PROVIDER_KEY;

--- a/src/app/api/notifications/providers/noop-notification-provider.ts
+++ b/src/app/api/notifications/providers/noop-notification-provider.ts
@@ -1,0 +1,22 @@
+// SPDX-FileCopyrightText: 2026 PNED G.I.E.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+import { NotificationProvider } from "@/app/api/notifications/providers/types";
+import { ListNotificationsResult } from "@/lib/notifications/types";
+
+export class NoopNotificationProvider implements NotificationProvider {
+  readonly key = "noop";
+
+  async list(): Promise<ListNotificationsResult> {
+    return { items: [], total: 0 };
+  }
+
+  async unreadCount(): Promise<number> {
+    return 0;
+  }
+
+  async markRead(): Promise<void> {}
+
+  async delete(): Promise<void> {}
+}

--- a/src/app/api/notifications/providers/types.ts
+++ b/src/app/api/notifications/providers/types.ts
@@ -1,0 +1,23 @@
+// SPDX-FileCopyrightText: 2026 PNED G.I.E.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+import {
+  ListNotificationsParams,
+  ListNotificationsResult,
+} from "@/lib/notifications/types";
+
+export interface NotificationProvider {
+  readonly key: string;
+  list: (
+    params: ListNotificationsParams,
+    headers: Record<string, string>
+  ) => Promise<ListNotificationsResult>;
+  unreadCount?: (headers: Record<string, string>) => Promise<number>;
+  markRead?: (ids: string[], headers: Record<string, string>) => Promise<void>;
+  // Omitting `ids` deletes all notifications for the current user.
+  delete?: (
+    ids: string[] | undefined,
+    headers: Record<string, string>
+  ) => Promise<void>;
+}

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -8,6 +8,7 @@ import ScrollToTop from "@/components/ScrollToTop";
 import { routing, type AppLocale } from "@/i18n/routing";
 import { DatasetBasketProvider } from "@/providers/DatasetBasketProvider";
 import { AlertProvider } from "@/providers/AlertProvider";
+import { NotificationsProvider } from "@/providers/notifications/NotificationsProvider";
 import { config } from "@fortawesome/fontawesome-svg-core";
 import "@fortawesome/fontawesome-svg-core/styles.css";
 import { NextIntlClientProvider } from "next-intl";
@@ -66,14 +67,16 @@ export default async function RootLayout({
             <DatasetBasketProvider>
               <div className="grid h-screen w-full grid-rows-[auto_1fr_auto]">
                 <SessionProviderWrapper>
-                  <div>
-                    <Header />
-                  </div>
-                  <FilterProvider>
-                    <div>{children}</div>
-                  </FilterProvider>
-                  <Navbar />
-                  <Footer />
+                  <NotificationsProvider>
+                    <div>
+                      <Header />
+                    </div>
+                    <FilterProvider>
+                      <div>{children}</div>
+                    </FilterProvider>
+                    <Navbar />
+                    <Footer />
+                  </NotificationsProvider>
                 </SessionProviderWrapper>
               </div>
             </DatasetBasketProvider>

--- a/src/components/Header/Notifications/NotificationBell.tsx
+++ b/src/components/Header/Notifications/NotificationBell.tsx
@@ -1,0 +1,44 @@
+// SPDX-FileCopyrightText: 2026 PNED G.I.E.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+"use client";
+
+import {
+  Popover,
+  PopoverContent,
+  PopoverTrigger,
+} from "@/components/shadcn/popover";
+import { useNotifications } from "@/providers/notifications/NotificationsProvider";
+import { faBell } from "@fortawesome/free-solid-svg-icons";
+import { FontAwesomeIcon } from "@fortawesome/react-fontawesome";
+import { useTranslations } from "next-intl";
+import NotificationList from "./NotificationList";
+
+const NotificationBell = () => {
+  const t = useTranslations();
+  const { enabled, unreadCount } = useNotifications();
+
+  if (!enabled) return null;
+
+  return (
+    <Popover>
+      <PopoverTrigger
+        aria-label={t("notifications.label")}
+        className="relative flex items-center text-info hover:text-secondary transition-opacity duration-300 p-2 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-inset focus-visible:ring-primary"
+      >
+        <FontAwesomeIcon icon={faBell} className="text-2xl lg:text-3xl" />
+        {unreadCount > 0 && (
+          <span className="absolute right-0 top-0 inline-flex -translate-y-1/3 translate-x-1/2 transform items-center justify-center rounded-full bg-secondary px-2.5 py-1.5 text-sm font-bold leading-none text-white">
+            {unreadCount > 99 ? "99+" : unreadCount}
+          </span>
+        )}
+      </PopoverTrigger>
+      <PopoverContent align="end" className="w-96 p-0">
+        <NotificationList />
+      </PopoverContent>
+    </Popover>
+  );
+};
+
+export default NotificationBell;

--- a/src/components/Header/Notifications/NotificationList.tsx
+++ b/src/components/Header/Notifications/NotificationList.tsx
@@ -1,0 +1,122 @@
+// SPDX-FileCopyrightText: 2026 PNED G.I.E.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+"use client";
+
+import { ScrollArea } from "@/components/shadcn/scroll-area";
+import { Link } from "@/i18n/navigation";
+import { resolveNotificationLink } from "@/lib/notifications/resolveNotificationLink";
+import { AppNotification } from "@/lib/notifications/types";
+import { useNotifications } from "@/providers/notifications/NotificationsProvider";
+import { formatDateTime } from "@/utils/formatDate";
+import { cn } from "@/utils/tailwindMerge";
+import { faCheck, faTrash } from "@fortawesome/free-solid-svg-icons";
+import { FontAwesomeIcon } from "@fortawesome/react-fontawesome";
+import { useTranslations } from "next-intl";
+
+const NotificationRow = ({
+  notification,
+}: {
+  notification: AppNotification;
+}) => {
+  const t = useTranslations();
+  const { markRead, remove } = useNotifications();
+  const href = resolveNotificationLink(notification);
+
+  const content = (
+    <div className="flex flex-1 flex-col gap-y-1 min-w-0">
+      <span className={cn("text-sm", !notification.read && "font-semibold")}>
+        {notification.title}
+      </span>
+      <span className="text-sm text-info line-clamp-2">
+        {notification.message}
+      </span>
+      <span className="text-xs text-info opacity-70">
+        {formatDateTime(notification.createdAt)}
+      </span>
+    </div>
+  );
+
+  return (
+    <li
+      className={cn(
+        "flex items-start gap-x-2 px-4 py-3 border-b border-gray-100 last:border-b-0",
+        !notification.read && "bg-primary/5"
+      )}
+    >
+      {href ? (
+        <Link
+          href={href}
+          className="flex flex-1 min-w-0"
+          onClick={() => {
+            if (!notification.read) markRead([notification.id]);
+          }}
+        >
+          {content}
+        </Link>
+      ) : (
+        content
+      )}
+      <div className="flex flex-col gap-y-1 shrink-0">
+        {!notification.read && (
+          <button
+            type="button"
+            aria-label={t("notifications.markRead")}
+            title={t("notifications.markRead")}
+            onClick={() => markRead([notification.id])}
+            className="p-1 text-info hover:text-primary transition-colors"
+          >
+            <FontAwesomeIcon icon={faCheck} />
+          </button>
+        )}
+        <button
+          type="button"
+          aria-label={t("notifications.delete")}
+          title={t("notifications.delete")}
+          onClick={() => remove([notification.id])}
+          className="p-1 text-info hover:text-secondary transition-colors"
+        >
+          <FontAwesomeIcon icon={faTrash} />
+        </button>
+      </div>
+    </li>
+  );
+};
+
+const NotificationList = () => {
+  const t = useTranslations();
+  const { notifications, isLoading } = useNotifications();
+
+  return (
+    <div className="flex flex-col">
+      <div className="px-4 py-3 border-b border-gray-100">
+        <span className="font-semibold text-black">
+          {t("notifications.label")}
+        </span>
+      </div>
+      <ScrollArea className="max-h-96">
+        {isLoading ? (
+          <p className="px-4 py-6 text-sm text-info text-center">
+            {t("notifications.loading")}
+          </p>
+        ) : notifications.length === 0 ? (
+          <p className="px-4 py-6 text-sm text-info text-center">
+            {t("notifications.empty")}
+          </p>
+        ) : (
+          <ul>
+            {notifications.map((notification) => (
+              <NotificationRow
+                key={notification.id}
+                notification={notification}
+              />
+            ))}
+          </ul>
+        )}
+      </ScrollArea>
+    </div>
+  );
+};
+
+export default NotificationList;

--- a/src/components/Header/index.tsx
+++ b/src/components/Header/index.tsx
@@ -25,6 +25,7 @@ import Image from "next/image";
 import { useEffect, useState } from "react";
 import Button from "../Button";
 import Avatar from "./Avatar";
+import NotificationBell from "./Notifications/NotificationBell";
 import RequestIcon from "./RequestIcon";
 
 function Header() {
@@ -103,6 +104,7 @@ function Header() {
   if (status !== "loading" && contentConfig.showBasketAndLogin) {
     loginBtn = session ? (
       <>
+        <NotificationBell />
         <RequestIcon isActive={!!activeTab?.includes("requests")} />
         <Avatar user={session.user as User} />
       </>

--- a/src/i18n/messages.json
+++ b/src/i18n/messages.json
@@ -1510,5 +1510,25 @@
   "datasets.card.entitlementEnd": {
     "en": "End: {date}",
     "fr": "Fin : {date}"
+  },
+  "notifications.label": {
+    "en": "Notifications",
+    "fr": "Notifications"
+  },
+  "notifications.empty": {
+    "en": "You have no notifications",
+    "fr": "Vous n'avez aucune notification"
+  },
+  "notifications.loading": {
+    "en": "Loading notifications…",
+    "fr": "Chargement des notifications…"
+  },
+  "notifications.markRead": {
+    "en": "Mark as read",
+    "fr": "Marquer comme lu"
+  },
+  "notifications.delete": {
+    "en": "Delete notification",
+    "fr": "Supprimer la notification"
   }
 }

--- a/src/lib/notifications/__tests__/resolveNotificationLink.test.ts
+++ b/src/lib/notifications/__tests__/resolveNotificationLink.test.ts
@@ -1,0 +1,29 @@
+// SPDX-FileCopyrightText: 2026 PNED G.I.E.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+import { resolveNotificationLink } from "@/lib/notifications/resolveNotificationLink";
+import { AppNotification } from "@/lib/notifications/types";
+
+const baseNotification: AppNotification = {
+  id: "1",
+  title: "title",
+  message: "message",
+  createdAt: "2026-07-01T00:00:00.000Z",
+  read: false,
+};
+
+describe("resolveNotificationLink", () => {
+  test("returns undefined when there is no applicationId", () => {
+    expect(resolveNotificationLink(baseNotification)).toBeUndefined();
+  });
+
+  test("builds an applications route when applicationId is present", () => {
+    const link = resolveNotificationLink({
+      ...baseNotification,
+      meta: { applicationId: "42" },
+    });
+
+    expect(link).toBe("/applications/42");
+  });
+});

--- a/src/lib/notifications/resolveNotificationLink.ts
+++ b/src/lib/notifications/resolveNotificationLink.ts
@@ -1,0 +1,18 @@
+// SPDX-FileCopyrightText: 2026 PNED G.I.E.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+import { AppNotification } from "@/lib/notifications/types";
+
+/**
+ * Maps a notification's `meta` to the in-app route it should deep-link to.
+ * All application-related notifications currently resolve to the same
+ * route; if a future `applicationType` needs a different destination,
+ * branch on it here — the list/row UI stays generic either way.
+ */
+export const resolveNotificationLink = (
+  notification: AppNotification
+): string | undefined => {
+  const { applicationId } = notification.meta ?? {};
+  return applicationId ? `/applications/${applicationId}` : undefined;
+};

--- a/src/lib/notifications/types.ts
+++ b/src/lib/notifications/types.ts
@@ -1,0 +1,33 @@
+// SPDX-FileCopyrightText: 2026 PNED G.I.E.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+/**
+ * Generic notification shape shown by the UI. Provider-specific payloads are
+ * mapped into this contract in the server/API layer.
+ */
+export interface AppNotificationMeta {
+  code?: string;
+  applicationId?: string;
+  applicationType?: string;
+  rawProperties?: Record<string, unknown>;
+}
+
+export interface AppNotification {
+  id: string;
+  title: string;
+  message: string;
+  createdAt: string;
+  read: boolean;
+  meta?: AppNotificationMeta;
+}
+
+export interface ListNotificationsParams {
+  page?: number;
+  limit?: number;
+}
+
+export interface ListNotificationsResult {
+  items: AppNotification[];
+  total?: number;
+}

--- a/src/providers/notifications/NotificationsProvider.tsx
+++ b/src/providers/notifications/NotificationsProvider.tsx
@@ -1,0 +1,128 @@
+// SPDX-FileCopyrightText: 2026 PNED G.I.E.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+"use client";
+
+import {
+  deleteNotificationsApi,
+  getNotificationsSnapshotApi,
+  markNotificationsReadApi,
+} from "@/app/api/notifications";
+import { AppNotification } from "@/lib/notifications/types";
+import { useSession } from "next-auth/react";
+import {
+  ReactNode,
+  createContext,
+  useCallback,
+  useContext,
+  useEffect,
+  useState,
+} from "react";
+
+interface NotificationsContextState {
+  enabled: boolean;
+  notifications: AppNotification[];
+  unreadCount: number;
+  isLoading: boolean;
+  refresh: () => Promise<void>;
+  markRead: (ids: string[]) => Promise<void>;
+  remove: (ids: string[]) => Promise<void>;
+}
+
+const NotificationsContext = createContext<
+  NotificationsContextState | undefined
+>(undefined);
+
+export const NotificationsProvider = ({
+  children,
+}: {
+  children: ReactNode;
+}) => {
+  const { status: sessionStatus } = useSession();
+  const [enabled, setEnabled] = useState(false);
+  const [notifications, setNotifications] = useState<AppNotification[]>([]);
+  const [unreadCount, setUnreadCount] = useState(0);
+  const [isLoading, setIsLoading] = useState(true);
+
+  const refresh = useCallback(async () => {
+    setIsLoading(true);
+    try {
+      const snapshot = await getNotificationsSnapshotApi();
+      setEnabled(snapshot.enabled);
+      setNotifications(snapshot.list.items);
+      setUnreadCount(snapshot.unreadCount);
+    } finally {
+      setIsLoading(false);
+    }
+  }, []);
+
+  useEffect(() => {
+    if (sessionStatus === "loading") return;
+
+    if (sessionStatus !== "authenticated") {
+      setIsLoading(false);
+      return;
+    }
+
+    refresh().catch(() => setIsLoading(false));
+  }, [sessionStatus, refresh]);
+
+  const markRead = useCallback(async (ids: string[]) => {
+    await markNotificationsReadApi(ids);
+    setNotifications((prev) => {
+      const idSet = new Set(ids);
+      let unreadMarked = 0;
+      const next = prev.map((notification) => {
+        if (idSet.has(notification.id) && !notification.read) {
+          unreadMarked += 1;
+          return { ...notification, read: true };
+        }
+        return notification;
+      });
+      setUnreadCount((count) => Math.max(0, count - unreadMarked));
+      return next;
+    });
+  }, []);
+
+  const remove = useCallback(async (ids: string[]) => {
+    await deleteNotificationsApi(ids);
+    setNotifications((prev) => {
+      const idSet = new Set(ids);
+      let removedUnread = 0;
+      const next = prev.filter((notification) => {
+        if (!idSet.has(notification.id)) return true;
+        if (!notification.read) removedUnread += 1;
+        return false;
+      });
+      setUnreadCount((count) => Math.max(0, count - removedUnread));
+      return next;
+    });
+  }, []);
+
+  return (
+    <NotificationsContext.Provider
+      value={{
+        enabled,
+        notifications,
+        unreadCount,
+        isLoading,
+        refresh,
+        markRead,
+        remove,
+      }}
+    >
+      {children}
+    </NotificationsContext.Provider>
+  );
+};
+
+export const useNotifications = () => {
+  const context = useContext(NotificationsContext);
+  if (context === undefined) {
+    throw new Error(
+      "useNotifications must be used within a NotificationsProvider"
+    );
+  }
+  return context;
+};

--- a/src/providers/notifications/NotificationsProvider.tsx
+++ b/src/providers/notifications/NotificationsProvider.tsx
@@ -61,6 +61,9 @@ export const NotificationsProvider = ({
     if (sessionStatus === "loading") return;
 
     if (sessionStatus !== "authenticated") {
+      setEnabled(false);
+      setNotifications([]);
+      setUnreadCount(0);
       setIsLoading(false);
       return;
     }


### PR DESCRIPTION
Notification data are mocked for UI demo: 

<img width="598" height="595" alt="Screenshot 2026-07-21 at 14 13 57" src="https://github.com/user-attachments/assets/d99598b2-a791-435f-a11a-3e608bdc0b64" />


## Summary by Sourcery

Introduce a pluggable notifications system with a header bell backed by environment-configured providers and a default no-op implementation.

New Features:
- Add a NotificationProvider context and header bell UI that surfaces user notifications and unread counts when a non-noop provider is configured.
- Define a generic notification data contract and link resolver to deep-link notifications to in-app routes.

Enhancements:
- Centralize notification server actions to fetch snapshots, list notifications, mark them read, and delete them via provider abstractions.
- Add a provider factory that selects implementations based on NOTIFICATION_PROVIDER and derives feature enablement from this configuration.

Documentation:
- Document how to configure the notification provider via NOTIFICATION_PROVIDER and how the bell visibility depends on this setting.

Tests:
- Add tests for notification server actions, provider factory resolution and feature flag behavior, noop provider semantics, and notification link resolution.