### PR TITLE
fix: encode linguistic as instance of LinguisticSystem

### DIFF
--- a/src/app/api/discovery/harvester/__tests__/dcat-harvester-service.test.ts
+++ b/src/app/api/discovery/harvester/__tests__/dcat-harvester-service.test.ts
@@ -19,8 +19,12 @@ describe("DcatHarvesterService", () => {
         description: "National & regional data",
         catalogue: "Main Catalogue",
         languages: [
-          "http://publications.europa.eu/resource/authority/language/ENG",
-          "DEU",
+          {
+            value:
+              "http://publications.europa.eu/resource/authority/language/ENG",
+            label: "English",
+          },
+          { value: "DEU", label: "German" },
         ],
         createdAt: "2023-06-15T00:00:00.000Z",
         modifiedAt: "2024-02-20T14:30:00.000Z",
@@ -479,7 +483,10 @@ describe("DcatHarvesterService", () => {
 
     const datasets = await service.parseDatasetsFromRdf(rdf);
     expect(datasets[0].languages).toEqual([
-      "http://publications.europa.eu/resource/authority/language/ENG",
+      {
+        value: "http://publications.europa.eu/resource/authority/language/ENG",
+        label: "English",
+      },
     ]);
   });
 

--- a/src/app/api/discovery/harvester/dcat-dataset-mapper.ts
+++ b/src/app/api/discovery/harvester/dcat-dataset-mapper.ts
@@ -14,6 +14,7 @@ import { extractDatasetRelations } from "@/app/api/discovery/harvester/dcat-data
 import { extractDistributions } from "@/app/api/discovery/harvester/dcat-distribution-mapper";
 import { RdfGraph } from "@/app/api/discovery/harvester/rdf-graph";
 import { normalizeDate } from "@/app/api/discovery/harvester/date-utils";
+import formatDatasetLanguage from "@/utils/formatDatasetLanguage";
 
 export const DCAT_DATASET = "http://www.w3.org/ns/dcat#Dataset";
 export const DCAT_CATALOG = "http://www.w3.org/ns/dcat#Catalog";
@@ -232,7 +233,11 @@ const getDatasetDescription = (
 const getDatasetLanguages = (
   datasetSubject: RDF.Term,
   graph: RdfGraph
-): string[] => graph.getObjectValues(datasetSubject, DCT_LANGUAGE);
+): Array<{ value: string; label: string }> =>
+  graph.getObjectValues(datasetSubject, DCT_LANGUAGE).map((uri) => ({
+    value: uri,
+    label: formatDatasetLanguage(uri) ?? uri.split("/").pop() ?? uri,
+  }));
 
 const getDatasetCatalogue = (
   datasetSubject: RDF.Term,

--- a/src/app/api/discovery/harvester/rdf/mappers/dataset-core-quad-mapper.ts
+++ b/src/app/api/discovery/harvester/rdf/mappers/dataset-core-quad-mapper.ts
@@ -7,6 +7,7 @@ import {
   addLiteral,
   addNamedNode,
   createDateTimeLiteral,
+  createLanguageLiteral,
   createLiteral,
   createNamedNode,
   createNestedNode,
@@ -26,17 +27,26 @@ export const addDatasetCoreQuads = ({
   addLiteral(store, datasetNode, ns.dct("description"), dataset.description);
   addNamedNode(store, datasetNode, ns.dcat("inCatalog"), dataset.catalogue);
 
-  dataset.languages?.forEach((language) => {
-    if (!isNonEmptyString(language)) {
+  dataset.languages?.forEach(({ value, label }) => {
+    if (!isNonEmptyString(value)) {
       return;
     }
 
-    if (isAbsoluteUri(language)) {
-      store.add(datasetNode, ns.dct("language"), createNamedNode(language));
+    if (isAbsoluteUri(value)) {
+      const langNode = createNamedNode(value);
+      store.add(datasetNode, ns.dct("language"), langNode);
+      store.add(langNode, ns.rdf("type"), ns.dct("LinguisticSystem"));
+      if (isNonEmptyString(label)) {
+        store.add(
+          langNode,
+          ns.skos("prefLabel"),
+          createLanguageLiteral(label, "eng")
+        );
+      }
       return;
     }
 
-    store.add(datasetNode, ns.dct("language"), createLiteral(language));
+    store.add(datasetNode, ns.dct("language"), createLiteral(value));
   });
 
   if (isNonEmptyString(dataset.createdAt)) {

--- a/src/app/api/discovery/local-store/opensearch/__tests__/mappers.test.ts
+++ b/src/app/api/discovery/local-store/opensearch/__tests__/mappers.test.ts
@@ -14,7 +14,7 @@ const canonicalSource = buildLocalDiscoveryDataset({
   title: "A",
   description: "desc-a",
   catalogue: "catalogue-a",
-  languages: ["ENG"],
+  languages: [{ value: "ENG", label: "English" }],
   populationCoverage: undefined,
   spatialCoverage: undefined,
   spatialResolutionInMeters: undefined,

--- a/src/app/api/discovery/local-store/opensearch/__tests__/queries.test.ts
+++ b/src/app/api/discovery/local-store/opensearch/__tests__/queries.test.ts
@@ -17,7 +17,10 @@ const canonicalDataset = buildLocalDiscoveryDataset({
   title: "A",
   description: "D1",
   catalogue: "catalogue-1",
-  languages: ["ENG", "FRA"],
+  languages: [
+    { value: "ENG", label: "English" },
+    { value: "FRA", label: "French" },
+  ],
   populationCoverage: undefined,
   spatialCoverage: undefined,
   spatialResolutionInMeters: undefined,
@@ -523,7 +526,9 @@ describe("opensearch/queries", () => {
     expect(body).toContain('"identifier":"IDENT-1"');
     expect(body).toContain('"title":"A"');
     expect(body).toContain('"catalogue":"catalogue-1"');
-    expect(body).toContain('"languages":["ENG","FRA"]');
+    expect(body).toContain(
+      '"languages":[{"value":"ENG","label":"English"},{"value":"FRA","label":"French"}]'
+    );
     expect(body).toContain('"createdAt":"2024-01-01T00:00:00.000Z"');
     expect(body).toContain('"version":"1.0.0"');
     expect(body).toContain(

--- a/src/app/api/discovery/local-store/types.ts
+++ b/src/app/api/discovery/local-store/types.ts
@@ -60,7 +60,7 @@ export interface LocalDiscoveryDataset {
   title: string;
   description?: string;
   catalogue?: string;
-  languages?: string[];
+  languages?: Array<{ value: string; label: string }>;
   createdAt?: string;
   modifiedAt?: string;
   version?: string;

--- a/src/app/api/discovery/providers/__tests__/local-index-discovery-provider.test.ts
+++ b/src/app/api/discovery/providers/__tests__/local-index-discovery-provider.test.ts
@@ -406,7 +406,11 @@ describe("LocalIndexDiscoveryProvider", () => {
         id: "retrieve-id",
         identifier: "IDENT-R",
         languages: [
-          "http://publications.europa.eu/resource/authority/language/FRA",
+          {
+            value:
+              "http://publications.europa.eu/resource/authority/language/FRA",
+            label: "French",
+          },
         ],
         spatialCoverage: [
           {
@@ -686,7 +690,9 @@ describe("LocalIndexDiscoveryProvider", () => {
         identifier: undefined,
         description: undefined,
         catalogue: undefined,
-        languages: ["custom-language-code"],
+        languages: [
+          { value: "custom-language-code", label: "custom-language-code" },
+        ],
         spatialCoverage: [{ text: "Luxembourg" }],
         populationCoverage: undefined,
         spatialResolutionInMeters: undefined,

--- a/src/app/api/discovery/providers/local-index-discovery-provider.ts
+++ b/src/app/api/discovery/providers/local-index-discovery-provider.ts
@@ -19,7 +19,6 @@ import {
   DiscoveryRetrievedDataset,
   DiscoveryValueLabel,
 } from "@/app/api/discovery/providers/types";
-import formatDatasetLanguage from "@/utils/formatDatasetLanguage";
 
 export class LocalIndexDiscoveryProvider extends BasePlaceholderDiscoveryProvider {
   readonly key = "local-index";
@@ -32,16 +31,10 @@ export class LocalIndexDiscoveryProvider extends BasePlaceholderDiscoveryProvide
 
   private readonly store = getLocalDiscoveryStore();
 
-  private mapDatasetLanguages(languages?: string[]): DiscoveryValueLabel[] {
-    return (
-      languages?.map((language) => ({
-        value: language,
-        label:
-          formatDatasetLanguage(language) ??
-          language.split("/").pop() ??
-          language,
-      })) ?? []
-    );
+  private mapDatasetLanguages(
+    languages?: Array<{ value: string; label: string }>
+  ): DiscoveryValueLabel[] {
+    return languages?.map(({ value, label }) => ({ value, label })) ?? [];
   }
 
   private mapAgent(

--- a/src/app/api/discovery/test-utils/fixtures.ts
+++ b/src/app/api/discovery/test-utils/fixtures.ts
@@ -237,7 +237,10 @@ export const buildLocalDiscoveryDataset = (
   description: "desc-a",
   catalogue: "catalogue-a",
   languages: [
-    "http://publications.europa.eu/resource/authority/language/ENG", // NOSONAR
+    {
+      value: "http://publications.europa.eu/resource/authority/language/ENG", // NOSONAR
+      label: "English",
+    },
   ],
   createdAt: "2024-01-01T00:00:00.000Z",
   modifiedAt: "2024-03-10T00:00:00.000Z",


### PR DESCRIPTION
fix the way the language is encoded, now it's instance of LinguisticSystem:

```
    <dct:LinguisticSystem rdf:about="http://publications.europa.eu/resource/authority/language/ENG">
         <skos:prefLabel xml:lang="eng">English</skos:prefLabel>
       </dct:LinguisticSystem>
```

## Summary by Sourcery

Represent dataset languages as value/label pairs and encode RDF languages as dct:LinguisticSystem resources with SKOS labels.

New Features:
- Encode dataset language URIs as dct:LinguisticSystem instances with optional skos:prefLabel literals.

Bug Fixes:
- Fix incorrect encoding of dataset languages by modeling them as LinguisticSystem resources instead of plain literals.

Enhancements:
- Standardize dataset language representation across harvester, local store, and providers using value/label objects.

Tests:
- Update harvester, provider, and fixture tests to cover the new language value/label structure and RDF encoding.