### PR TITLE
fix: media type to be encoded with an instance of MediaType

### DIFF
--- a/src/app/api/discovery/harvester/__tests__/dcat-dataset-rdf-generator.test.ts
+++ b/src/app/api/discovery/harvester/__tests__/dcat-dataset-rdf-generator.test.ts
@@ -604,6 +604,42 @@ describe("DCAT dataset export generators", () => {
     expect(isTypedAsFrequency).toBe(true);
   });
 
+  test("emits distribution mediaType as nested dct:MediaType element with skos:prefLabel in RDF/XML", async () => {
+    const mediaTypeUri = "http://www.iana.org/assignments/media-types/text/csv";
+    const dataset = buildLocalDiscoveryDataset({
+      id: "https://example.org/datasets/export-1",
+      distributions: [
+        {
+          id: "distribution-1",
+          title: "CSV Distribution",
+          mediaType: { value: mediaTypeUri, label: "CSV" },
+        },
+      ],
+    });
+
+    const turtle = await serializeDatasetAsTurtle(dataset);
+    const rdfXml = await serializeDatasetAsRdfXml(dataset);
+
+    expect(turtle).toContain("dcat:mediaType");
+    expect(turtle).toContain(mediaTypeUri);
+    expect(turtle).toContain('"CSV"@eng');
+
+    expect(rdfXml).toContain(`<dct:MediaType rdf:about="${mediaTypeUri}">`);
+    expect(rdfXml).toContain(
+      `<skos:prefLabel xml:lang="eng">CSV</skos:prefLabel>`
+    );
+
+    const quads = await parseRdfXmlToQuads(rdfXml);
+    const isTypedAsMediaType = quads.some(
+      (q) =>
+        q.subject.value === mediaTypeUri &&
+        q.predicate.value ===
+          "http://www.w3.org/1999/02/22-rdf-syntax-ns#type" &&
+        q.object.value === "http://purl.org/dc/terms/MediaType"
+    );
+    expect(isTypedAsMediaType).toBe(true);
+  });
+
   test("emits documentation as nested foaf:Document element with rdf:about in RDF/XML", async () => {
     const dataset = buildLocalDiscoveryDataset({
       id: "https://example.org/datasets/export-1",

--- a/src/app/api/discovery/harvester/rdf/mappers/dataset-distribution-quad-mapper.ts
+++ b/src/app/api/discovery/harvester/rdf/mappers/dataset-distribution-quad-mapper.ts
@@ -7,10 +7,12 @@ import {
   addConcept,
   addLiteral,
   addNamedNode,
+  createLanguageLiteral,
   createLiteral,
   createNamedNode,
   createNestedNode,
   isAbsoluteUri,
+  isNonEmptyString,
   ns,
 } from "@/app/api/discovery/harvester/rdf/context";
 import { DATASET_EXPORT_PREFIXES } from "@/app/api/discovery/harvester/dcat-dataset-rdf-shared";
@@ -44,13 +46,19 @@ export const addDatasetDistributionQuads = ({
     }
 
     if (distribution.mediaType) {
-      addConcept(
-        store,
-        distributionNode,
-        ns.dcat("mediaType"),
-        distribution.mediaType.value,
-        distribution.mediaType.label
-      );
+      const { value, label } = distribution.mediaType;
+      if (isNonEmptyString(value) && isAbsoluteUri(value)) {
+        const mediaTypeNode = createNamedNode(value);
+        store.add(distributionNode, ns.dcat("mediaType"), mediaTypeNode);
+        store.add(mediaTypeNode, ns.rdf("type"), ns.dct("MediaType"));
+        if (isNonEmptyString(label)) {
+          store.add(
+            mediaTypeNode,
+            ns.skos("prefLabel"),
+            createLanguageLiteral(label, "eng")
+          );
+        }
+      }
     }
 
     if (distribution.license) {


### PR DESCRIPTION
The mediaType should be encoded as an instance of MediaType nested object:
```

<dcat:mediaType>         <dct:MediaType rdf:about="http://www.iana.org/assignments/media-types/application    /1d-interleaved-parityfec">
           <skos:prefLabel xml:lang="eng">application/1d-interleaved-parityfec</skos:prefL    abel>
           </dct:MediaType>
        </dcat:mediaType>
```

## Summary by Sourcery

Ensure DCAT distribution media types are exported as nested dct:MediaType resources with appropriate labeling in RDF/XML and Turtle.

New Features:
- Add support for emitting distribution mediaType as a dct:MediaType resource with skos:prefLabel in RDF/XML exports.

Enhancements:
- Refine dataset distribution quad mapping to validate mediaType values and emit language-tagged labels using skos:prefLabel.

Tests:
- Add coverage verifying distribution mediaType is serialized as a nested dct:MediaType with skos:prefLabel and correct rdf:type in RDF/XML and Turtle outputs.