### PR TITLE
fix: max and min typical age non negative and conforms to as Standard

### DIFF
--- a/src/app/api/discovery/harvester/__tests__/dcat-dataset-rdf-generator.test.ts
+++ b/src/app/api/discovery/harvester/__tests__/dcat-dataset-rdf-generator.test.ts
@@ -225,6 +225,54 @@ describe("DCAT dataset export generators", () => {
     );
   });
 
+  test("encodes maxTypicalAge as xsd:nonNegativeInteger", async () => {
+    const XSD_NON_NEGATIVE_INTEGER =
+      "http://www.w3.org/2001/XMLSchema#nonNegativeInteger";
+    const dataset = buildLocalDiscoveryDataset({
+      id: "https://example.org/datasets/export-1",
+      maxTypicalAge: 95,
+    });
+
+    const rdfXml = await serializeDatasetAsRdfXml(dataset);
+    const quads = await parseRdfXmlToQuads(rdfXml);
+
+    const quad = quads.find(
+      (q) =>
+        q.predicate.value ===
+        "http://healthdataportal.eu/ns/health#maxTypicalAge"
+    );
+    expect(quad).toBeDefined();
+    expect(quad!.object.termType).toBe("Literal");
+    expect(quad!.object.value).toBe("95");
+    expect((quad!.object as any).datatype?.value).toBe(
+      XSD_NON_NEGATIVE_INTEGER
+    );
+  });
+
+  test("encodes minTypicalAge as xsd:nonNegativeInteger", async () => {
+    const XSD_NON_NEGATIVE_INTEGER =
+      "http://www.w3.org/2001/XMLSchema#nonNegativeInteger";
+    const dataset = buildLocalDiscoveryDataset({
+      id: "https://example.org/datasets/export-1",
+      minTypicalAge: 18,
+    });
+
+    const rdfXml = await serializeDatasetAsRdfXml(dataset);
+    const quads = await parseRdfXmlToQuads(rdfXml);
+
+    const quad = quads.find(
+      (q) =>
+        q.predicate.value ===
+        "http://healthdataportal.eu/ns/health#minTypicalAge"
+    );
+    expect(quad).toBeDefined();
+    expect(quad!.object.termType).toBe("Literal");
+    expect(quad!.object.value).toBe("18");
+    expect((quad!.object as any).datatype?.value).toBe(
+      XSD_NON_NEGATIVE_INTEGER
+    );
+  });
+
   test("facade dispatches serializers and MIME types for all supported formats", async () => {
     const dataset = buildLocalDiscoveryDataset({
       id: "https://example.org/datasets/export-1",
@@ -562,7 +610,9 @@ describe("DCAT dataset export generators", () => {
             (q) =>
               q.predicate.value ===
                 "http://www.w3.org/1999/02/22-rdf-syntax-ns#type" &&
-              q.object.value === "http://purl.org/dc/terms/Standard"
+              q.object.value === "http://purl.org/dc/terms/Standard" &&
+              (q.subject.value === "https://www.wikidata.org/entity/Q9006342" ||
+                q.subject.value === "https://www.wikidata.org/entity/Q5969475")
           )
           .map((q) => q.subject.value)
       ),
@@ -742,5 +792,33 @@ describe("DCAT dataset export generators", () => {
         q.predicate.value === "http://www.w3.org/2000/01/rdf-schema#label"
     );
     expect(labelQuad?.object.value).toBe("GDPR");
+  });
+
+  test("emits conformsTo as nested dct:Standard element with rdf:about in RDF/XML", async () => {
+    const standardUri = "https://example.org/spec/healthdcat-ap-v6";
+    const dataset = buildLocalDiscoveryDataset({
+      id: "https://example.org/datasets/export-1",
+      conformsTo: [{ value: standardUri, label: "HealthDCAT-AP v6" }],
+    });
+
+    const turtle = await serializeDatasetAsTurtle(dataset);
+    const rdfXml = await serializeDatasetAsRdfXml(dataset);
+
+    expect(turtle).toContain("dct:conformsTo");
+    expect(turtle).toContain(standardUri);
+
+    // rdflib emits the Standard node as a separate top-level block (same as hasCodingSystem)
+    expect(rdfXml).toContain(`<dct:conformsTo rdf:resource="${standardUri}"/>`);
+    expect(rdfXml).toContain(`<dct:Standard rdf:about="${standardUri}">`);
+
+    const quads = await parseRdfXmlToQuads(rdfXml);
+    const isTypedAsStandard = quads.some(
+      (q) =>
+        q.subject.value === standardUri &&
+        q.predicate.value ===
+          "http://www.w3.org/1999/02/22-rdf-syntax-ns#type" &&
+        q.object.value === "http://purl.org/dc/terms/Standard"
+    );
+    expect(isTypedAsStandard).toBe(true);
   });
 });

--- a/src/app/api/discovery/harvester/rdf/mappers/dataset-classification-quad-mapper.ts
+++ b/src/app/api/discovery/harvester/rdf/mappers/dataset-classification-quad-mapper.ts
@@ -8,6 +8,8 @@ import {
   createLanguageLiteral,
   createLiteral,
   createNamedNode,
+  isAbsoluteUri,
+  isNonEmptyString,
   ns,
 } from "@/app/api/discovery/harvester/rdf/context";
 
@@ -64,13 +66,10 @@ export const addDatasetClassificationQuads = ({
       }
     }
   }
-  dataset.conformsTo?.forEach((entry) =>
-    addConcept(
-      store,
-      datasetNode,
-      ns.dct("conformsTo"),
-      entry.value,
-      entry.label
-    )
-  );
+  dataset.conformsTo?.forEach((entry) => {
+    if (!isNonEmptyString(entry.value) || !isAbsoluteUri(entry.value)) return;
+    const standardNode = createNamedNode(entry.value);
+    store.add(datasetNode, ns.dct("conformsTo"), standardNode);
+    store.add(standardNode, ns.rdf("type"), ns.dct("Standard"));
+  });
 };

--- a/src/app/api/discovery/harvester/rdf/mappers/dataset-coverage-quad-mapper.ts
+++ b/src/app/api/discovery/harvester/rdf/mappers/dataset-coverage-quad-mapper.ts
@@ -8,7 +8,6 @@ import {
   createDateTimeLiteral,
   createDecimalLiteral,
   createDurationLiteral,
-  createIntegerLiteral,
   createNamedNode,
   createNonNegativeIntegerLiteral,
   createNestedNode,
@@ -39,14 +38,14 @@ export const addDatasetCoverageQuads = ({
     store.add(
       datasetNode,
       ns.health("maxTypicalAge"),
-      createIntegerLiteral(dataset.maxTypicalAge)
+      createNonNegativeIntegerLiteral(dataset.maxTypicalAge)
     );
   }
   if (typeof dataset.minTypicalAge === "number") {
     store.add(
       datasetNode,
       ns.health("minTypicalAge"),
-      createIntegerLiteral(dataset.minTypicalAge)
+      createNonNegativeIntegerLiteral(dataset.minTypicalAge)
     );
   }
 

--- a/src/app/api/discovery/providers/__tests__/local-index-discovery-provider.test.ts
+++ b/src/app/api/discovery/providers/__tests__/local-index-discovery-provider.test.ts
@@ -1167,9 +1167,9 @@ describe("LocalIndexDiscoveryProvider", () => {
     expect(
       hasQuad(quads, {
         subject: "https://example.org/spec/healthdcat-ap-v6",
-        predicate: "http://www.w3.org/2004/02/skos/core#prefLabel",
-        object: "HealthDCAT-AP v6",
-        objectTermType: "Literal",
+        predicate: "http://www.w3.org/1999/02/22-rdf-syntax-ns#type",
+        object: "http://purl.org/dc/terms/Standard",
+        objectTermType: "NamedNode",
       })
     ).toBe(true);
     expect(


### PR DESCRIPTION
Fix the way max and min typical age are encoded, they should be non negative integer.
Also, fix conforms to such that it has the instance of Standard as value:

```
     <dct:conformsTo>
       <dct:Standard rdf:about="https://hdeu-dcat.acceptance.data.health.europa.eu/resource/authority/standard/CDA"/>
     </dct:conformsTo>
```

## Summary by Sourcery

Ensure DCAT dataset RDF export encodes typical age values as non-negative integers and represents dct:conformsTo using proper Standard resources.

New Features:
- Support emitting conformsTo as a dct:Standard resource in RDF/XML and Turtle outputs.

Enhancements:
- Validate conformsTo entries as non-empty absolute URIs before adding classification quads.
- Encode maxTypicalAge and minTypicalAge using xsd:nonNegativeInteger literals instead of generic integers.

Tests:
- Add RDF/XML serialization tests for maxTypicalAge and minTypicalAge as xsd:nonNegativeInteger literals.
- Add tests verifying conformsTo is emitted as a nested dct:Standard element with rdf:about and typed correctly as dct:Standard.
- Update local index discovery provider tests to expect conformsTo standards to be typed as dct:Standard instead of labeled with skos:prefLabel.