### PR TITLE
fix: fill accrualPeriodicity with an instance of Frquency

### DIFF
--- a/src/app/api/discovery/harvester/__tests__/dcat-dataset-rdf-generator.test.ts
+++ b/src/app/api/discovery/harvester/__tests__/dcat-dataset-rdf-generator.test.ts
@@ -573,6 +573,37 @@ describe("DCAT dataset export generators", () => {
     ]);
   });
 
+  test("emits accrualPeriodicity as nested dct:Frequency element with skos:prefLabel in RDF/XML", async () => {
+    const frequencyUri =
+      "http://publications.europa.eu/resource/authority/frequency/ANNUAL";
+    const dataset = buildLocalDiscoveryDataset({
+      id: "https://example.org/datasets/export-1",
+      frequency: { value: frequencyUri, label: "Annual" },
+    });
+
+    const turtle = await serializeDatasetAsTurtle(dataset);
+    const rdfXml = await serializeDatasetAsRdfXml(dataset);
+
+    expect(turtle).toContain("dct:accrualPeriodicity");
+    expect(turtle).toContain(frequencyUri);
+    expect(turtle).toContain('"Annual"@eng');
+
+    expect(rdfXml).toContain(`<dct:Frequency rdf:about="${frequencyUri}">`);
+    expect(rdfXml).toContain(
+      `<skos:prefLabel xml:lang="eng">Annual</skos:prefLabel>`
+    );
+
+    const quads = await parseRdfXmlToQuads(rdfXml);
+    const isTypedAsFrequency = quads.some(
+      (q) =>
+        q.subject.value === frequencyUri &&
+        q.predicate.value ===
+          "http://www.w3.org/1999/02/22-rdf-syntax-ns#type" &&
+        q.object.value === "http://purl.org/dc/terms/Frequency"
+    );
+    expect(isTypedAsFrequency).toBe(true);
+  });
+
   test("emits documentation as nested foaf:Document element with rdf:about in RDF/XML", async () => {
     const dataset = buildLocalDiscoveryDataset({
       id: "https://example.org/datasets/export-1",
@@ -620,7 +651,7 @@ describe("DCAT dataset export generators", () => {
     ]);
   });
 
-  test("emits hasCodeValues as language-tagged literal with xml:lang='en' in RDF/XML", async () => {
+  test("emits documentation as nested foaf:Document element with rdf:about in RDF/XML", async () => {
     const dataset = buildLocalDiscoveryDataset({
       id: "https://example.org/datasets/export-1",
       codeValues: [

--- a/src/app/api/discovery/harvester/rdf/mappers/dataset-governance-quad-mapper.ts
+++ b/src/app/api/discovery/harvester/rdf/mappers/dataset-governance-quad-mapper.ts
@@ -21,13 +21,19 @@ export const addDatasetGovernanceQuads = ({
   datasetNode,
 }: DatasetRdfContext): void => {
   if (dataset.frequency) {
-    addConcept(
-      store,
-      datasetNode,
-      ns.dct("accrualPeriodicity"),
-      dataset.frequency.value,
-      dataset.frequency.label
-    );
+    const { value, label } = dataset.frequency;
+    if (isNonEmptyString(value) && isAbsoluteUri(value)) {
+      const frequencyNode = createNamedNode(value);
+      store.add(datasetNode, ns.dct("accrualPeriodicity"), frequencyNode);
+      store.add(frequencyNode, ns.rdf("type"), ns.dct("Frequency"));
+      if (isNonEmptyString(label)) {
+        store.add(
+          frequencyNode,
+          ns.skos("prefLabel"),
+          createLanguageLiteral(label, "eng")
+        );
+      }
+    }
   }
 
   dataset.legalBasis?.forEach((entry, index) => {


### PR DESCRIPTION
The field accrualPeriodicity should be filled with an Instance of Frequency:
`<dct:accrualPeriodicity>
    <dct:Frequency rdf:about="http://publications.europa.eu/resource/authority/frequency/    ANNUAL">
      <skos:prefLabel xml:lang="eng">Annual</skos:prefLabel>
 </dct:Frequency>`

## Summary by Sourcery

Emit dataset accrualPeriodicity as a typed dct:Frequency resource with an optional English skos:prefLabel when a valid frequency URI is provided.

Bug Fixes:
- Ensure accrualPeriodicity is represented as a dct:Frequency instance instead of a generic concept when exporting datasets to RDF.

Tests:
- Add RDF/XML and Turtle tests verifying accrualPeriodicity is emitted as a nested dct:Frequency with an English skos:prefLabel and correct rdf:type.
- Rename an RDF/XML export test to accurately reflect that it covers nested foaf:Document documentation elements.