### PR TITLE
fix: applicable legislation should be filled with an instance of Lega…

### DIFF
--- a/src/app/api/discovery/harvester/__tests__/dcat-dataset-rdf-generator.test.ts
+++ b/src/app/api/discovery/harvester/__tests__/dcat-dataset-rdf-generator.test.ts
@@ -670,4 +670,41 @@ describe("DCAT dataset export generators", () => {
     );
     expect(rdfXml).not.toContain("<healthdcatap:hasCodeValues rdf:resource=");
   });
+
+  test("emits applicableLegislation as nested eli:LegalResource element with rdfs:label in RDF/XML", async () => {
+    const legislationUri = "http://data.europa.eu/eli/reg/2016/679";
+    const dataset = buildLocalDiscoveryDataset({
+      id: "https://example.org/datasets/export-1",
+      applicableLegislation: [{ value: legislationUri, label: "GDPR" }],
+    });
+
+    const turtle = await serializeDatasetAsTurtle(dataset);
+    const rdfXml = await serializeDatasetAsRdfXml(dataset);
+
+    expect(turtle).toContain("dcatap:applicableLegislation");
+    expect(turtle).toContain(legislationUri);
+    expect(turtle).toContain('"GDPR"@eng');
+
+    expect(rdfXml).toContain(
+      `<eli:LegalResource rdf:about="${legislationUri}">`
+    );
+    expect(rdfXml).toContain(`<rdfs:label xml:lang="eng">GDPR</rdfs:label>`);
+
+    const quads = await parseRdfXmlToQuads(rdfXml);
+    const isTypedAsLegalResource = quads.some(
+      (q) =>
+        q.subject.value === legislationUri &&
+        q.predicate.value ===
+          "http://www.w3.org/1999/02/22-rdf-syntax-ns#type" &&
+        q.object.value === "http://data.europa.eu/eli/ontology#LegalResource"
+    );
+    expect(isTypedAsLegalResource).toBe(true);
+
+    const labelQuad = quads.find(
+      (q) =>
+        q.subject.value === legislationUri &&
+        q.predicate.value === "http://www.w3.org/2000/01/rdf-schema#label"
+    );
+    expect(labelQuad?.object.value).toBe("GDPR");
+  });
 });

--- a/src/app/api/discovery/harvester/__tests__/dcat-dataset-rdf-shared.test.ts
+++ b/src/app/api/discovery/harvester/__tests__/dcat-dataset-rdf-shared.test.ts
@@ -68,6 +68,7 @@ describe("dcat dataset rdf shared helpers", () => {
       foaf: "http://xmlns.com/foaf/0.1/",
       vcard: "http://www.w3.org/2006/vcard/ns#",
       xsd: "http://www.w3.org/2001/XMLSchema#",
+      eli: "http://data.europa.eu/eli/ontology#",
     });
   });
 });

--- a/src/app/api/discovery/harvester/dcat-dataset-rdf-shared.ts
+++ b/src/app/api/discovery/harvester/dcat-dataset-rdf-shared.ts
@@ -20,6 +20,7 @@ export const DATASET_EXPORT_PREFIXES = {
   foaf: "http://xmlns.com/foaf/0.1/", // NOSONAR
   vcard: "http://www.w3.org/2006/vcard/ns#", // NOSONAR
   xsd: "http://www.w3.org/2001/XMLSchema#", // NOSONAR
+  eli: "http://data.europa.eu/eli/ontology#", // NOSONAR
 } as const;
 
 export const escapeXml = (value: string): string =>

--- a/src/app/api/discovery/harvester/rdf/context.ts
+++ b/src/app/api/discovery/harvester/rdf/context.ts
@@ -36,6 +36,7 @@ export const ns = {
   foaf: rdf.Namespace(DATASET_EXPORT_PREFIXES.foaf),
   vcard: rdf.Namespace(DATASET_EXPORT_PREFIXES.vcard),
   xsd: rdf.Namespace(DATASET_EXPORT_PREFIXES.xsd),
+  eli: rdf.Namespace(DATASET_EXPORT_PREFIXES.eli),
 } as const;
 
 export const createDatasetRdfContext = (

--- a/src/app/api/discovery/harvester/rdf/mappers/dataset-governance-quad-mapper.ts
+++ b/src/app/api/discovery/harvester/rdf/mappers/dataset-governance-quad-mapper.ts
@@ -55,15 +55,19 @@ export const addDatasetGovernanceQuads = ({
     );
   });
 
-  dataset.applicableLegislation?.forEach((entry) =>
-    addConcept(
-      store,
-      datasetNode,
-      ns.dcatap("applicableLegislation"),
-      entry.value,
-      entry.label
-    )
-  );
+  dataset.applicableLegislation?.forEach((entry) => {
+    if (!isNonEmptyString(entry.value) || !isAbsoluteUri(entry.value)) return;
+    const legislationNode = createNamedNode(entry.value);
+    store.add(datasetNode, ns.dcatap("applicableLegislation"), legislationNode);
+    store.add(legislationNode, ns.rdf("type"), ns.eli("LegalResource"));
+    if (isNonEmptyString(entry.label)) {
+      store.add(
+        legislationNode,
+        ns.rdfs("label"),
+        createLanguageLiteral(entry.label, "eng")
+      );
+    }
+  });
 
   dataset.personalData?.forEach((entry) =>
     addNamedNode(store, datasetNode, ns.dpv("hasPersonalData"), entry.value)

--- a/src/app/api/discovery/providers/__tests__/local-index-discovery-provider.test.ts
+++ b/src/app/api/discovery/providers/__tests__/local-index-discovery-provider.test.ts
@@ -1199,7 +1199,7 @@ describe("LocalIndexDiscoveryProvider", () => {
     expect(
       hasQuad(quads, {
         subject: "http://data.europa.eu/eli/reg/2016/679",
-        predicate: "http://www.w3.org/2004/02/skos/core#prefLabel",
+        predicate: "http://www.w3.org/2000/01/rdf-schema#label",
         object: "GDPR",
         objectTermType: "Literal",
       })


### PR DESCRIPTION
Fix the way applicable legislation is encoded to the rdf, it should be filled with a LegalResource object like that:

```
 <r5r:applicableLegislation>
     <eli:LegalResource rdf:about="http://data.legilux.public.lu/eli/etat/leg/rgd/2022/04/    07/a180/jo">
         <rdfs:label xml:lang="eng">Règlement grand-ducal du 7 avril 2022 déterminant les me    sures d’exécution de la loi du 23 décembre 2016 instituant un régime d’aides pour la promot    ion de la durabilité, de l’utilisation rationnelle de l’énergie et des énergies renouvelabl    es dans le domaine du logement.</rdfs:label>
        </eli:LegalResource>
      </r5r:applicableLegislation>
   
```

## Summary by Sourcery

Encode applicableLegislation in dataset RDF as nested eli:LegalResource resources with English rdfs:label literals, and update prefixes and tests accordingly.

New Features:
- Support eli:LegalResource typing for applicableLegislation resources in exported dataset RDF.

Enhancements:
- Validate applicableLegislation URIs before emitting RDF, and attach rdfs:label language-tagged literals instead of skos:prefLabel.
- Extend dataset RDF export namespace prefixes to include the ELI ontology.

Tests:
- Add RDF/XML and Turtle tests to verify applicableLegislation is emitted as eli:LegalResource with rdfs:label and correct typing.
- Update discovery provider tests to expect rdfs:label for applicableLegislation labels instead of skos:prefLabel.