### PR TITLE
fix the hdab structure making as an instance of foaf:agent

### DIFF
--- a/src/app/api/discovery/harvester/__tests__/dcat-dataset-rdf-generator.test.ts
+++ b/src/app/api/discovery/harvester/__tests__/dcat-dataset-rdf-generator.test.ts
@@ -993,4 +993,106 @@ describe("DCAT dataset export generators", () => {
     expect(quad!.object.value).toBe("false");
     expect((quad!.object as any).datatype?.value).toBe(XSD_BOOLEAN);
   });
+
+  test("emits cv:contactPoint nested inside healthdcatap:hdab foaf:Agent node", async () => {
+    const CV_NS = "http://data.europa.eu/m8g/";
+    const VCARD_NS = "http://www.w3.org/2006/vcard/ns#";
+    const FOAF_NS = "http://xmlns.com/foaf/0.1/";
+    const HEALTH_HDAB = "http://healthdataportal.eu/ns/health#hdab";
+
+    const agentUri = "https://health.data.lu/hdab/luxembourg";
+    const contactName = "HDAB Contact Point";
+    const contactEmail = "hdab@health.lu";
+
+    const dataset = buildLocalDiscoveryDataset({
+      id: "https://example.org/datasets/export-1",
+      hdab: [
+        {
+          name: "Health Data Access Body Luxembourg",
+          uri: agentUri,
+          contactPoints: [{ name: contactName, email: contactEmail }],
+        },
+      ],
+    });
+
+    const turtle = await serializeDatasetAsTurtle(dataset);
+    const rdfXml = await serializeDatasetAsRdfXml(dataset);
+    const quads = await parseRdfXmlToQuads(rdfXml);
+
+    // Turtle should mention cv:contactPoint
+    expect(turtle).toContain("cv:contactPoint");
+    expect(turtle).toContain(contactName);
+    expect(turtle).toContain(contactEmail);
+
+    // RDF/XML should contain the cv:ContactPoint type element
+    expect(rdfXml).toContain("cv:contactPoint");
+
+    // The agent node should be typed as foaf:Organization
+    const agentTypeQuad = quads.find(
+      (q) =>
+        q.subject.value === agentUri &&
+        q.predicate.value ===
+          "http://www.w3.org/1999/02/22-rdf-syntax-ns#type" &&
+        q.object.value === `${FOAF_NS}Organization`
+    );
+    expect(agentTypeQuad).toBeDefined();
+
+    // The dataset should have a healthdcatap:hdab triple pointing to the agent
+    const hdabQuad = quads.find(
+      (q) => q.predicate.value === HEALTH_HDAB && q.object.value === agentUri
+    );
+    expect(hdabQuad).toBeDefined();
+
+    // There should be a cv:contactPoint triple from the agent node
+    const cpQuad = quads.find(
+      (q) =>
+        q.subject.value === agentUri &&
+        q.predicate.value === `${CV_NS}contactPoint`
+    );
+    expect(cpQuad).toBeDefined();
+    const cpNodeUri = cpQuad!.object.value;
+
+    // The contact point node should be typed as cv:ContactPoint (primary) and vcard:Kind (secondary)
+    const cpTypeQuad = quads.find(
+      (q) =>
+        q.subject.value === cpNodeUri &&
+        q.predicate.value ===
+          "http://www.w3.org/1999/02/22-rdf-syntax-ns#type" &&
+        q.object.value === `${CV_NS}ContactPoint`
+    );
+    expect(cpTypeQuad).toBeDefined();
+    const cpKindTypeQuad = quads.find(
+      (q) =>
+        q.subject.value === cpNodeUri &&
+        q.predicate.value ===
+          "http://www.w3.org/1999/02/22-rdf-syntax-ns#type" &&
+        q.object.value === `${VCARD_NS}Kind`
+    );
+    expect(cpKindTypeQuad).toBeDefined();
+
+    // The contact point should have vcard:fn with the contact name
+    const fnQuad = quads.find(
+      (q) =>
+        q.subject.value === cpNodeUri && q.predicate.value === `${VCARD_NS}fn`
+    );
+    expect(fnQuad).toBeDefined();
+    expect(fnQuad!.object.value).toBe(contactName);
+
+    // The contact point should have vcard:hasEmail pointing to a mailto: URI
+    const hasEmailQuad = quads.find(
+      (q) =>
+        q.subject.value === cpNodeUri &&
+        q.predicate.value === `${VCARD_NS}hasEmail`
+    );
+    expect(hasEmailQuad).toBeDefined();
+    expect(hasEmailQuad!.object.value).toBe(`mailto:${contactEmail}`);
+
+    // The contact point should have cv:email with the raw email string
+    const cvEmailQuad = quads.find(
+      (q) =>
+        q.subject.value === cpNodeUri && q.predicate.value === `${CV_NS}email`
+    );
+    expect(cvEmailQuad).toBeDefined();
+    expect(cvEmailQuad!.object.value).toBe(contactEmail);
+  });
 });

--- a/src/app/api/discovery/harvester/__tests__/dcat-dataset-rdf-generator.test.ts
+++ b/src/app/api/discovery/harvester/__tests__/dcat-dataset-rdf-generator.test.ts
@@ -1095,4 +1095,37 @@ describe("DCAT dataset export generators", () => {
     expect(cvEmailQuad).toBeDefined();
     expect(cvEmailQuad!.object.value).toBe(contactEmail);
   });
+
+  test("emits healthdcatap:hdab agent typed as foaf:Organization and publishers as foaf:Agent", async () => {
+    const FOAF_NS = "http://xmlns.com/foaf/0.1/";
+    const publisherUri = "https://example.org/publisher/1";
+    const hdabUri = "https://example.org/hdab/1";
+
+    const dataset = buildLocalDiscoveryDataset({
+      id: "https://example.org/datasets/export-1",
+      publishers: [{ name: "Publisher One", uri: publisherUri }],
+      hdab: [{ name: "HDAB One", uri: hdabUri }],
+    });
+
+    const rdfXml = await serializeDatasetAsRdfXml(dataset);
+    const quads = await parseRdfXmlToQuads(rdfXml);
+
+    const publisherTypeQuad = quads.find(
+      (q) =>
+        q.subject.value === publisherUri &&
+        q.predicate.value ===
+          "http://www.w3.org/1999/02/22-rdf-syntax-ns#type" &&
+        q.object.value === `${FOAF_NS}Agent`
+    );
+    expect(publisherTypeQuad).toBeDefined();
+
+    const hdabTypeQuad = quads.find(
+      (q) =>
+        q.subject.value === hdabUri &&
+        q.predicate.value ===
+          "http://www.w3.org/1999/02/22-rdf-syntax-ns#type" &&
+        q.object.value === `${FOAF_NS}Organization`
+    );
+    expect(hdabTypeQuad).toBeDefined();
+  });
 });

--- a/src/app/api/discovery/harvester/__tests__/dcat-dataset-rdf-shared.test.ts
+++ b/src/app/api/discovery/harvester/__tests__/dcat-dataset-rdf-shared.test.ts
@@ -69,6 +69,7 @@ describe("dcat dataset rdf shared helpers", () => {
       vcard: "http://www.w3.org/2006/vcard/ns#",
       xsd: "http://www.w3.org/2001/XMLSchema#",
       eli: "http://data.europa.eu/eli/ontology#",
+      cv: "http://data.europa.eu/m8g/",
     });
   });
 });

--- a/src/app/api/discovery/harvester/__tests__/dcat-harvester-service.test.ts
+++ b/src/app/api/discovery/harvester/__tests__/dcat-harvester-service.test.ts
@@ -81,6 +81,9 @@ describe("DcatHarvesterService", () => {
             name: "Health Data Access Body Luxembourg",
             email: "hdab@health.lu",
             uri: "https://health.data.lu/hdab/luxembourg",
+            contactPoints: [
+              { name: "HDAB Contact Point", email: "hdab@health.lu" },
+            ],
           },
         ],
         creators: [

--- a/src/app/api/discovery/harvester/dcat-dataset-mapper.ts
+++ b/src/app/api/discovery/harvester/dcat-dataset-mapper.ts
@@ -74,6 +74,10 @@ const DCT_PUBLISHER = "http://purl.org/dc/terms/publisher"; // NOSONAR
 const DCT_CREATOR = "http://purl.org/dc/terms/creator"; // NOSONAR
 const FOAF_NAME = "http://xmlns.com/foaf/0.1/name"; // NOSONAR
 const FOAF_MBOX = "http://xmlns.com/foaf/0.1/mbox"; // NOSONAR
+const CV_CONTACT_POINT = "http://data.europa.eu/m8g/contactPoint"; // NOSONAR
+const CV_EMAIL = "http://data.europa.eu/m8g/email"; // NOSONAR
+const VCARD_FN = "http://www.w3.org/2006/vcard/ns#fn"; // NOSONAR
+const VCARD_HAS_EMAIL = "http://www.w3.org/2006/vcard/ns#hasEmail"; // NOSONAR
 const FOAF_HOMEPAGE = "http://xmlns.com/foaf/0.1/homepage"; // NOSONAR
 const FOAF_URL = "http://xmlns.com/foaf/0.1/workInfoHomepage"; // NOSONAR
 const HEALTHDCATAP_HDAB = "http://healthdataportal.eu/ns/health#hdab"; // NOSONAR
@@ -567,6 +571,29 @@ const extractAgent = (
     }
   }
 
+  // cv:contactPoint → extract name and email
+  const contactPointObjects = graph.getObjects(agentSubject, CV_CONTACT_POINT);
+  const contactPoints =
+    contactPointObjects.length > 0
+      ? contactPointObjects
+          .map((cp) => {
+            const cpName = graph.getLiteral(cp, VCARD_FN) || undefined;
+            const hasEmailObjects = graph.getObjects(cp, VCARD_HAS_EMAIL);
+            const rawHasEmail = hasEmailObjects[0]?.value?.trim() ?? "";
+            const cpEmail =
+              (rawHasEmail.startsWith("mailto:")
+                ? rawHasEmail.slice("mailto:".length)
+                : rawHasEmail) ||
+              graph.getLiteral(cp, CV_EMAIL) ||
+              undefined;
+            return {
+              ...(cpName && { name: cpName }),
+              ...(cpEmail && { email: cpEmail }),
+            };
+          })
+          .filter((cp) => cp.name || cp.email)
+      : undefined;
+
   return {
     name,
     ...(email && { email }),
@@ -575,6 +602,7 @@ const extractAgent = (
     ...(homepage && { homepage }),
     ...(type && { type }),
     ...(identifier && { identifier }),
+    ...(contactPoints?.length && { contactPoints }),
   };
 };
 

--- a/src/app/api/discovery/harvester/dcat-dataset-rdf-shared.ts
+++ b/src/app/api/discovery/harvester/dcat-dataset-rdf-shared.ts
@@ -21,6 +21,7 @@ export const DATASET_EXPORT_PREFIXES = {
   vcard: "http://www.w3.org/2006/vcard/ns#", // NOSONAR
   xsd: "http://www.w3.org/2001/XMLSchema#", // NOSONAR
   eli: "http://data.europa.eu/eli/ontology#", // NOSONAR
+  cv: "http://data.europa.eu/m8g/", // NOSONAR
 } as const;
 
 export const escapeXml = (value: string): string =>

--- a/src/app/api/discovery/harvester/rdf/context.ts
+++ b/src/app/api/discovery/harvester/rdf/context.ts
@@ -37,6 +37,7 @@ export const ns = {
   vcard: rdf.Namespace(DATASET_EXPORT_PREFIXES.vcard),
   xsd: rdf.Namespace(DATASET_EXPORT_PREFIXES.xsd),
   eli: rdf.Namespace(DATASET_EXPORT_PREFIXES.eli),
+  cv: rdf.Namespace(DATASET_EXPORT_PREFIXES.cv),
 } as const;
 
 export const createDatasetRdfContext = (

--- a/src/app/api/discovery/harvester/rdf/mappers/dataset-agent-quad-mapper.ts
+++ b/src/app/api/discovery/harvester/rdf/mappers/dataset-agent-quad-mapper.ts
@@ -7,9 +7,11 @@ import {
   addConcept,
   addLiteral,
   addNamedNode,
+  createLanguageLiteral,
   createLiteral,
   createNamedNode,
   createNestedNode,
+  isNonEmptyString,
   ns,
   toMailtoUri,
 } from "@/app/api/discovery/harvester/rdf/context";
@@ -18,9 +20,11 @@ const addAgents = (
   context: DatasetRdfContext,
   predicate: any,
   segment: string,
-  agents: DatasetRdfContext["dataset"]["publishers"]
+  agents: DatasetRdfContext["dataset"]["publishers"],
+  agentRdfType?: any
 ) => {
   const { store, datasetNode } = context;
+  const typeNode = agentRdfType ?? ns.foaf("Agent");
 
   agents.forEach((agent, index) => {
     const node = agent.uri
@@ -28,8 +32,14 @@ const addAgents = (
       : createNestedNode(context, `${segment}-${index + 1}`);
 
     store.add(datasetNode, predicate, node);
-    store.add(node, ns.rdf("type"), ns.foaf("Agent"));
-    store.add(node, ns.foaf("name"), createLiteral(agent.name));
+    store.add(node, ns.rdf("type"), typeNode);
+    if (isNonEmptyString(agent.name)) {
+      store.add(
+        node,
+        ns.foaf("name"),
+        createLanguageLiteral(agent.name, "eng")
+      );
+    }
     addNamedNode(store, node, ns.foaf("workInfoHomepage"), agent.url);
     addNamedNode(store, node, ns.foaf("homepage"), agent.homepage);
     addNamedNode(store, node, ns.foaf("mbox"), toMailtoUri(agent.email));
@@ -43,6 +53,28 @@ const addAgents = (
         agent.type.label
       );
     }
+
+    agent.contactPoints?.forEach((cp, cpIndex) => {
+      const cpNode = createNestedNode(
+        context,
+        `${segment}-${index + 1}-contact-point-${cpIndex + 1}`
+      );
+      store.add(node, ns.cv("contactPoint"), cpNode);
+      store.add(cpNode, ns.rdf("type"), ns.cv("ContactPoint"));
+      store.add(cpNode, ns.rdf("type"), ns.vcard("Kind"));
+      if (isNonEmptyString(cp.name)) {
+        store.add(cpNode, ns.vcard("fn"), createLiteral(cp.name));
+      }
+      if (isNonEmptyString(cp.email)) {
+        addNamedNode(
+          store,
+          cpNode,
+          ns.vcard("hasEmail"),
+          toMailtoUri(cp.email)
+        );
+        store.add(cpNode, ns.cv("email"), createLiteral(cp.email));
+      }
+    });
   });
 };
 
@@ -53,6 +85,12 @@ export const addDatasetAgentQuads = (context: DatasetRdfContext): void => {
     "publisher",
     context.dataset.publishers
   );
-  addAgents(context, ns.health("hdab"), "hdab", context.dataset.hdab);
+  addAgents(
+    context,
+    ns.health("hdab"),
+    "hdab",
+    context.dataset.hdab,
+    ns.foaf("Organization")
+  );
   addAgents(context, ns.dct("creator"), "creator", context.dataset.creators);
 };

--- a/src/app/api/discovery/local-store/types.ts
+++ b/src/app/api/discovery/local-store/types.ts
@@ -19,6 +19,7 @@ export interface LocalAgent {
   type?: { value: string; label: string };
   identifier?: string;
   actedOnBehalfOf?: LocalAgent[];
+  contactPoints?: Array<{ name?: string; email?: string }>;
 }
 
 export interface LocalDiscoveryDistribution {

--- a/src/app/api/discovery/test-utils/fixtures.ts
+++ b/src/app/api/discovery/test-utils/fixtures.ts
@@ -17,7 +17,8 @@ export const canonicalDiscoveryRdf = `
            xmlns:dpv="http://www.w3.org/ns/dpv#"
            xmlns:csvw="http://www.w3.org/ns/csvw#"
            xmlns:foaf="http://xmlns.com/foaf/0.1/"
-           xmlns:vcard="http://www.w3.org/2006/vcard/ns#">
+           xmlns:vcard="http://www.w3.org/2006/vcard/ns#"
+           xmlns:cv="http://data.europa.eu/m8g/">
     <dcat:Catalog rdf:about="https://example.org/catalogues/main">
       <dct:title>Main Catalogue</dct:title>
     </dcat:Catalog>
@@ -162,6 +163,14 @@ export const canonicalDiscoveryRdf = `
         <foaf:Agent rdf:about="https://health.data.lu/hdab/luxembourg">
           <foaf:name xml:lang="eng">Health Data Access Body Luxembourg</foaf:name>
           <foaf:mbox rdf:resource="mailto:hdab@health.lu"/>
+          <cv:contactPoint>
+            <cv:ContactPoint rdf:nodeID="NhdabContactPoint1">
+              <rdf:type rdf:resource="http://www.w3.org/2006/vcard/ns#Kind"/>
+              <vcard:fn>HDAB Contact Point</vcard:fn>
+              <vcard:hasEmail rdf:resource="mailto:hdab@health.lu"/>
+              <cv:email>hdab@health.lu</cv:email>
+            </cv:ContactPoint>
+          </cv:contactPoint>
         </foaf:Agent>
       </healthdcatap:hdab>
       <dct:creator>


### PR DESCRIPTION
Fix the structure Agent that is used in the hdab field, to be encoded this way:

```
<healthdcatap:hdab>
  <foaf:Organization rdf:nodeID="...">
    <foaf:name xml:lang="eng">Health Data Access Body Luxembourg</foaf:name>
    <cv:contactPoint>
      <cv:ContactPoint rdf:nodeID="...">
        <rdf:type rdf:resource="http://www.w3.org/2006/vcard/ns#Kind"/>
        <vcard:fn>HDAB Contact Point</vcard:fn>
        <vcard:hasEmail rdf:resource="mailto:hdab@health.lu"/>
        <cv:email>hdab@health.lu</cv:email>
      </cv:ContactPoint>
    </cv:contactPoint>
  </foaf:Organization>
</healthdcatap:hdab>
```

## Summary by Sourcery

Encode HDAB agents as foaf:Organization with nested cv:ContactPoint contact details and support round-tripping of this structure through the DCAT mapper.

New Features:
- Support contact point metadata (name and email) on local agents and expose it in exported RDF via cv:ContactPoint and vcard properties.

Enhancements:
- Type HDAB agents as foaf:Organization instead of generic foaf:Agent and emit foaf:name as a language-tagged literal.
- Extend RDF prefixes and namespaces to include the Core Public Service Vocabulary (cv) for contact point modeling.

Tests:
- Add RDF/XML and Turtle export tests ensuring HDAB agents include cv:contactPoint nodes with correct foaf, vcard, and cv properties, and that the DCAT mapper can parse them back into local agent contactPoints.