### PR TITLE
fix: add applicable legislation in distribution

### DIFF
--- a/src/app/api/discovery/harvester/__tests__/dcat-dataset-rdf-generator.test.ts
+++ b/src/app/api/discovery/harvester/__tests__/dcat-dataset-rdf-generator.test.ts
@@ -1128,4 +1128,78 @@ describe("DCAT dataset export generators", () => {
     );
     expect(hdabTypeQuad).toBeDefined();
   });
+
+  test("emits distribution applicableLegislation as nested eli:LegalResource element in RDF/XML", async () => {
+    const legislationUri =
+      "http://data.legilux.public.lu/eli/etat/leg/rgd/2022/04/07/a180/jo";
+    const ELI_LEGAL_RESOURCE =
+      "http://data.europa.eu/eli/ontology#LegalResource";
+    const DCATAP_APPLICABLE_LEGISLATION =
+      "http://data.europa.eu/r5r/applicableLegislation";
+
+    const dataset = buildLocalDiscoveryDataset({
+      id: "https://example.org/datasets/export-1",
+      distributions: [
+        {
+          id: "distribution-1",
+          title: "Test Distribution",
+          applicableLegislation: [
+            { value: legislationUri, label: "RGD 2022/04/07" },
+          ],
+        },
+      ],
+    });
+
+    const turtle = await serializeDatasetAsTurtle(dataset);
+    const rdfXml = await serializeDatasetAsRdfXml(dataset);
+    const quads = await parseRdfXmlToQuads(rdfXml);
+
+    // Turtle should mention applicableLegislation and the URI
+    expect(turtle).toContain("dcatap:applicableLegislation");
+    expect(turtle).toContain(legislationUri);
+    expect(turtle).toContain('"RGD 2022/04/07"@eng');
+
+    // RDF/XML should contain the eli:LegalResource element
+    expect(rdfXml).toContain(
+      `<eli:LegalResource rdf:about="${legislationUri}">`
+    );
+    expect(rdfXml).toContain(
+      `<rdfs:label xml:lang="eng">RGD 2022/04/07</rdfs:label>`
+    );
+
+    // The distribution node should have a dcatap:applicableLegislation triple
+    const distributionUri = quads.find(
+      (q) =>
+        q.predicate.value ===
+          "http://www.w3.org/1999/02/22-rdf-syntax-ns#type" &&
+        q.object.value === "http://www.w3.org/ns/dcat#Distribution"
+    )?.subject.value;
+    expect(distributionUri).toBeDefined();
+
+    const legislationQuad = quads.find(
+      (q) =>
+        q.subject.value === distributionUri &&
+        q.predicate.value === DCATAP_APPLICABLE_LEGISLATION &&
+        q.object.value === legislationUri
+    );
+    expect(legislationQuad).toBeDefined();
+
+    // The legislation node should be typed as eli:LegalResource
+    const typeQuad = quads.find(
+      (q) =>
+        q.subject.value === legislationUri &&
+        q.predicate.value ===
+          "http://www.w3.org/1999/02/22-rdf-syntax-ns#type" &&
+        q.object.value === ELI_LEGAL_RESOURCE
+    );
+    expect(typeQuad).toBeDefined();
+
+    // The legislation node should have an rdfs:label
+    const labelQuad = quads.find(
+      (q) =>
+        q.subject.value === legislationUri &&
+        q.predicate.value === "http://www.w3.org/2000/01/rdf-schema#label"
+    );
+    expect(labelQuad?.object.value).toBe("RGD 2022/04/07");
+  });
 });

--- a/src/app/api/discovery/harvester/__tests__/dcat-harvester-service.test.ts
+++ b/src/app/api/discovery/harvester/__tests__/dcat-harvester-service.test.ts
@@ -242,6 +242,13 @@ describe("DcatHarvesterService", () => {
                 label: "standard-1",
               },
             ],
+            applicableLegislation: [
+              {
+                value:
+                  "http://data.legilux.public.lu/eli/etat/leg/rgd/2022/04/07/a180/jo",
+                label: "jo",
+              },
+            ],
             byteSize: 2048,
             accessUrl: "https://example.org/access/population-registry",
             downloadUrl: "https://example.org/download/population-registry.csv",

--- a/src/app/api/discovery/harvester/dcat-distribution-mapper.ts
+++ b/src/app/api/discovery/harvester/dcat-distribution-mapper.ts
@@ -20,6 +20,8 @@ const DCT_FORMAT = "http://purl.org/dc/terms/format"; // NOSONAR
 const DCAT_MEDIA_TYPE = "http://www.w3.org/ns/dcat#mediaType"; // NOSONAR
 const DCT_LICENSE = "http://purl.org/dc/terms/license"; // NOSONAR
 const DCT_CONFORMS_TO = "http://purl.org/dc/terms/conformsTo"; // NOSONAR
+const DCATAP_APPLICABLE_LEGISLATION =
+  "http://data.europa.eu/r5r/applicableLegislation"; // NOSONAR
 const DCAT_BYTE_SIZE = "http://www.w3.org/ns/dcat#byteSize"; // NOSONAR
 const SKOS_PREF_LABEL = "http://www.w3.org/2004/02/skos/core#prefLabel"; // NOSONAR
 const RDFS_LABEL = "http://www.w3.org/2000/01/rdf-schema#label"; // NOSONAR
@@ -87,6 +89,10 @@ const mapDistribution = (
     mediaType: getDistributionMediaType(distributionSubject, graph),
     license: getDistributionLicense(distributionSubject, graph),
     conformsTo: getDistributionConformsTo(distributionSubject, graph),
+    applicableLegislation: getDistributionApplicableLegislation(
+      distributionSubject,
+      graph
+    ),
     byteSize: getDistributionByteSize(distributionSubject, graph),
     accessUrl,
     downloadUrl,
@@ -214,6 +220,31 @@ const getDistributionConformsTo = (
   graph: RdfGraph
 ): LocalDiscoveryDistribution["conformsTo"] => {
   const objects = graph.getObjects(distributionSubject, DCT_CONFORMS_TO);
+  if (!objects.length) return undefined;
+
+  const result = objects
+    .map((obj) => {
+      const value = graph.getNamedNodeValue(obj) || obj.value.trim();
+      if (!value) return null;
+      const label =
+        graph.getFirstLiteral(obj, [SKOS_PREF_LABEL, RDFS_LABEL]) ||
+        value.split("/").pop() ||
+        value;
+      return { value, label };
+    })
+    .filter((item): item is { value: string; label: string } => item !== null);
+
+  return result.length > 0 ? result : undefined;
+};
+
+const getDistributionApplicableLegislation = (
+  distributionSubject: RDF.Term,
+  graph: RdfGraph
+): LocalDiscoveryDistribution["applicableLegislation"] => {
+  const objects = graph.getObjects(
+    distributionSubject,
+    DCATAP_APPLICABLE_LEGISLATION
+  );
   if (!objects.length) return undefined;
 
   const result = objects

--- a/src/app/api/discovery/harvester/dcat-distribution-mapper.ts
+++ b/src/app/api/discovery/harvester/dcat-distribution-mapper.ts
@@ -215,11 +215,12 @@ const getDistributionLicense = (
   return { value, label };
 };
 
-const getDistributionConformsTo = (
+const getDistributionValueLabelArray = (
   distributionSubject: RDF.Term,
-  graph: RdfGraph
-): LocalDiscoveryDistribution["conformsTo"] => {
-  const objects = graph.getObjects(distributionSubject, DCT_CONFORMS_TO);
+  graph: RdfGraph,
+  predicate: string
+): Array<{ value: string; label: string }> | undefined => {
+  const objects = graph.getObjects(distributionSubject, predicate);
   if (!objects.length) return undefined;
 
   const result = objects
@@ -236,31 +237,22 @@ const getDistributionConformsTo = (
 
   return result.length > 0 ? result : undefined;
 };
+
+const getDistributionConformsTo = (
+  distributionSubject: RDF.Term,
+  graph: RdfGraph
+): LocalDiscoveryDistribution["conformsTo"] =>
+  getDistributionValueLabelArray(distributionSubject, graph, DCT_CONFORMS_TO);
 
 const getDistributionApplicableLegislation = (
   distributionSubject: RDF.Term,
   graph: RdfGraph
-): LocalDiscoveryDistribution["applicableLegislation"] => {
-  const objects = graph.getObjects(
+): LocalDiscoveryDistribution["applicableLegislation"] =>
+  getDistributionValueLabelArray(
     distributionSubject,
+    graph,
     DCATAP_APPLICABLE_LEGISLATION
   );
-  if (!objects.length) return undefined;
-
-  const result = objects
-    .map((obj) => {
-      const value = graph.getNamedNodeValue(obj) || obj.value.trim();
-      if (!value) return null;
-      const label =
-        graph.getFirstLiteral(obj, [SKOS_PREF_LABEL, RDFS_LABEL]) ||
-        value.split("/").pop() ||
-        value;
-      return { value, label };
-    })
-    .filter((item): item is { value: string; label: string } => item !== null);
-
-  return result.length > 0 ? result : undefined;
-};
 
 const getDistributionByteSize = (
   distributionSubject: RDF.Term,

--- a/src/app/api/discovery/harvester/rdf/mappers/dataset-distribution-quad-mapper.ts
+++ b/src/app/api/discovery/harvester/rdf/mappers/dataset-distribution-quad-mapper.ts
@@ -90,6 +90,25 @@ export const addDatasetDistributionQuads = ({
       }
     });
 
+    distribution.applicableLegislation?.forEach((entry) => {
+      if (isNonEmptyString(entry.value) && isAbsoluteUri(entry.value)) {
+        const legislationNode = createNamedNode(entry.value);
+        store.add(
+          distributionNode,
+          ns.dcatap("applicableLegislation"),
+          legislationNode
+        );
+        store.add(legislationNode, ns.rdf("type"), ns.eli("LegalResource"));
+        if (isNonEmptyString(entry.label)) {
+          store.add(
+            legislationNode,
+            ns.rdfs("label"),
+            createLanguageLiteral(entry.label, "eng")
+          );
+        }
+      }
+    });
+
     if (distribution.byteSize !== undefined) {
       store.add(
         distributionNode,

--- a/src/app/api/discovery/local-store/types.ts
+++ b/src/app/api/discovery/local-store/types.ts
@@ -30,6 +30,7 @@ export interface LocalDiscoveryDistribution {
   mediaType?: { value: string; label: string };
   license?: { value: string; label: string };
   conformsTo?: Array<{ value: string; label: string }>;
+  applicableLegislation?: Array<{ value: string; label: string }>;
   byteSize?: number;
   accessUrl?: string;
   downloadUrl?: string;

--- a/src/app/api/discovery/providers/local-index-discovery-provider.ts
+++ b/src/app/api/discovery/providers/local-index-discovery-provider.ts
@@ -110,6 +110,7 @@ export class LocalIndexDiscoveryProvider extends BasePlaceholderDiscoveryProvide
       mediaType: distribution.mediaType,
       license: distribution.license,
       conformsTo: distribution.conformsTo,
+      applicableLegislation: distribution.applicableLegislation,
       byteSize: distribution.byteSize,
       accessUrl: distribution.accessUrl,
       downloadUrl: distribution.downloadUrl,

--- a/src/app/api/discovery/test-utils/fixtures.ts
+++ b/src/app/api/discovery/test-utils/fixtures.ts
@@ -18,7 +18,8 @@ export const canonicalDiscoveryRdf = `
            xmlns:csvw="http://www.w3.org/ns/csvw#"
            xmlns:foaf="http://xmlns.com/foaf/0.1/"
            xmlns:vcard="http://www.w3.org/2006/vcard/ns#"
-           xmlns:cv="http://data.europa.eu/m8g/">
+           xmlns:cv="http://data.europa.eu/m8g/"
+           xmlns:r5r="http://data.europa.eu/r5r/">
     <dcat:Catalog rdf:about="https://example.org/catalogues/main">
       <dct:title>Main Catalogue</dct:title>
     </dcat:Catalog>
@@ -211,6 +212,7 @@ export const canonicalDiscoveryRdf = `
             </dct:LicenseDocument>
           </dct:license>
           <dct:conformsTo rdf:resource="https://example.org/spec/standard-1" />
+          <r5r:applicableLegislation rdf:resource="http://data.legilux.public.lu/eli/etat/leg/rgd/2022/04/07/a180/jo"/>
           <dcat:byteSize rdf:datatype="http://www.w3.org/2001/XMLSchema#nonNegativeInteger">2048</dcat:byteSize>
           <dcat:accessURL rdf:resource="https://example.org/access/population-registry" />
           <dcat:downloadURL rdf:resource="https://example.org/download/population-registry.csv" />


### PR DESCRIPTION
ApplicableLegislation is now added to the distribution too.

## Summary by Sourcery

Add support for mapping distribution-level applicable legislation from DCAT into the local discovery model and RDF exports.

New Features:
- Expose applicableLegislation on LocalDiscoveryDistribution and propagate it through the local index discovery provider.
- Include distribution applicableLegislation in generated RDF Turtle and RDF/XML as eli:LegalResource resources with labels.

Tests:
- Add unit tests and fixtures verifying distribution applicableLegislation is parsed from DCAT, stored locally, and emitted correctly in RDF Turtle and RDF/XML.