### PR TITLE
add the logic to harvest hasStructuredData and encode it to the rdf

### DIFF
--- a/src/app/api/discovery/harvester/__tests__/dcat-dataset-rdf-generator.test.ts
+++ b/src/app/api/discovery/harvester/__tests__/dcat-dataset-rdf-generator.test.ts
@@ -945,4 +945,52 @@ describe("DCAT dataset export generators", () => {
     );
     expect(isTypedAsStandard).toBe(true);
   });
+
+  test("emits hasStructuredData as xsd:boolean literal in RDF/XML", async () => {
+    const XSD_BOOLEAN = "http://www.w3.org/2001/XMLSchema#boolean";
+    const HEALTH_HAS_STRUCTURED_DATA =
+      "http://healthdataportal.eu/ns/health#hasStructuredData";
+
+    const dataset = buildLocalDiscoveryDataset({
+      id: "https://example.org/datasets/export-1",
+      hasStructuredData: true,
+    });
+
+    const turtle = await serializeDatasetAsTurtle(dataset);
+    const rdfXml = await serializeDatasetAsRdfXml(dataset);
+    const quads = await parseRdfXmlToQuads(rdfXml);
+
+    expect(turtle).toContain("healthdcatap:hasStructuredData");
+    expect(turtle).toContain("true");
+
+    const quad = quads.find(
+      (q) => q.predicate.value === HEALTH_HAS_STRUCTURED_DATA
+    );
+    expect(quad).toBeDefined();
+    expect(quad!.object.termType).toBe("Literal");
+    expect(quad!.object.value).toBe("true");
+    expect((quad!.object as any).datatype?.value).toBe(XSD_BOOLEAN);
+  });
+
+  test("emits hasStructuredData false as xsd:boolean literal in RDF/XML", async () => {
+    const XSD_BOOLEAN = "http://www.w3.org/2001/XMLSchema#boolean";
+    const HEALTH_HAS_STRUCTURED_DATA =
+      "http://healthdataportal.eu/ns/health#hasStructuredData";
+
+    const dataset = buildLocalDiscoveryDataset({
+      id: "https://example.org/datasets/export-1",
+      hasStructuredData: false,
+    });
+
+    const rdfXml = await serializeDatasetAsRdfXml(dataset);
+    const quads = await parseRdfXmlToQuads(rdfXml);
+
+    const quad = quads.find(
+      (q) => q.predicate.value === HEALTH_HAS_STRUCTURED_DATA
+    );
+    expect(quad).toBeDefined();
+    expect(quad!.object.termType).toBe("Literal");
+    expect(quad!.object.value).toBe("false");
+    expect((quad!.object as any).datatype?.value).toBe(XSD_BOOLEAN);
+  });
 });

--- a/src/app/api/discovery/harvester/dcat-dataset-mapper.ts
+++ b/src/app/api/discovery/harvester/dcat-dataset-mapper.ts
@@ -44,6 +44,8 @@ const HEALTHDCATAP_MAX_TYPICAL_AGE =
   "http://healthdataportal.eu/ns/health#maxTypicalAge"; // NOSONAR
 const HEALTHDCATAP_MIN_TYPICAL_AGE =
   "http://healthdataportal.eu/ns/health#minTypicalAge"; // NOSONAR
+const HEALTHDCATAP_HAS_STRUCTURED_DATA =
+  "http://healthdataportal.eu/ns/health#hasStructuredData"; // NOSONAR
 const HEALTHDCATAP_POPULATION_COVERAGE =
   "http://healthdataportal.eu/ns/health#populationCoverage"; // NOSONAR
 const DCAT_SPATIAL_RESOLUTION_IN_METERS =
@@ -141,6 +143,11 @@ export const mapDataset = (
       datasetSubject,
       graph,
       HEALTHDCATAP_MIN_TYPICAL_AGE
+    ),
+    hasStructuredData: extractBooleanLiteral(
+      datasetSubject,
+      graph,
+      HEALTHDCATAP_HAS_STRUCTURED_DATA
     ),
     spatialCoverage: extractSpatialCoverage(datasetSubject, graph),
     populationCoverage: extractPopulationCoverage(datasetSubject, graph),
@@ -288,6 +295,17 @@ const extractNumericLiteral = (
   if (!value) return undefined;
   const parsed = Number.parseInt(value, 10);
   return Number.isNaN(parsed) ? undefined : parsed;
+};
+
+const extractBooleanLiteral = (
+  datasetSubject: RDF.Term,
+  graph: RdfGraph,
+  predicate: string
+): boolean | undefined => {
+  const value = graph.getLiteral(datasetSubject, predicate);
+  if (value === "true") return true;
+  if (value === "false") return false;
+  return undefined;
 };
 
 const extractPopulationCoverage = (

--- a/src/app/api/discovery/harvester/rdf/context.ts
+++ b/src/app/api/discovery/harvester/rdf/context.ts
@@ -82,6 +82,9 @@ export const createDateTimeLiteral = (value: string) =>
 export const createDurationLiteral = (value: string) =>
   createLiteral(value, `${DATASET_EXPORT_PREFIXES.xsd}duration`);
 
+export const createBooleanLiteral = (value: boolean) =>
+  createLiteral(String(value), `${DATASET_EXPORT_PREFIXES.xsd}boolean`);
+
 export const addLiteral = (
   store: RdfStore,
   subject: RdfNamedNode,

--- a/src/app/api/discovery/harvester/rdf/mappers/dataset-coverage-quad-mapper.ts
+++ b/src/app/api/discovery/harvester/rdf/mappers/dataset-coverage-quad-mapper.ts
@@ -5,6 +5,7 @@
 import {
   DatasetRdfContext,
   addLiteral,
+  createBooleanLiteral,
   createDateTimeLiteral,
   createDecimalLiteral,
   createDurationLiteral,
@@ -46,6 +47,13 @@ export const addDatasetCoverageQuads = ({
       datasetNode,
       ns.health("minTypicalAge"),
       createNonNegativeIntegerLiteral(dataset.minTypicalAge)
+    );
+  }
+  if (typeof dataset.hasStructuredData === "boolean") {
+    store.add(
+      datasetNode,
+      ns.health("hasStructuredData"),
+      createBooleanLiteral(dataset.hasStructuredData)
     );
   }
 

--- a/src/app/api/discovery/local-index.ts
+++ b/src/app/api/discovery/local-index.ts
@@ -59,6 +59,7 @@ export const seedLocalIndexFromDdsApi = async (
         distributionsCount: dataset.distributionsCount,
         maxTypicalAge: dataset.maxTypicalAge,
         minTypicalAge: dataset.minTypicalAge,
+        hasStructuredData: dataset.hasStructuredData,
         publishers: dataset.publishers ?? [],
         hdab: [],
         creators: [],

--- a/src/app/api/discovery/local-store/opensearch/__tests__/queries.test.ts
+++ b/src/app/api/discovery/local-store/opensearch/__tests__/queries.test.ts
@@ -55,7 +55,12 @@ describe("opensearch/queries", () => {
           },
           isReferencedBy: { type: "keyword" },
           documentation: { type: "keyword" },
-          languages: { type: "keyword" },
+          languages: {
+            properties: {
+              value: { type: "keyword" },
+              label: { type: "keyword" },
+            },
+          },
           createdAt: { type: "date" },
           modifiedAt: { type: "date" },
           version: { type: "keyword" },
@@ -71,6 +76,7 @@ describe("opensearch/queries", () => {
           numberOfUniqueIndividuals: { type: "integer" },
           maxTypicalAge: { type: "integer" },
           minTypicalAge: { type: "integer" },
+          hasStructuredData: { type: "boolean" },
           populationCoverage: { type: "text" },
           spatialCoverage: { type: "object" },
           spatialResolutionInMeters: { type: "float" },

--- a/src/app/api/discovery/local-store/opensearch/queries.ts
+++ b/src/app/api/discovery/local-store/opensearch/queries.ts
@@ -368,7 +368,9 @@ export const createIndexMappings = () => ({
       },
       description: { type: "text" },
       catalogue: { type: "keyword" },
-      languages: { type: "keyword" },
+      languages: {
+        properties: { value: { type: "keyword" }, label: { type: "keyword" } },
+      },
       createdAt: { type: "date" },
       modifiedAt: { type: "date" },
       version: { type: "keyword" },
@@ -381,6 +383,7 @@ export const createIndexMappings = () => ({
       numberOfUniqueIndividuals: { type: "integer" },
       maxTypicalAge: { type: "integer" },
       minTypicalAge: { type: "integer" },
+      hasStructuredData: { type: "boolean" },
       populationCoverage: { type: "text" },
       spatialCoverage: { type: "object" },
       spatialResolutionInMeters: { type: "float" },

--- a/src/app/api/discovery/local-store/types.ts
+++ b/src/app/api/discovery/local-store/types.ts
@@ -70,6 +70,7 @@ export interface LocalDiscoveryDataset {
   numberOfUniqueIndividuals?: number;
   maxTypicalAge?: number;
   minTypicalAge?: number;
+  hasStructuredData?: boolean;
   populationCoverage?: string;
   spatialCoverage?: SpatialCoverage[];
   spatialResolutionInMeters?: number[];

--- a/src/app/api/discovery/providers/local-index-discovery-provider.ts
+++ b/src/app/api/discovery/providers/local-index-discovery-provider.ts
@@ -76,6 +76,7 @@ export class LocalIndexDiscoveryProvider extends BasePlaceholderDiscoveryProvide
       numberOfUniqueIndividuals: dataset.numberOfUniqueIndividuals,
       maxTypicalAge: dataset.maxTypicalAge,
       minTypicalAge: dataset.minTypicalAge,
+      hasStructuredData: dataset.hasStructuredData,
       themes: dataset.themes ?? [],
       keywords: dataset.keywords ?? [],
       conformsTo: dataset.conformsTo ?? [],

--- a/src/app/api/discovery/providers/types.ts
+++ b/src/app/api/discovery/providers/types.ts
@@ -91,6 +91,7 @@ export interface DiscoveryDatasetBase {
   numberOfUniqueIndividuals?: number;
   maxTypicalAge?: number;
   minTypicalAge?: number;
+  hasStructuredData?: boolean;
   temporalCoverage?: DiscoveryTimeWindow;
   populationCoverage?: string;
   spatialCoverage?: DiscoverySpatialCoverage[];


### PR DESCRIPTION
The logic to harvest hasStructuredData was missing.
in this pr:
1. harvesting for hasStructuredData
2. encoded into the RDF as boolean (according to healthDcat specification).
Here how it looks like:

`<healthdcatap:hasStructuredData rdf:datatype="http://www.w3.org/2001/XMLSchema#boolean">true</healthdcatap:hasStructuredData    >`

## Summary by Sourcery

Add support for harvesting the hasStructuredData flag and exposing it across RDF exports and the local discovery index.

New Features:
- Capture hasStructuredData from DCAT datasets and map it into the internal discovery dataset model.
- Include hasStructuredData as an xsd:boolean literal in RDF/XML and Turtle dataset coverage exports.
- Index hasStructuredData as a boolean field in the OpenSearch mappings for discovery datasets.

Enhancements:
- Extend language field mappings to store both value and label in the OpenSearch index.
- Add a reusable helper for creating xsd:boolean literals in the RDF context utilities.

Tests:
- Add RDF export tests verifying hasStructuredData is emitted as a typed xsd:boolean literal for true and false values.
- Update OpenSearch query tests to cover the new hasStructuredData field and the nested language mapping.