### PR TITLE
fix: encode format as instance of MediaTypeOrExtent

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -21331,6 +21331,111 @@
         "type": "github",
         "url": "https://github.com/sponsors/wooorm"
       }
+    },
+    "node_modules/next-runtime-env/node_modules/@next/swc-darwin-x64": {
+      "version": "16.2.10",
+      "resolved": "https://registry.npmjs.org/@next/swc-darwin-x64/-/swc-darwin-x64-16.2.10.tgz",
+      "integrity": "sha512-17IS0jJRViROGmA9uGdNR8VPJpfbnaVG7E9qhso5jDLkmyd0lSDORWxbcKINzcFqzZqGwGtMSnrFRxBpuUYjLQ==",
+      "cpu": [
+        "x64"
+      ],
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/next-runtime-env/node_modules/@next/swc-linux-arm64-gnu": {
+      "version": "16.2.10",
+      "resolved": "https://registry.npmjs.org/@next/swc-linux-arm64-gnu/-/swc-linux-arm64-gnu-16.2.10.tgz",
+      "integrity": "sha512-GRQRsRtuciNJvB54AvvuQTiq0oZtFwa1owQqtZD8wwnGpM2L39MV22kpI72YSXLKIyY40LC66EiLFv4PiicXxg==",
+      "cpu": [
+        "arm64"
+      ],
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/next-runtime-env/node_modules/@next/swc-linux-arm64-musl": {
+      "version": "16.2.10",
+      "resolved": "https://registry.npmjs.org/@next/swc-linux-arm64-musl/-/swc-linux-arm64-musl-16.2.10.tgz",
+      "integrity": "sha512-zkN9MQYS7UQBro+FnISUq1itaQjXI9xqISzuQ+2bc921NcJ1x4yPCqrn77tVN6/dOOXaaWVX3k6/bR07pPwK+A==",
+      "cpu": [
+        "arm64"
+      ],
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/next-runtime-env/node_modules/@next/swc-linux-x64-gnu": {
+      "version": "16.2.10",
+      "resolved": "https://registry.npmjs.org/@next/swc-linux-x64-gnu/-/swc-linux-x64-gnu-16.2.10.tgz",
+      "integrity": "sha512-iCVJnwvrPYECvA6WM/7+oo+OiTvedIKLxtCLAZP4xZR3nXa1zmzZyLPbYCmWvpd4CvMYF1EMTafd0ii3DygLvA==",
+      "cpu": [
+        "x64"
+      ],
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/next-runtime-env/node_modules/@next/swc-linux-x64-musl": {
+      "version": "16.2.10",
+      "resolved": "https://registry.npmjs.org/@next/swc-linux-x64-musl/-/swc-linux-x64-musl-16.2.10.tgz",
+      "integrity": "sha512-ov2g4H0dHY9bPoOU83m91hWT7Iq5qy13bUnyyshLU3HGR1Ownn0X9QpmDPc5iIUaahTp7f7LeGAhV4DSFtackw==",
+      "cpu": [
+        "x64"
+      ],
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/next-runtime-env/node_modules/@next/swc-win32-arm64-msvc": {
+      "version": "16.2.10",
+      "resolved": "https://registry.npmjs.org/@next/swc-win32-arm64-msvc/-/swc-win32-arm64-msvc-16.2.10.tgz",
+      "integrity": "sha512-DwAnhLX76HQiFFQNgWlcK+JzlnD1rZ+UK/WY0ZMI/deXpvgnesjNYrqcfo1JzBuz4Kf7o3brIBL0glI1junatA==",
+      "cpu": [
+        "arm64"
+      ],
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/next-runtime-env/node_modules/@next/swc-win32-x64-msvc": {
+      "version": "16.2.10",
+      "resolved": "https://registry.npmjs.org/@next/swc-win32-x64-msvc/-/swc-win32-x64-msvc-16.2.10.tgz",
+      "integrity": "sha512-0JXq3b85Jk9Jg4ntLUbXSPvoDw3gpZou7twuKdoFG2jOw635v7+IiXfTaa0TxVMyx78pUjnrVYwLgjKfX4e6/A==",
+      "cpu": [
+        "x64"
+      ],
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
     }
   }
 }

--- a/src/app/api/discovery/harvester/__tests__/dcat-dataset-rdf-generator.test.ts
+++ b/src/app/api/discovery/harvester/__tests__/dcat-dataset-rdf-generator.test.ts
@@ -794,6 +794,49 @@ describe("DCAT dataset export generators", () => {
     expect(labelQuad?.object.value).toBe("GDPR");
   });
 
+  test("emits distribution license as nested dct:LicenseDocument element with skos:prefLabel in RDF/XML", async () => {
+    const licenseUri = "https://creativecommons.org/licenses/by/4.0/legalcode";
+    const dataset = buildLocalDiscoveryDataset({
+      id: "https://example.org/datasets/export-1",
+      distributions: [
+        {
+          id: "distribution-1",
+          title: "CSV Distribution",
+          license: { value: licenseUri, label: "Legalcode" },
+        },
+      ],
+    });
+
+    const turtle = await serializeDatasetAsTurtle(dataset);
+    const rdfXml = await serializeDatasetAsRdfXml(dataset);
+
+    expect(turtle).toContain("dct:license");
+    expect(turtle).toContain(licenseUri);
+    expect(turtle).toContain('"Legalcode"@eng');
+
+    expect(rdfXml).toContain(`<dct:LicenseDocument rdf:about="${licenseUri}">`);
+    expect(rdfXml).toContain(
+      `<skos:prefLabel xml:lang="eng">Legalcode</skos:prefLabel>`
+    );
+
+    const quads = await parseRdfXmlToQuads(rdfXml);
+    const isTypedAsLicenseDocument = quads.some(
+      (q) =>
+        q.subject.value === licenseUri &&
+        q.predicate.value ===
+          "http://www.w3.org/1999/02/22-rdf-syntax-ns#type" &&
+        q.object.value === "http://purl.org/dc/terms/LicenseDocument"
+    );
+    expect(isTypedAsLicenseDocument).toBe(true);
+
+    const labelQuad = quads.find(
+      (q) =>
+        q.subject.value === licenseUri &&
+        q.predicate.value === "http://www.w3.org/2004/02/skos/core#prefLabel"
+    );
+    expect(labelQuad?.object.value).toBe("Legalcode");
+  });
+
   test("emits conformsTo as nested dct:Standard element with rdf:about in RDF/XML", async () => {
     const standardUri = "https://example.org/spec/healthdcat-ap-v6";
     const dataset = buildLocalDiscoveryDataset({
@@ -808,6 +851,87 @@ describe("DCAT dataset export generators", () => {
     expect(turtle).toContain(standardUri);
 
     // rdflib emits the Standard node as a separate top-level block (same as hasCodingSystem)
+    expect(rdfXml).toContain(`<dct:conformsTo rdf:resource="${standardUri}"/>`);
+    expect(rdfXml).toContain(`<dct:Standard rdf:about="${standardUri}">`);
+
+    const quads = await parseRdfXmlToQuads(rdfXml);
+    const isTypedAsStandard = quads.some(
+      (q) =>
+        q.subject.value === standardUri &&
+        q.predicate.value ===
+          "http://www.w3.org/1999/02/22-rdf-syntax-ns#type" &&
+        q.object.value === "http://purl.org/dc/terms/Standard"
+    );
+    expect(isTypedAsStandard).toBe(true);
+  });
+
+  test("emits distribution format as nested dct:MediaTypeOrExtent element with skos:prefLabel in RDF/XML", async () => {
+    const formatUri =
+      "http://publications.europa.eu/resource/authority/file-type/7Z";
+    const dataset = buildLocalDiscoveryDataset({
+      id: "https://example.org/datasets/export-1",
+      distributions: [
+        {
+          id: "distribution-1",
+          title: "7Z Distribution",
+          format: { value: formatUri, label: "7Z" },
+        },
+      ],
+    });
+
+    const turtle = await serializeDatasetAsTurtle(dataset);
+    const rdfXml = await serializeDatasetAsRdfXml(dataset);
+
+    expect(turtle).toContain("dct:format");
+    expect(turtle).toContain(formatUri);
+    expect(turtle).toContain('"7Z"@eng');
+
+    expect(rdfXml).toContain(
+      `<dct:MediaTypeOrExtent rdf:about="${formatUri}">`
+    );
+    expect(rdfXml).toContain(
+      `<skos:prefLabel xml:lang="eng">7Z</skos:prefLabel>`
+    );
+
+    const quads = await parseRdfXmlToQuads(rdfXml);
+    const isTypedAsMediaTypeOrExtent = quads.some(
+      (q) =>
+        q.subject.value === formatUri &&
+        q.predicate.value ===
+          "http://www.w3.org/1999/02/22-rdf-syntax-ns#type" &&
+        q.object.value === "http://purl.org/dc/terms/MediaTypeOrExtent"
+    );
+    expect(isTypedAsMediaTypeOrExtent).toBe(true);
+
+    const labelQuad = quads.find(
+      (q) =>
+        q.subject.value === formatUri &&
+        q.predicate.value === "http://www.w3.org/2004/02/skos/core#prefLabel"
+    );
+    expect(labelQuad?.object.value).toBe("7Z");
+  });
+
+  test("emits distribution conformsTo as nested dct:Standard element with rdf:about in RDF/XML", async () => {
+    const standardUri =
+      "https://hdeu-dcat.acceptance.data.health.europa.eu/resource/authority/standard/CDA";
+    const dataset = buildLocalDiscoveryDataset({
+      id: "https://example.org/datasets/export-1",
+      distributions: [
+        {
+          id: "distribution-1",
+          title: "CDA Distribution",
+          conformsTo: [{ value: standardUri, label: "CDA" }],
+        },
+      ],
+    });
+
+    const turtle = await serializeDatasetAsTurtle(dataset);
+    const rdfXml = await serializeDatasetAsRdfXml(dataset);
+
+    expect(turtle).toContain("dct:conformsTo");
+    expect(turtle).toContain(standardUri);
+
+    // rdflib emits the Standard node as a separate top-level block
     expect(rdfXml).toContain(`<dct:conformsTo rdf:resource="${standardUri}"/>`);
     expect(rdfXml).toContain(`<dct:Standard rdf:about="${standardUri}">`);
 

--- a/src/app/api/discovery/harvester/rdf/mappers/dataset-distribution-quad-mapper.ts
+++ b/src/app/api/discovery/harvester/rdf/mappers/dataset-distribution-quad-mapper.ts
@@ -4,7 +4,6 @@
 
 import {
   DatasetRdfContext,
-  addConcept,
   addLiteral,
   addNamedNode,
   createLanguageLiteral,
@@ -36,13 +35,19 @@ export const addDatasetDistributionQuads = ({
     addLiteral(store, distributionNode, ns.dct("title"), distribution.title);
 
     if (distribution.format) {
-      addConcept(
-        store,
-        distributionNode,
-        ns.dct("format"),
-        distribution.format.value,
-        distribution.format.label
-      );
+      const { value, label } = distribution.format;
+      if (isNonEmptyString(value) && isAbsoluteUri(value)) {
+        const formatNode = createNamedNode(value);
+        store.add(distributionNode, ns.dct("format"), formatNode);
+        store.add(formatNode, ns.rdf("type"), ns.dct("MediaTypeOrExtent"));
+        if (isNonEmptyString(label)) {
+          store.add(
+            formatNode,
+            ns.skos("prefLabel"),
+            createLanguageLiteral(label, "eng")
+          );
+        }
+      }
     }
 
     if (distribution.mediaType) {
@@ -62,18 +67,28 @@ export const addDatasetDistributionQuads = ({
     }
 
     if (distribution.license) {
-      addConcept(
-        store,
-        distributionNode,
-        ns.dct("license"),
-        distribution.license.value,
-        distribution.license.label
-      );
+      const { value, label } = distribution.license;
+      if (isNonEmptyString(value) && isAbsoluteUri(value)) {
+        const licenseNode = createNamedNode(value);
+        store.add(distributionNode, ns.dct("license"), licenseNode);
+        store.add(licenseNode, ns.rdf("type"), ns.dct("LicenseDocument"));
+        if (isNonEmptyString(label)) {
+          store.add(
+            licenseNode,
+            ns.skos("prefLabel"),
+            createLanguageLiteral(label, "eng")
+          );
+        }
+      }
     }
 
-    distribution.conformsTo?.forEach((entry) =>
-      addNamedNode(store, distributionNode, ns.dct("conformsTo"), entry.value)
-    );
+    distribution.conformsTo?.forEach((entry) => {
+      if (isNonEmptyString(entry.value) && isAbsoluteUri(entry.value)) {
+        const standardNode = createNamedNode(entry.value);
+        store.add(distributionNode, ns.dct("conformsTo"), standardNode);
+        store.add(standardNode, ns.rdf("type"), ns.dct("Standard"));
+      }
+    });
 
     if (distribution.byteSize !== undefined) {
       store.add(


### PR DESCRIPTION
Fix: format in distribution is supposed to be encoded as an instance of MediaTypeOrExtent:

```
      <dct:format>
          <dct:MediaTypeOrExtent rdf:about="http://publications.europa.eu/resource/authority/file-type/7Z">
            <skos:prefLabel xml:lang="eng">7Z</skos:prefLabel>
           </dct:MediaTypeOrExtent>
         </dct:format>
```

## Summary by Sourcery

Adjust DCAT distribution RDF export to encode license, format, and conformsTo as typed concept resources with labels rather than plain values.

New Features:
- Support encoding distribution format as a dct:MediaTypeOrExtent resource with skos:prefLabel in RDF outputs.
- Support encoding distribution license as a dct:LicenseDocument resource with skos:prefLabel in RDF outputs.
- Support encoding distribution conformsTo entries as dct:Standard resources in RDF outputs.

Tests:
- Add RDF/XML and Turtle tests verifying distribution license is emitted as a typed dct:LicenseDocument with prefLabel.
- Add RDF/XML and Turtle tests verifying distribution format is emitted as a typed dct:MediaTypeOrExtent with prefLabel.
- Add RDF/XML and Turtle tests verifying distribution-level conformsTo is emitted as a typed dct:Standard resource.