### PR TITLE
feat(ga4gh): implement GA4GH Passport/Visa-based entitlement listing …

### DIFF
--- a/jest.config.js
+++ b/jest.config.js
@@ -19,6 +19,7 @@ module.exports = {
   },
   moduleNameMapper: {
     "^@/(.*)$": "<rootDir>/src/$1",
+    "^server-only$": "<rootDir>/src/__mocks__/server-only.ts",
   },
   transformIgnorePatterns: ["/node_modules/(?!(iso-639-3)/)"],
   testPathIgnorePatterns: [

--- a/package-lock.json
+++ b/package-lock.json
@@ -61,6 +61,7 @@
         "rehype-raw": "^7.0.0",
         "rehype-slug": "^6.0.0",
         "remark-gfm": "^4.0.0",
+        "server-only": "^0.0.1",
         "sharp": "^0.35.0",
         "tailwind-merge": "^3.0.0",
         "tailwindcss-animate": "^1.0.7",
@@ -14220,17 +14221,6 @@
         }
       }
     },
-    "node_modules/next-intl/node_modules/@swc/helpers": {
-      "version": "0.5.23",
-      "resolved": "https://registry.npmjs.org/@swc/helpers/-/helpers-0.5.23.tgz",
-      "integrity": "sha512-5lSsMOTXURePglDfvuAQUqkGek9Hg2kksOYay2m0+XR++b2NWYL/4sWyuvVBIs8oKnJaxkdi9whaL/sqN13afw==",
-      "license": "Apache-2.0",
-      "optional": true,
-      "peer": true,
-      "dependencies": {
-        "tslib": "^2.8.0"
-      }
-    },
     "node_modules/next-intl/node_modules/negotiator": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/negotiator/-/negotiator-1.0.0.tgz",
@@ -16563,6 +16553,12 @@
         "node": ">=10"
       }
     },
+    "node_modules/server-only": {
+      "version": "0.0.1",
+      "resolved": "https://registry.npmjs.org/server-only/-/server-only-0.0.1.tgz",
+      "integrity": "sha512-qepMx2JxAa5jjfzxG79yPPq+8BuFToHd1hm7kI+Z4zAq1ftQiP7HcxMhDDItrbtwVeLg/cY2JnKnrcFkmiswNA==",
+      "license": "MIT"
+    },
     "node_modules/set-function-length": {
       "version": "1.2.2",
       "dev": true,
@@ -18502,111 +18498,6 @@
       "funding": {
         "type": "github",
         "url": "https://github.com/sponsors/wooorm"
-      }
-    },
-    "node_modules/next-runtime-env/node_modules/@next/swc-darwin-x64": {
-      "version": "16.2.10",
-      "resolved": "https://registry.npmjs.org/@next/swc-darwin-x64/-/swc-darwin-x64-16.2.10.tgz",
-      "integrity": "sha512-17IS0jJRViROGmA9uGdNR8VPJpfbnaVG7E9qhso5jDLkmyd0lSDORWxbcKINzcFqzZqGwGtMSnrFRxBpuUYjLQ==",
-      "cpu": [
-        "x64"
-      ],
-      "optional": true,
-      "os": [
-        "darwin"
-      ],
-      "engines": {
-        "node": ">= 10"
-      }
-    },
-    "node_modules/next-runtime-env/node_modules/@next/swc-linux-arm64-gnu": {
-      "version": "16.2.10",
-      "resolved": "https://registry.npmjs.org/@next/swc-linux-arm64-gnu/-/swc-linux-arm64-gnu-16.2.10.tgz",
-      "integrity": "sha512-GRQRsRtuciNJvB54AvvuQTiq0oZtFwa1owQqtZD8wwnGpM2L39MV22kpI72YSXLKIyY40LC66EiLFv4PiicXxg==",
-      "cpu": [
-        "arm64"
-      ],
-      "optional": true,
-      "os": [
-        "linux"
-      ],
-      "engines": {
-        "node": ">= 10"
-      }
-    },
-    "node_modules/next-runtime-env/node_modules/@next/swc-linux-arm64-musl": {
-      "version": "16.2.10",
-      "resolved": "https://registry.npmjs.org/@next/swc-linux-arm64-musl/-/swc-linux-arm64-musl-16.2.10.tgz",
-      "integrity": "sha512-zkN9MQYS7UQBro+FnISUq1itaQjXI9xqISzuQ+2bc921NcJ1x4yPCqrn77tVN6/dOOXaaWVX3k6/bR07pPwK+A==",
-      "cpu": [
-        "arm64"
-      ],
-      "optional": true,
-      "os": [
-        "linux"
-      ],
-      "engines": {
-        "node": ">= 10"
-      }
-    },
-    "node_modules/next-runtime-env/node_modules/@next/swc-linux-x64-gnu": {
-      "version": "16.2.10",
-      "resolved": "https://registry.npmjs.org/@next/swc-linux-x64-gnu/-/swc-linux-x64-gnu-16.2.10.tgz",
-      "integrity": "sha512-iCVJnwvrPYECvA6WM/7+oo+OiTvedIKLxtCLAZP4xZR3nXa1zmzZyLPbYCmWvpd4CvMYF1EMTafd0ii3DygLvA==",
-      "cpu": [
-        "x64"
-      ],
-      "optional": true,
-      "os": [
-        "linux"
-      ],
-      "engines": {
-        "node": ">= 10"
-      }
-    },
-    "node_modules/next-runtime-env/node_modules/@next/swc-linux-x64-musl": {
-      "version": "16.2.10",
-      "resolved": "https://registry.npmjs.org/@next/swc-linux-x64-musl/-/swc-linux-x64-musl-16.2.10.tgz",
-      "integrity": "sha512-ov2g4H0dHY9bPoOU83m91hWT7Iq5qy13bUnyyshLU3HGR1Ownn0X9QpmDPc5iIUaahTp7f7LeGAhV4DSFtackw==",
-      "cpu": [
-        "x64"
-      ],
-      "optional": true,
-      "os": [
-        "linux"
-      ],
-      "engines": {
-        "node": ">= 10"
-      }
-    },
-    "node_modules/next-runtime-env/node_modules/@next/swc-win32-arm64-msvc": {
-      "version": "16.2.10",
-      "resolved": "https://registry.npmjs.org/@next/swc-win32-arm64-msvc/-/swc-win32-arm64-msvc-16.2.10.tgz",
-      "integrity": "sha512-DwAnhLX76HQiFFQNgWlcK+JzlnD1rZ+UK/WY0ZMI/deXpvgnesjNYrqcfo1JzBuz4Kf7o3brIBL0glI1junatA==",
-      "cpu": [
-        "arm64"
-      ],
-      "optional": true,
-      "os": [
-        "win32"
-      ],
-      "engines": {
-        "node": ">= 10"
-      }
-    },
-    "node_modules/next-runtime-env/node_modules/@next/swc-win32-x64-msvc": {
-      "version": "16.2.10",
-      "resolved": "https://registry.npmjs.org/@next/swc-win32-x64-msvc/-/swc-win32-x64-msvc-16.2.10.tgz",
-      "integrity": "sha512-0JXq3b85Jk9Jg4ntLUbXSPvoDw3gpZou7twuKdoFG2jOw635v7+IiXfTaa0TxVMyx78pUjnrVYwLgjKfX4e6/A==",
-      "cpu": [
-        "x64"
-      ],
-      "optional": true,
-      "os": [
-        "win32"
-      ],
-      "engines": {
-        "node": ">= 10"
       }
     }
   }

--- a/package-lock.json
+++ b/package-lock.json
@@ -18503,6 +18503,111 @@
         "type": "github",
         "url": "https://github.com/sponsors/wooorm"
       }
+    },
+    "node_modules/next-runtime-env/node_modules/@next/swc-darwin-x64": {
+      "version": "16.2.10",
+      "resolved": "https://registry.npmjs.org/@next/swc-darwin-x64/-/swc-darwin-x64-16.2.10.tgz",
+      "integrity": "sha512-17IS0jJRViROGmA9uGdNR8VPJpfbnaVG7E9qhso5jDLkmyd0lSDORWxbcKINzcFqzZqGwGtMSnrFRxBpuUYjLQ==",
+      "cpu": [
+        "x64"
+      ],
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/next-runtime-env/node_modules/@next/swc-linux-arm64-gnu": {
+      "version": "16.2.10",
+      "resolved": "https://registry.npmjs.org/@next/swc-linux-arm64-gnu/-/swc-linux-arm64-gnu-16.2.10.tgz",
+      "integrity": "sha512-GRQRsRtuciNJvB54AvvuQTiq0oZtFwa1owQqtZD8wwnGpM2L39MV22kpI72YSXLKIyY40LC66EiLFv4PiicXxg==",
+      "cpu": [
+        "arm64"
+      ],
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/next-runtime-env/node_modules/@next/swc-linux-arm64-musl": {
+      "version": "16.2.10",
+      "resolved": "https://registry.npmjs.org/@next/swc-linux-arm64-musl/-/swc-linux-arm64-musl-16.2.10.tgz",
+      "integrity": "sha512-zkN9MQYS7UQBro+FnISUq1itaQjXI9xqISzuQ+2bc921NcJ1x4yPCqrn77tVN6/dOOXaaWVX3k6/bR07pPwK+A==",
+      "cpu": [
+        "arm64"
+      ],
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/next-runtime-env/node_modules/@next/swc-linux-x64-gnu": {
+      "version": "16.2.10",
+      "resolved": "https://registry.npmjs.org/@next/swc-linux-x64-gnu/-/swc-linux-x64-gnu-16.2.10.tgz",
+      "integrity": "sha512-iCVJnwvrPYECvA6WM/7+oo+OiTvedIKLxtCLAZP4xZR3nXa1zmzZyLPbYCmWvpd4CvMYF1EMTafd0ii3DygLvA==",
+      "cpu": [
+        "x64"
+      ],
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/next-runtime-env/node_modules/@next/swc-linux-x64-musl": {
+      "version": "16.2.10",
+      "resolved": "https://registry.npmjs.org/@next/swc-linux-x64-musl/-/swc-linux-x64-musl-16.2.10.tgz",
+      "integrity": "sha512-ov2g4H0dHY9bPoOU83m91hWT7Iq5qy13bUnyyshLU3HGR1Ownn0X9QpmDPc5iIUaahTp7f7LeGAhV4DSFtackw==",
+      "cpu": [
+        "x64"
+      ],
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/next-runtime-env/node_modules/@next/swc-win32-arm64-msvc": {
+      "version": "16.2.10",
+      "resolved": "https://registry.npmjs.org/@next/swc-win32-arm64-msvc/-/swc-win32-arm64-msvc-16.2.10.tgz",
+      "integrity": "sha512-DwAnhLX76HQiFFQNgWlcK+JzlnD1rZ+UK/WY0ZMI/deXpvgnesjNYrqcfo1JzBuz4Kf7o3brIBL0glI1junatA==",
+      "cpu": [
+        "arm64"
+      ],
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/next-runtime-env/node_modules/@next/swc-win32-x64-msvc": {
+      "version": "16.2.10",
+      "resolved": "https://registry.npmjs.org/@next/swc-win32-x64-msvc/-/swc-win32-x64-msvc-16.2.10.tgz",
+      "integrity": "sha512-0JXq3b85Jk9Jg4ntLUbXSPvoDw3gpZou7twuKdoFG2jOw635v7+IiXfTaa0TxVMyx78pUjnrVYwLgjKfX4e6/A==",
+      "cpu": [
+        "x64"
+      ],
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
     }
   }
 }

--- a/package.json
+++ b/package.json
@@ -81,6 +81,7 @@
     "rehype-raw": "^7.0.0",
     "rehype-slug": "^6.0.0",
     "remark-gfm": "^4.0.0",
+    "server-only": "^0.0.1",
     "sharp": "^0.35.0",
     "tailwind-merge": "^3.0.0",
     "tailwindcss-animate": "^1.0.7",

--- a/src/__mocks__/server-only.ts
+++ b/src/__mocks__/server-only.ts
@@ -1,0 +1,6 @@
+// SPDX-FileCopyrightText: 2026 PNED G.I.E.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+// No-op mock for Jest — server-only throws in non-Next.js environments.
+export {};

--- a/src/app/api/access-management/additional-types.ts
+++ b/src/app/api/access-management/additional-types.ts
@@ -38,8 +38,14 @@ export enum LicenseType {
   TEXT = "custom",
 }
 
+export type Entitlement = {
+  datasetId: string;
+  start?: string;
+  end?: string;
+};
+
 export type DatasetEntitlement = {
   dataset: SearchedDataset;
-  start: string;
+  start?: string;
   end?: string;
 };

--- a/src/app/api/access-management/index.ts
+++ b/src/app/api/access-management/index.ts
@@ -13,6 +13,8 @@ import { accessManagementClient } from "@/app/api/shared/client";
 import { createHeaders } from "@/app/api/shared/headers";
 import { AxiosError, isAxiosError } from "axios";
 import { ZodError } from "zod";
+import serverConfig from "@/config/serverConfig";
+import { retrieveEntitlementsV2 } from "@/app/api/ga4gh/entitlements";
 
 export const createApplicationApi = async (createApplicationCommand: {
   datasetIds: string[];
@@ -138,6 +140,11 @@ export const submitApplicationApi = async (applicationId: number) => {
 };
 
 export const retrieveEntitlementsApi = async () => {
+  if (serverConfig.entitlementsV2Enabled) {
+    return retrieveEntitlementsV2();
+  }
+
+  // V1 path: REMS-based entitlements via DAAM
   const headers = await createHeaders();
   return accessManagementClient.retrieve_granted_dataset_identifiers({
     headers,

--- a/src/app/api/auth/config.ts
+++ b/src/app/api/auth/config.ts
@@ -43,7 +43,7 @@ export const authOptions: NextAuthOptions = {
         params: {
           scope:
             process.env.KEYCLOAK_CLIENT_SCOPE ??
-            "openid profile email elixir_id ga4gh_passport_v1",
+            "openid profile email elixir_id",
         },
       },
     }),

--- a/src/app/api/auth/config.ts
+++ b/src/app/api/auth/config.ts
@@ -43,7 +43,7 @@ export const authOptions: NextAuthOptions = {
         params: {
           scope:
             process.env.KEYCLOAK_CLIENT_SCOPE ??
-            "openid profile email elixir_id",
+            "openid profile email elixir_id ga4gh_passport_v1",
         },
       },
     }),

--- a/src/app/api/ga4gh/__tests__/entitlements.test.ts
+++ b/src/app/api/ga4gh/__tests__/entitlements.test.ts
@@ -91,11 +91,13 @@ describe("retrieveEntitlementsV2", () => {
 
   it("uses empty string for start when visa iat is absent", async () => {
     const visaWithoutIat = { ...CONTROLLED_ACCESS_VISA, iat: undefined };
-    mockedFetchGa4ghPassport.mockResolvedValueOnce([makeVisaJwt(visaWithoutIat)]);
+    mockedFetchGa4ghPassport.mockResolvedValueOnce([
+      makeVisaJwt(visaWithoutIat),
+    ]);
 
     const { entitlements } = await retrieveEntitlementsV2();
 
-    expect(entitlements[0].start).toBe("");
+    expect(entitlements[0].start).toBeUndefined();
   });
 
   it("converts exp Unix timestamp to ISO 8601 end date", async () => {
@@ -156,7 +158,7 @@ describe("retrieveEntitlementsV2", () => {
     ]);
   });
 
-  it("uses empty string for end when visa exp is absent", async () => {
+  it("omits end date when visa exp is absent", async () => {
     const visaWithoutExp = {
       ...CONTROLLED_ACCESS_VISA,
       exp: undefined,
@@ -167,7 +169,7 @@ describe("retrieveEntitlementsV2", () => {
 
     const { entitlements } = await retrieveEntitlementsV2();
 
-    expect(entitlements[0].end).toBe("");
+    expect(entitlements[0].end).toBeUndefined();
   });
 
   it("propagates errors thrown by fetchGa4ghPassport", async () => {

--- a/src/app/api/ga4gh/__tests__/entitlements.test.ts
+++ b/src/app/api/ga4gh/__tests__/entitlements.test.ts
@@ -33,7 +33,6 @@ const CONTROLLED_ACCESS_VISA = {
     value: "GDID-12345678-11se",
     source: "https://daam.portal.dev.gdi.lu/",
     by: "dac",
-    asserted: 1784905094,
   },
 };
 
@@ -47,7 +46,6 @@ const RESEARCHER_STATUS_VISA = {
     value: "https://doi.org/10.1038/s41431-018-0219-y",
     source: "https://other-issuer.example.org/",
     by: "peer",
-    asserted: 1784905094,
   },
 };
 
@@ -79,7 +77,7 @@ describe("retrieveEntitlementsV2", () => {
     expect(result.entitlements[0].datasetId).toBe("GDID-12345678-11se");
   });
 
-  it("converts asserted Unix timestamp to ISO 8601 start date", async () => {
+  it("converts iat Unix timestamp to ISO 8601 start date", async () => {
     mockedFetchGa4ghPassport.mockResolvedValueOnce([
       makeVisaJwt(CONTROLLED_ACCESS_VISA),
     ]);
@@ -87,10 +85,17 @@ describe("retrieveEntitlementsV2", () => {
     const { entitlements } = await retrieveEntitlementsV2();
 
     expect(entitlements[0].start).toBe(
-      new Date(
-        CONTROLLED_ACCESS_VISA.ga4gh_visa_v1.asserted * 1000
-      ).toISOString()
+      new Date(CONTROLLED_ACCESS_VISA.iat * 1000).toISOString()
     );
+  });
+
+  it("uses empty string for start when visa iat is absent", async () => {
+    const visaWithoutIat = { ...CONTROLLED_ACCESS_VISA, iat: undefined };
+    mockedFetchGa4ghPassport.mockResolvedValueOnce([makeVisaJwt(visaWithoutIat)]);
+
+    const { entitlements } = await retrieveEntitlementsV2();
+
+    expect(entitlements[0].start).toBe("");
   });
 
   it("converts exp Unix timestamp to ISO 8601 end date", async () => {
@@ -134,7 +139,6 @@ describe("retrieveEntitlementsV2", () => {
       ga4gh_visa_v1: {
         ...CONTROLLED_ACCESS_VISA.ga4gh_visa_v1,
         value: "GDID-99999999-xyz",
-        asserted: 1785000000,
       },
     };
 
@@ -150,6 +154,20 @@ describe("retrieveEntitlementsV2", () => {
       "GDID-12345678-11se",
       "GDID-99999999-xyz",
     ]);
+  });
+
+  it("uses empty string for end when visa exp is absent", async () => {
+    const visaWithoutExp = {
+      ...CONTROLLED_ACCESS_VISA,
+      exp: undefined,
+    };
+    mockedFetchGa4ghPassport.mockResolvedValueOnce([
+      makeVisaJwt(visaWithoutExp),
+    ]);
+
+    const { entitlements } = await retrieveEntitlementsV2();
+
+    expect(entitlements[0].end).toBe("");
   });
 
   it("propagates errors thrown by fetchGa4ghPassport", async () => {

--- a/src/app/api/ga4gh/__tests__/entitlements.test.ts
+++ b/src/app/api/ga4gh/__tests__/entitlements.test.ts
@@ -87,7 +87,9 @@ describe("retrieveEntitlementsV2", () => {
     const { entitlements } = await retrieveEntitlementsV2();
 
     expect(entitlements[0].start).toBe(
-      new Date(CONTROLLED_ACCESS_VISA.ga4gh_visa_v1.asserted * 1000).toISOString()
+      new Date(
+        CONTROLLED_ACCESS_VISA.ga4gh_visa_v1.asserted * 1000
+      ).toISOString()
     );
   });
 

--- a/src/app/api/ga4gh/__tests__/entitlements.test.ts
+++ b/src/app/api/ga4gh/__tests__/entitlements.test.ts
@@ -1,0 +1,162 @@
+// SPDX-FileCopyrightText: 2026 PNED G.I.E.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+import { jest } from "@jest/globals";
+import { fetchGa4ghPassport } from "../passport";
+import { retrieveEntitlementsV2 } from "../entitlements";
+
+jest.mock("../passport");
+const mockedFetchGa4ghPassport = fetchGa4ghPassport as jest.MockedFunction<
+  typeof fetchGa4ghPassport
+>;
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+function makeVisaJwt(payload: object): string {
+  const header = Buffer.from(
+    JSON.stringify({ alg: "RS256", typ: "JWT" })
+  ).toString("base64url");
+  const body = Buffer.from(JSON.stringify(payload)).toString("base64url");
+  return `${header}.${body}.fakesignature`;
+}
+
+const CONTROLLED_ACCESS_VISA = {
+  iss: "https://daam.portal.dev.gdi.lu/",
+  sub: "2951f8b568bd3595d9a291605e88207fac707718@lifescience-ri.eu",
+  iat: 1785223779,
+  exp: 1816759779,
+  ga4gh_visa_v1: {
+    type: "ControlledAccessGrants",
+    value: "GDID-12345678-11se",
+    source: "https://daam.portal.dev.gdi.lu/",
+    by: "dac",
+    asserted: 1784905094,
+  },
+};
+
+const RESEARCHER_STATUS_VISA = {
+  iss: "https://other-issuer.example.org/",
+  sub: "2951f8b568bd3595d9a291605e88207fac707718@lifescience-ri.eu",
+  iat: 1785223779,
+  exp: 1816759779,
+  ga4gh_visa_v1: {
+    type: "ResearcherStatus",
+    value: "https://doi.org/10.1038/s41431-018-0219-y",
+    source: "https://other-issuer.example.org/",
+    by: "peer",
+    asserted: 1784905094,
+  },
+};
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+describe("retrieveEntitlementsV2", () => {
+  beforeEach(() => {
+    jest.resetAllMocks();
+  });
+
+  it("returns empty entitlements when passport contains no visas", async () => {
+    mockedFetchGa4ghPassport.mockResolvedValueOnce([]);
+
+    const result = await retrieveEntitlementsV2();
+
+    expect(result).toEqual({ entitlements: [] });
+  });
+
+  it("maps a single ControlledAccessGrants visa to a dataset entitlement", async () => {
+    mockedFetchGa4ghPassport.mockResolvedValueOnce([
+      makeVisaJwt(CONTROLLED_ACCESS_VISA),
+    ]);
+
+    const result = await retrieveEntitlementsV2();
+
+    expect(result.entitlements).toHaveLength(1);
+    expect(result.entitlements[0].datasetId).toBe("GDID-12345678-11se");
+  });
+
+  it("converts asserted Unix timestamp to ISO 8601 start date", async () => {
+    mockedFetchGa4ghPassport.mockResolvedValueOnce([
+      makeVisaJwt(CONTROLLED_ACCESS_VISA),
+    ]);
+
+    const { entitlements } = await retrieveEntitlementsV2();
+
+    expect(entitlements[0].start).toBe(
+      new Date(CONTROLLED_ACCESS_VISA.ga4gh_visa_v1.asserted * 1000).toISOString()
+    );
+  });
+
+  it("converts exp Unix timestamp to ISO 8601 end date", async () => {
+    mockedFetchGa4ghPassport.mockResolvedValueOnce([
+      makeVisaJwt(CONTROLLED_ACCESS_VISA),
+    ]);
+
+    const { entitlements } = await retrieveEntitlementsV2();
+
+    expect(entitlements[0].end).toBe(
+      new Date(CONTROLLED_ACCESS_VISA.exp * 1000).toISOString()
+    );
+  });
+
+  it("ignores non-ControlledAccessGrants visas", async () => {
+    mockedFetchGa4ghPassport.mockResolvedValueOnce([
+      makeVisaJwt(RESEARCHER_STATUS_VISA),
+    ]);
+
+    const result = await retrieveEntitlementsV2();
+
+    expect(result).toEqual({ entitlements: [] });
+  });
+
+  it("extracts only ControlledAccessGrants from a mixed passport", async () => {
+    mockedFetchGa4ghPassport.mockResolvedValueOnce([
+      makeVisaJwt(CONTROLLED_ACCESS_VISA),
+      makeVisaJwt(RESEARCHER_STATUS_VISA),
+    ]);
+
+    const { entitlements } = await retrieveEntitlementsV2();
+
+    expect(entitlements).toHaveLength(1);
+    expect(entitlements[0].datasetId).toBe("GDID-12345678-11se");
+  });
+
+  it("maps multiple ControlledAccessGrants visas to multiple entitlements", async () => {
+    const second = {
+      ...CONTROLLED_ACCESS_VISA,
+      exp: 1900000000,
+      ga4gh_visa_v1: {
+        ...CONTROLLED_ACCESS_VISA.ga4gh_visa_v1,
+        value: "GDID-99999999-xyz",
+        asserted: 1785000000,
+      },
+    };
+
+    mockedFetchGa4ghPassport.mockResolvedValueOnce([
+      makeVisaJwt(CONTROLLED_ACCESS_VISA),
+      makeVisaJwt(second),
+    ]);
+
+    const { entitlements } = await retrieveEntitlementsV2();
+
+    expect(entitlements).toHaveLength(2);
+    expect(entitlements.map((e) => e.datasetId)).toEqual([
+      "GDID-12345678-11se",
+      "GDID-99999999-xyz",
+    ]);
+  });
+
+  it("propagates errors thrown by fetchGa4ghPassport", async () => {
+    mockedFetchGa4ghPassport.mockRejectedValueOnce(
+      new Error("LS-AAI token exchange failed: 401")
+    );
+
+    await expect(retrieveEntitlementsV2()).rejects.toThrow(
+      "LS-AAI token exchange failed: 401"
+    );
+  });
+});

--- a/src/app/api/ga4gh/__tests__/entitlements.test.ts
+++ b/src/app/api/ga4gh/__tests__/entitlements.test.ts
@@ -89,7 +89,7 @@ describe("retrieveEntitlementsV2", () => {
     );
   });
 
-  it("uses empty string for start when visa iat is absent", async () => {
+  it("omits start date when visa iat is absent", async () => {
     const visaWithoutIat = { ...CONTROLLED_ACCESS_VISA, iat: undefined };
     mockedFetchGa4ghPassport.mockResolvedValueOnce([
       makeVisaJwt(visaWithoutIat),

--- a/src/app/api/ga4gh/__tests__/passport.test.ts
+++ b/src/app/api/ga4gh/__tests__/passport.test.ts
@@ -96,6 +96,14 @@ describe("fetchGa4ghPassport", () => {
         "LS-AAI token exchange returned no access_token"
       );
     });
+    it("includes error field from broker JSON body in thrown message", async () => {
+      mockedGetToken.mockResolvedValueOnce(KEYCLOAK_TOKEN);
+      mockFetch([{ ok: false, status: 401, body: { error: "invalid_token" } }]);
+
+      await expect(fetchGa4ghPassport()).rejects.toThrow(
+        "LS-AAI token exchange failed: 401 invalid_token"
+      );
+    });
   });
 
   describe("Step 2 — LS-AAI userinfo passport fetch", () => {
@@ -149,6 +157,18 @@ describe("fetchGa4ghPassport", () => {
 
       await expect(fetchGa4ghPassport()).rejects.toThrow(
         "LS-AAI userinfo request failed: 403"
+      );
+    });
+
+    it("includes error field from userinfo JSON body in thrown message", async () => {
+      mockedGetToken.mockResolvedValueOnce(KEYCLOAK_TOKEN);
+      mockFetch([
+        { ok: true, body: { access_token: LS_AAI_TOKEN } },
+        { ok: false, status: 401, body: { error: "invalid_token" } },
+      ]);
+
+      await expect(fetchGa4ghPassport()).rejects.toThrow(
+        "LS-AAI userinfo request failed: 401 invalid_token"
       );
     });
   });

--- a/src/app/api/ga4gh/__tests__/passport.test.ts
+++ b/src/app/api/ga4gh/__tests__/passport.test.ts
@@ -17,7 +17,7 @@ function mockFetch(
   responses: Array<{ ok: boolean; status?: number; body: object }>
 ): void {
   let callIndex = 0;
-  global.fetch = jest.fn(() => {
+  global.fetch = jest.fn((): Promise<Response> => {
     const resp = responses[callIndex++] ?? responses[responses.length - 1];
     return Promise.resolve({
       ok: resp.ok,
@@ -25,7 +25,7 @@ function mockFetch(
       statusText: resp.ok ? "OK" : "Internal Server Error",
       json: () => Promise.resolve(resp.body),
     } as Response);
-  }) as jest.Mock;
+  }) as typeof global.fetch;
 }
 
 const KEYCLOAK_TOKEN = "keycloak-access-token";

--- a/src/app/api/ga4gh/__tests__/passport.test.ts
+++ b/src/app/api/ga4gh/__tests__/passport.test.ts
@@ -31,6 +31,7 @@ function mockFetch(
 const KEYCLOAK_TOKEN = "keycloak-access-token";
 const LS_AAI_TOKEN = "ls-aai-access-token";
 const VISA_JWT = "eyJhbGciOiJSUzI1NiJ9.eyJzdWIiOiJ1c2VyIn0.sig";
+const LS_AAI_USERINFO_URL = "https://login.aai.lifescience-ri.eu/oidc/userinfo";
 
 // ---------------------------------------------------------------------------
 // Tests
@@ -39,6 +40,11 @@ const VISA_JWT = "eyJhbGciOiJSUzI1NiJ9.eyJzdWIiOiJ1c2VyIn0.sig";
 describe("fetchGa4ghPassport", () => {
   beforeEach(() => {
     jest.resetAllMocks();
+    process.env.LS_AAI_USERINFO_URL = LS_AAI_USERINFO_URL;
+  });
+
+  afterEach(() => {
+    delete process.env.LS_AAI_USERINFO_URL;
   });
 
   describe("when user is unauthenticated", () => {
@@ -103,10 +109,7 @@ describe("fetchGa4ghPassport", () => {
       await fetchGa4ghPassport();
 
       const userinfoCall = (global.fetch as jest.Mock).mock.calls[1];
-      const userinfoUrl =
-        process.env.LS_AAI_USERINFO_URL ??
-        "https://login.aai.lifescience-ri.eu/oidc/userinfo";
-      expect(userinfoCall[0]).toBe(userinfoUrl);
+      expect(userinfoCall[0]).toBe(LS_AAI_USERINFO_URL);
       expect((userinfoCall[1] as RequestInit).method).toBe("POST");
       expect((userinfoCall[1] as RequestInit).headers).toMatchObject({
         Authorization: `Bearer ${LS_AAI_TOKEN}`,
@@ -146,6 +149,30 @@ describe("fetchGa4ghPassport", () => {
 
       await expect(fetchGa4ghPassport()).rejects.toThrow(
         "LS-AAI userinfo request failed: 403"
+      );
+    });
+  });
+
+  describe("missing required environment variables", () => {
+    it("throws when KEYCLOAK_ISSUER_URL is not set", async () => {
+      const original = process.env.KEYCLOAK_ISSUER_URL;
+      delete process.env.KEYCLOAK_ISSUER_URL;
+      mockedGetToken.mockResolvedValueOnce(KEYCLOAK_TOKEN);
+
+      await expect(fetchGa4ghPassport()).rejects.toThrow(
+        "Missing required environment variable: KEYCLOAK_ISSUER_URL"
+      );
+
+      process.env.KEYCLOAK_ISSUER_URL = original;
+    });
+
+    it("throws when LS_AAI_USERINFO_URL is not set", async () => {
+      delete process.env.LS_AAI_USERINFO_URL;
+      mockedGetToken.mockResolvedValueOnce(KEYCLOAK_TOKEN);
+      mockFetch([{ ok: true, body: { access_token: LS_AAI_TOKEN } }]);
+
+      await expect(fetchGa4ghPassport()).rejects.toThrow(
+        "Missing required environment variable: LS_AAI_USERINFO_URL"
       );
     });
   });

--- a/src/app/api/ga4gh/__tests__/passport.test.ts
+++ b/src/app/api/ga4gh/__tests__/passport.test.ts
@@ -1,0 +1,168 @@
+// SPDX-FileCopyrightText: 2026 PNED G.I.E.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+import { jest } from "@jest/globals";
+import { getToken } from "@/app/api/auth/auth";
+import { fetchGa4ghPassport } from "../passport";
+
+jest.mock("@/app/api/auth/auth");
+const mockedGetToken = getToken as jest.MockedFunction<typeof getToken>;
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+function mockFetch(
+  responses: Array<{ ok: boolean; status?: number; body: object }>
+): void {
+  let callIndex = 0;
+  global.fetch = jest.fn(() => {
+    const resp = responses[callIndex++] ?? responses[responses.length - 1];
+    return Promise.resolve({
+      ok: resp.ok,
+      status: resp.status ?? (resp.ok ? 200 : 500),
+      statusText: resp.ok ? "OK" : "Internal Server Error",
+      json: () => Promise.resolve(resp.body),
+    } as Response);
+  }) as jest.Mock;
+}
+
+const KEYCLOAK_TOKEN = "keycloak-access-token";
+const LS_AAI_TOKEN = "ls-aai-access-token";
+const VISA_JWT = "eyJhbGciOiJSUzI1NiJ9.eyJzdWIiOiJ1c2VyIn0.sig";
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+describe("fetchGa4ghPassport", () => {
+  beforeEach(() => {
+    jest.resetAllMocks();
+  });
+
+  describe("when user is unauthenticated", () => {
+    it("returns an empty array without making any HTTP calls", async () => {
+      mockedGetToken.mockResolvedValueOnce(null);
+      const fetchSpy = jest.spyOn(global, "fetch");
+
+      const result = await fetchGa4ghPassport();
+
+      expect(result).toEqual([]);
+      expect(fetchSpy).not.toHaveBeenCalled();
+    });
+  });
+
+  describe("Step 1 — Keycloak broker token exchange", () => {
+    it("calls the correct broker endpoint with the Keycloak Bearer token", async () => {
+      mockedGetToken.mockResolvedValueOnce(KEYCLOAK_TOKEN);
+      mockFetch([
+        { ok: true, body: { access_token: LS_AAI_TOKEN } },
+        { ok: true, body: { ga4gh_passport_v1: [] } },
+      ]);
+
+      await fetchGa4ghPassport();
+
+      const [brokerCall] = (global.fetch as jest.Mock).mock.calls;
+      expect(brokerCall[0]).toBe(
+        `${process.env.KEYCLOAK_ISSUER_URL}/broker/LSAAI/token`
+      );
+      expect((brokerCall[1] as RequestInit).method).toBe("GET");
+      expect((brokerCall[1] as RequestInit).headers).toMatchObject({
+        Authorization: `Bearer ${KEYCLOAK_TOKEN}`,
+      });
+    });
+
+    it("throws when the broker endpoint returns a non-OK status", async () => {
+      mockedGetToken.mockResolvedValueOnce(KEYCLOAK_TOKEN);
+      mockFetch([{ ok: false, status: 401, body: {} }]);
+
+      await expect(fetchGa4ghPassport()).rejects.toThrow(
+        "LS-AAI token exchange failed: 401"
+      );
+    });
+
+    it("throws when the broker response contains no access_token", async () => {
+      mockedGetToken.mockResolvedValueOnce(KEYCLOAK_TOKEN);
+      mockFetch([{ ok: true, body: {} }]);
+
+      await expect(fetchGa4ghPassport()).rejects.toThrow(
+        "LS-AAI token exchange returned no access_token"
+      );
+    });
+  });
+
+  describe("Step 2 — LS-AAI userinfo passport fetch", () => {
+    it("calls the userinfo endpoint with the LS-AAI Bearer token", async () => {
+      mockedGetToken.mockResolvedValueOnce(KEYCLOAK_TOKEN);
+      mockFetch([
+        { ok: true, body: { access_token: LS_AAI_TOKEN } },
+        { ok: true, body: { ga4gh_passport_v1: [VISA_JWT] } },
+      ]);
+
+      await fetchGa4ghPassport();
+
+      const userinfoCall = (global.fetch as jest.Mock).mock.calls[1];
+      const userinfoUrl =
+        process.env.LS_AAI_USERINFO_URL ??
+        "https://login.aai.lifescience-ri.eu/oidc/userinfo";
+      expect(userinfoCall[0]).toBe(userinfoUrl);
+      expect((userinfoCall[1] as RequestInit).method).toBe("POST");
+      expect((userinfoCall[1] as RequestInit).headers).toMatchObject({
+        Authorization: `Bearer ${LS_AAI_TOKEN}`,
+      });
+    });
+
+    it("returns the ga4gh_passport_v1 array from the userinfo response", async () => {
+      mockedGetToken.mockResolvedValueOnce(KEYCLOAK_TOKEN);
+      mockFetch([
+        { ok: true, body: { access_token: LS_AAI_TOKEN } },
+        { ok: true, body: { ga4gh_passport_v1: [VISA_JWT] } },
+      ]);
+
+      const result = await fetchGa4ghPassport();
+
+      expect(result).toEqual([VISA_JWT]);
+    });
+
+    it("returns an empty array when userinfo contains no ga4gh_passport_v1", async () => {
+      mockedGetToken.mockResolvedValueOnce(KEYCLOAK_TOKEN);
+      mockFetch([
+        { ok: true, body: { access_token: LS_AAI_TOKEN } },
+        { ok: true, body: { sub: "user123" } },
+      ]);
+
+      const result = await fetchGa4ghPassport();
+
+      expect(result).toEqual([]);
+    });
+
+    it("throws when the userinfo endpoint returns a non-OK status", async () => {
+      mockedGetToken.mockResolvedValueOnce(KEYCLOAK_TOKEN);
+      mockFetch([
+        { ok: true, body: { access_token: LS_AAI_TOKEN } },
+        { ok: false, status: 403, body: {} },
+      ]);
+
+      await expect(fetchGa4ghPassport()).rejects.toThrow(
+        "LS-AAI userinfo request failed: 403"
+      );
+    });
+  });
+
+  describe("full two-step flow", () => {
+    it("returns multiple visa JWTs when passport contains several visas", async () => {
+      const visa1 = "visa-jwt-1";
+      const visa2 = "visa-jwt-2";
+      mockedGetToken.mockResolvedValueOnce(KEYCLOAK_TOKEN);
+      mockFetch([
+        { ok: true, body: { access_token: LS_AAI_TOKEN } },
+        { ok: true, body: { ga4gh_passport_v1: [visa1, visa2] } },
+      ]);
+
+      const result = await fetchGa4ghPassport();
+
+      expect(result).toEqual([visa1, visa2]);
+    });
+  });
+});

--- a/src/app/api/ga4gh/__tests__/visa.test.ts
+++ b/src/app/api/ga4gh/__tests__/visa.test.ts
@@ -1,0 +1,151 @@
+// SPDX-FileCopyrightText: 2026 PNED G.I.E.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+import {
+  decodeVisaPayload,
+  extractControlledAccessGrants,
+  Ga4ghVisaPayload,
+} from "../visa";
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+function makeVisaJwt(payload: object): string {
+  const header = Buffer.from(
+    JSON.stringify({ alg: "RS256", typ: "JWT" })
+  ).toString("base64url");
+  const body = Buffer.from(JSON.stringify(payload)).toString("base64url");
+  return `${header}.${body}.fakesignature`;
+}
+
+const CONTROLLED_ACCESS_VISA: Ga4ghVisaPayload = {
+  iss: "https://daam.portal.dev.gdi.lu/",
+  sub: "2951f8b568bd3595d9a291605e88207fac707718@lifescience-ri.eu",
+  iat: 1785223779,
+  exp: 1816759779,
+  ga4gh_visa_v1: {
+    type: "ControlledAccessGrants",
+    value: "GDID-12345678-11se",
+    source: "https://daam.portal.dev.gdi.lu/",
+    by: "dac",
+    asserted: 1784905094,
+  },
+};
+
+const RESEARCHER_STATUS_VISA: Ga4ghVisaPayload = {
+  iss: "https://other-issuer.example.org/",
+  sub: "2951f8b568bd3595d9a291605e88207fac707718@lifescience-ri.eu",
+  iat: 1785223779,
+  exp: 1816759779,
+  ga4gh_visa_v1: {
+    type: "ResearcherStatus",
+    value: "https://doi.org/10.1038/s41431-018-0219-y",
+    source: "https://other-issuer.example.org/",
+    by: "peer",
+    asserted: 1784905094,
+  },
+};
+
+// ---------------------------------------------------------------------------
+// decodeVisaPayload
+// ---------------------------------------------------------------------------
+
+describe("decodeVisaPayload", () => {
+  test("decodes a valid ControlledAccessGrants visa JWT", () => {
+    const jwt = makeVisaJwt(CONTROLLED_ACCESS_VISA);
+    const result = decodeVisaPayload(jwt);
+
+    expect(result).not.toBeNull();
+    expect(result!.iss).toBe("https://daam.portal.dev.gdi.lu/");
+    expect(result!.exp).toBe(1816759779);
+    expect(result!.ga4gh_visa_v1.type).toBe("ControlledAccessGrants");
+    expect(result!.ga4gh_visa_v1.value).toBe("GDID-12345678-11se");
+  });
+
+  test("decodes a valid ResearcherStatus visa JWT", () => {
+    const jwt = makeVisaJwt(RESEARCHER_STATUS_VISA);
+    const result = decodeVisaPayload(jwt);
+
+    expect(result).not.toBeNull();
+    expect(result!.ga4gh_visa_v1.type).toBe("ResearcherStatus");
+  });
+
+  test("returns null for a malformed JWT", () => {
+    expect(decodeVisaPayload("not.a.jwt")).toBeNull();
+    expect(decodeVisaPayload("")).toBeNull();
+    expect(decodeVisaPayload("only-one-segment")).toBeNull();
+  });
+
+  test("returns null when ga4gh_visa_v1 claim is absent", () => {
+    const jwt = makeVisaJwt({ iss: "https://example.org", sub: "user", iat: 0, exp: 0 });
+    expect(decodeVisaPayload(jwt)).toBeNull();
+  });
+});
+
+// ---------------------------------------------------------------------------
+// extractControlledAccessGrants
+// ---------------------------------------------------------------------------
+
+describe("extractControlledAccessGrants", () => {
+  test("extracts ControlledAccessGrants and ignores other visa types", () => {
+    const jwtA = makeVisaJwt(CONTROLLED_ACCESS_VISA);
+    const jwtB = makeVisaJwt(RESEARCHER_STATUS_VISA);
+
+    const grants = extractControlledAccessGrants([jwtA, jwtB]);
+
+    expect(grants).toHaveLength(1);
+    expect(grants[0].datasetId).toBe("GDID-12345678-11se");
+  });
+
+  test("maps grant fields correctly from the visa payload", () => {
+    const jwt = makeVisaJwt(CONTROLLED_ACCESS_VISA);
+    const [grant] = extractControlledAccessGrants([jwt]);
+
+    expect(grant.datasetId).toBe(CONTROLLED_ACCESS_VISA.ga4gh_visa_v1.value);
+    expect(grant.source).toBe(CONTROLLED_ACCESS_VISA.ga4gh_visa_v1.source);
+    expect(grant.by).toBe(CONTROLLED_ACCESS_VISA.ga4gh_visa_v1.by);
+    expect(grant.asserted).toBe(CONTROLLED_ACCESS_VISA.ga4gh_visa_v1.asserted);
+    expect(grant.exp).toBe(CONTROLLED_ACCESS_VISA.exp);
+  });
+
+  test("returns empty array when passport contains no ControlledAccessGrants", () => {
+    const jwt = makeVisaJwt(RESEARCHER_STATUS_VISA);
+    expect(extractControlledAccessGrants([jwt])).toEqual([]);
+  });
+
+  test("returns empty array for an empty passport", () => {
+    expect(extractControlledAccessGrants([])).toEqual([]);
+  });
+
+  test("skips malformed JWTs without throwing", () => {
+    const validJwt = makeVisaJwt(CONTROLLED_ACCESS_VISA);
+    const grants = extractControlledAccessGrants(["bad-token", validJwt]);
+
+    expect(grants).toHaveLength(1);
+    expect(grants[0].datasetId).toBe("GDID-12345678-11se");
+  });
+
+  test("extracts multiple ControlledAccessGrants from a single passport", () => {
+    const second: Ga4ghVisaPayload = {
+      ...CONTROLLED_ACCESS_VISA,
+      ga4gh_visa_v1: {
+        ...CONTROLLED_ACCESS_VISA.ga4gh_visa_v1,
+        value: "GDID-99999999-abc",
+      },
+    };
+
+    const grants = extractControlledAccessGrants([
+      makeVisaJwt(CONTROLLED_ACCESS_VISA),
+      makeVisaJwt(RESEARCHER_STATUS_VISA),
+      makeVisaJwt(second),
+    ]);
+
+    expect(grants).toHaveLength(2);
+    expect(grants.map((g) => g.datasetId)).toEqual([
+      "GDID-12345678-11se",
+      "GDID-99999999-abc",
+    ]);
+  });
+});

--- a/src/app/api/ga4gh/__tests__/visa.test.ts
+++ b/src/app/api/ga4gh/__tests__/visa.test.ts
@@ -30,7 +30,6 @@ const CONTROLLED_ACCESS_VISA: Ga4ghVisaPayload = {
     value: "GDID-12345678-11se",
     source: "https://daam.portal.dev.gdi.lu/",
     by: "dac",
-    asserted: 1784905094,
   },
 };
 
@@ -44,7 +43,6 @@ const RESEARCHER_STATUS_VISA: Ga4ghVisaPayload = {
     value: "https://doi.org/10.1038/s41431-018-0219-y",
     source: "https://other-issuer.example.org/",
     by: "peer",
-    asserted: 1784905094,
   },
 };
 
@@ -109,9 +107,9 @@ describe("extractControlledAccessGrants", () => {
     const [grant] = extractControlledAccessGrants([jwt]);
 
     expect(grant.datasetId).toBe(CONTROLLED_ACCESS_VISA.ga4gh_visa_v1.value);
+    expect(grant.iat).toBe(CONTROLLED_ACCESS_VISA.iat);
     expect(grant.source).toBe(CONTROLLED_ACCESS_VISA.ga4gh_visa_v1.source);
     expect(grant.by).toBe(CONTROLLED_ACCESS_VISA.ga4gh_visa_v1.by);
-    expect(grant.asserted).toBe(CONTROLLED_ACCESS_VISA.ga4gh_visa_v1.asserted);
     expect(grant.exp).toBe(CONTROLLED_ACCESS_VISA.exp);
   });
 
@@ -122,6 +120,32 @@ describe("extractControlledAccessGrants", () => {
 
   test("returns empty array for an empty passport", () => {
     expect(extractControlledAccessGrants([])).toEqual([]);
+  });
+
+  test("prefers ga4gh_visa_v1.iat over outer JWT iat when present", () => {
+    const visaWithInnerIat: Ga4ghVisaPayload = {
+      ...CONTROLLED_ACCESS_VISA,
+      ga4gh_visa_v1: {
+        ...CONTROLLED_ACCESS_VISA.ga4gh_visa_v1,
+        iat: 1111111111,
+      },
+    };
+    const [grant] = extractControlledAccessGrants([makeVisaJwt(visaWithInnerIat)]);
+
+    expect(grant.iat).toBe(1111111111);
+  });
+
+  test("prefers ga4gh_visa_v1.exp over outer JWT exp when present", () => {
+    const visaWithInnerExp: Ga4ghVisaPayload = {
+      ...CONTROLLED_ACCESS_VISA,
+      ga4gh_visa_v1: {
+        ...CONTROLLED_ACCESS_VISA.ga4gh_visa_v1,
+        exp: 9999999999,
+      },
+    };
+    const [grant] = extractControlledAccessGrants([makeVisaJwt(visaWithInnerExp)]);
+
+    expect(grant.exp).toBe(9999999999);
   });
 
   test("skips malformed JWTs without throwing", () => {

--- a/src/app/api/ga4gh/__tests__/visa.test.ts
+++ b/src/app/api/ga4gh/__tests__/visa.test.ts
@@ -79,7 +79,12 @@ describe("decodeVisaPayload", () => {
   });
 
   test("returns null when ga4gh_visa_v1 claim is absent", () => {
-    const jwt = makeVisaJwt({ iss: "https://example.org", sub: "user", iat: 0, exp: 0 });
+    const jwt = makeVisaJwt({
+      iss: "https://example.org",
+      sub: "user",
+      iat: 0,
+      exp: 0,
+    });
     expect(decodeVisaPayload(jwt)).toBeNull();
   });
 });

--- a/src/app/api/ga4gh/__tests__/visa.test.ts
+++ b/src/app/api/ga4gh/__tests__/visa.test.ts
@@ -130,7 +130,9 @@ describe("extractControlledAccessGrants", () => {
         iat: 1111111111,
       },
     };
-    const [grant] = extractControlledAccessGrants([makeVisaJwt(visaWithInnerIat)]);
+    const [grant] = extractControlledAccessGrants([
+      makeVisaJwt(visaWithInnerIat),
+    ]);
 
     expect(grant.iat).toBe(1111111111);
   });
@@ -143,7 +145,9 @@ describe("extractControlledAccessGrants", () => {
         exp: 9999999999,
       },
     };
-    const [grant] = extractControlledAccessGrants([makeVisaJwt(visaWithInnerExp)]);
+    const [grant] = extractControlledAccessGrants([
+      makeVisaJwt(visaWithInnerExp),
+    ]);
 
     expect(grant.exp).toBe(9999999999);
   });

--- a/src/app/api/ga4gh/entitlements.ts
+++ b/src/app/api/ga4gh/entitlements.ts
@@ -5,7 +5,6 @@
 "use server";
 
 import { fetchGa4ghPassport } from "./passport";
-import { RetrieveGrantedDatasetIdentifiers } from "@/app/api/access-management/open-api/schemas";
 import { extractControlledAccessGrants } from "./visa";
 
 /**
@@ -16,16 +15,15 @@ import { extractControlledAccessGrants } from "./visa";
  * TODO (ART-27610): validate Visa JWT signatures.
  * TODO (ART-27611): handle visa expiry / refresh.
  */
-export const retrieveEntitlementsV2 =
-  async (): Promise<RetrieveGrantedDatasetIdentifiers> => {
-    const visaJwts = await fetchGa4ghPassport();
-    const grants = extractControlledAccessGrants(visaJwts);
+export const retrieveEntitlementsV2 = async () => {
+  const visaJwts = await fetchGa4ghPassport();
+  const grants = extractControlledAccessGrants(visaJwts);
 
-    const entitlements = grants.map((grant) => ({
-      datasetId: grant.datasetId,
-      start: grant.iat ? new Date(grant.iat * 1000).toISOString() : "",
-      end: grant.exp ? new Date(grant.exp * 1000).toISOString() : "",
-    }));
+  const entitlements = grants.map((grant) => ({
+    datasetId: grant.datasetId,
+    start: grant.iat ? new Date(grant.iat * 1000).toISOString() : undefined,
+    end: grant.exp ? new Date(grant.exp * 1000).toISOString() : undefined,
+  }));
 
-    return { entitlements };
-  };
+  return { entitlements };
+};

--- a/src/app/api/ga4gh/entitlements.ts
+++ b/src/app/api/ga4gh/entitlements.ts
@@ -23,8 +23,8 @@ export const retrieveEntitlementsV2 =
 
     const entitlements = grants.map((grant) => ({
       datasetId: grant.datasetId,
-      start: new Date(grant.asserted * 1000).toISOString(),
-      end: new Date(grant.exp * 1000).toISOString(),
+      start: grant.iat ? new Date(grant.iat * 1000).toISOString() : "",
+      end: grant.exp ? new Date(grant.exp * 1000).toISOString() : "",
     }));
 
     return { entitlements };

--- a/src/app/api/ga4gh/entitlements.ts
+++ b/src/app/api/ga4gh/entitlements.ts
@@ -1,0 +1,31 @@
+// SPDX-FileCopyrightText: 2026 PNED G.I.E.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+"use server";
+
+import { fetchGa4ghPassport } from "./passport";
+import { RetrieveGrantedDatasetIdentifiers } from "@/app/api/access-management/open-api/schemas";
+import { extractControlledAccessGrants } from "./visa";
+
+/**
+ * GA4GH Passport/Visa-based entitlement retrieval.
+ *
+ * Fetches raw Visa JWTs from the LS-AAI userinfo endpoint.
+ * Decodes Visa JWTs and extracts ControlledAccessGrants visas.
+ * TODO (ART-27610): validate Visa JWT signatures.
+ * TODO (ART-27611): handle visa expiry / refresh.
+ */
+export const retrieveEntitlementsV2 =
+  async (): Promise<RetrieveGrantedDatasetIdentifiers> => {
+    const visaJwts = await fetchGa4ghPassport();
+    const grants = extractControlledAccessGrants(visaJwts);
+
+    const entitlements = grants.map((grant) => ({
+      datasetId: grant.datasetId,
+      start: new Date(grant.asserted * 1000).toISOString(),
+      end: new Date(grant.exp * 1000).toISOString(),
+    }));
+
+    return { entitlements };
+  };

--- a/src/app/api/ga4gh/passport.ts
+++ b/src/app/api/ga4gh/passport.ts
@@ -1,0 +1,116 @@
+// SPDX-FileCopyrightText: 2026 PNED G.I.E.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+"use server";
+
+import { getToken } from "@/app/api/auth/auth";
+
+type LsAaiTokenResponse = {
+  access_token?: string;
+  error?: string;
+  [key: string]: unknown;
+};
+
+type UserinfoResponse = {
+  sub?: string;
+  ga4gh_passport_v1?: string[];
+  error?: string;
+  [key: string]: unknown;
+};
+
+/**
+ * Step 1: Exchanges the Keycloak access token for an LS-AAI access token via
+ * the Keycloak identity-provider token endpoint.
+ *
+ * GET `{KEYCLOAK_ISSUER_URL}/broker/LSAAI/token`
+ *
+ * @param keycloakAccessToken - The user's current Keycloak access token.
+ * @returns The LS-AAI access token string.
+ * @throws If the broker request fails or returns no access token.
+ */
+async function exchangeKeycloakTokenForLsAai(
+  keycloakAccessToken: string
+): Promise<string> {
+  const brokerUrl = `${process.env.KEYCLOAK_ISSUER_URL}/broker/LSAAI/token`;
+
+  const response = await fetch(brokerUrl, {
+    method: "GET",
+    headers: {
+      Authorization: `Bearer ${keycloakAccessToken}`,
+    },
+    cache: "no-store",
+  });
+
+  const data: LsAaiTokenResponse = await response.json();
+
+  if (!response.ok) {
+    throw new Error(
+      `LS-AAI token exchange failed: ${response.status} ${data.error ?? response.statusText}`
+    );
+  }
+
+  if (!data.access_token) {
+    throw new Error("LS-AAI token exchange returned no access_token");
+  }
+
+  return data.access_token;
+}
+
+/**
+ * Step 2: Fetches the GA4GH Passport from the LS-AAI userinfo endpoint using
+ * an LS-AAI access token.
+ *
+ * POST `{LS_AAI_USERINFO_URL}`
+ *
+ * @param lsAaiAccessToken - A valid LS-AAI access token.
+ * @returns Array of raw GA4GH Passport JWTs from the `ga4gh_passport_v1` claim.
+ * @throws If the userinfo request fails with a non-OK status.
+ */
+async function fetchPassportFromLsAai(
+  lsAaiAccessToken: string
+): Promise<string[]> {
+  const userinfoUrl =
+    process.env.LS_AAI_USERINFO_URL ??
+    "https://login.aai.lifescience-ri.eu/oidc/userinfo";
+
+  const response = await fetch(userinfoUrl, {
+    method: "POST",
+    headers: {
+      Authorization: `Bearer ${lsAaiAccessToken}`,
+    },
+    cache: "no-store",
+  });
+
+  const data: UserinfoResponse = await response.json();
+
+  if (!response.ok) {
+    throw new Error(
+      `LS-AAI userinfo request failed: ${response.status} ${data.error ?? response.statusText}`
+    );
+  }
+
+  return data.ga4gh_passport_v1 ?? [];
+}
+
+/**
+ * Fetches the GA4GH Passport for the current user via a two-step flow:
+ *  1. Exchange the Keycloak access token for an LS-AAI access token.
+ *  2. Call the LS-AAI userinfo endpoint to retrieve `ga4gh_passport_v1`.
+ *
+ * @returns Array of raw Passport JWTs, or an empty array if the user is
+ *   unauthenticated.
+ * @throws If either the token exchange or the userinfo request fails.
+ */
+export async function fetchGa4ghPassport(): Promise<string[]> {
+  const keycloakAccessToken = await getToken("access_token");
+
+  if (!keycloakAccessToken) {
+    return [];
+  }
+
+  const lsAaiAccessToken =
+    await exchangeKeycloakTokenForLsAai(keycloakAccessToken);
+
+  return fetchPassportFromLsAai(lsAaiAccessToken);
+}

--- a/src/app/api/ga4gh/passport.ts
+++ b/src/app/api/ga4gh/passport.ts
@@ -34,7 +34,9 @@ async function exchangeKeycloakTokenForLsAai(
 ): Promise<string> {
   const keycloakIssuerUrl = process.env.KEYCLOAK_ISSUER_URL;
   if (!keycloakIssuerUrl) {
-    throw new Error("Missing required environment variable: KEYCLOAK_ISSUER_URL");
+    throw new Error(
+      "Missing required environment variable: KEYCLOAK_ISSUER_URL"
+    );
   }
   const brokerUrl = `${keycloakIssuerUrl}/broker/LSAAI/token`;
 
@@ -46,13 +48,13 @@ async function exchangeKeycloakTokenForLsAai(
     cache: "no-store",
   });
 
-  const data: LsAaiTokenResponse = await response.json();
-
   if (!response.ok) {
     throw new Error(
-      `LS-AAI token exchange failed: ${response.status} ${data.error ?? response.statusText}`
+      `LS-AAI token exchange failed: ${response.status} ${response.statusText}`
     );
   }
+
+  const data: LsAaiTokenResponse = await response.json();
 
   if (!data.access_token) {
     throw new Error("LS-AAI token exchange returned no access_token");
@@ -76,7 +78,9 @@ async function fetchPassportFromLsAai(
 ): Promise<string[]> {
   const userinfoUrl = process.env.LS_AAI_USERINFO_URL;
   if (!userinfoUrl) {
-    throw new Error("Missing required environment variable: LS_AAI_USERINFO_URL");
+    throw new Error(
+      "Missing required environment variable: LS_AAI_USERINFO_URL"
+    );
   }
 
   const response = await fetch(userinfoUrl, {
@@ -87,13 +91,13 @@ async function fetchPassportFromLsAai(
     cache: "no-store",
   });
 
-  const data: UserinfoResponse = await response.json();
-
   if (!response.ok) {
     throw new Error(
-      `LS-AAI userinfo request failed: ${response.status} ${data.error ?? response.statusText}`
+      `LS-AAI userinfo request failed: ${response.status} ${response.statusText}`
     );
   }
+
+  const data: UserinfoResponse = await response.json();
 
   return data.ga4gh_passport_v1 ?? [];
 }

--- a/src/app/api/ga4gh/passport.ts
+++ b/src/app/api/ga4gh/passport.ts
@@ -32,7 +32,11 @@ type UserinfoResponse = {
 async function exchangeKeycloakTokenForLsAai(
   keycloakAccessToken: string
 ): Promise<string> {
-  const brokerUrl = `${process.env.KEYCLOAK_ISSUER_URL}/broker/LSAAI/token`;
+  const keycloakIssuerUrl = process.env.KEYCLOAK_ISSUER_URL;
+  if (!keycloakIssuerUrl) {
+    throw new Error("Missing required environment variable: KEYCLOAK_ISSUER_URL");
+  }
+  const brokerUrl = `${keycloakIssuerUrl}/broker/LSAAI/token`;
 
   const response = await fetch(brokerUrl, {
     method: "GET",
@@ -70,9 +74,10 @@ async function exchangeKeycloakTokenForLsAai(
 async function fetchPassportFromLsAai(
   lsAaiAccessToken: string
 ): Promise<string[]> {
-  const userinfoUrl =
-    process.env.LS_AAI_USERINFO_URL ??
-    "https://login.aai.lifescience-ri.eu/oidc/userinfo";
+  const userinfoUrl = process.env.LS_AAI_USERINFO_URL;
+  if (!userinfoUrl) {
+    throw new Error("Missing required environment variable: LS_AAI_USERINFO_URL");
+  }
 
   const response = await fetch(userinfoUrl, {
     method: "POST",

--- a/src/app/api/ga4gh/passport.ts
+++ b/src/app/api/ga4gh/passport.ts
@@ -49,8 +49,15 @@ async function exchangeKeycloakTokenForLsAai(
   });
 
   if (!response.ok) {
+    let detail = response.statusText;
+    try {
+      const errorBody = await response.json();
+      if (errorBody.error) detail = errorBody.error;
+    } catch {
+      // non-JSON body — keep statusText
+    }
     throw new Error(
-      `LS-AAI token exchange failed: ${response.status} ${response.statusText}`
+      `LS-AAI token exchange failed: ${response.status} ${detail}`
     );
   }
 
@@ -92,8 +99,15 @@ async function fetchPassportFromLsAai(
   });
 
   if (!response.ok) {
+    let detail = response.statusText;
+    try {
+      const errorBody = await response.json();
+      if (errorBody.error) detail = errorBody.error;
+    } catch {
+      // non-JSON body — keep statusText
+    }
     throw new Error(
-      `LS-AAI userinfo request failed: ${response.status} ${response.statusText}`
+      `LS-AAI userinfo request failed: ${response.status} ${detail}`
     );
   }
 

--- a/src/app/api/ga4gh/visa.ts
+++ b/src/app/api/ga4gh/visa.ts
@@ -1,0 +1,75 @@
+// SPDX-FileCopyrightText: 2026 PNED G.I.E.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+import { jwtDecode } from "jwt-decode";
+
+export type Ga4ghVisaV1 = {
+  type: string;
+  value: string;
+  source: string;
+  by: string;
+  asserted: number;
+};
+
+export type Ga4ghVisaPayload = {
+  iss: string;
+  sub: string;
+  iat: number;
+  exp: number;
+  ga4gh_visa_v1: Ga4ghVisaV1;
+};
+
+export type ControlledAccessGrant = {
+  datasetId: string;
+  source: string;
+  by: string;
+  asserted: number;
+  exp: number;
+};
+
+const CONTROLLED_ACCESS_GRANTS = "ControlledAccessGrants";
+
+/**
+ * Decodes the payload of a GA4GH Visa JWT without verifying the signature.
+ *
+ * @returns The decoded payload, or `null` if the JWT is malformed or is
+ *   missing the `ga4gh_visa_v1` claim.
+ */
+export function decodeVisaPayload(jwt: string): Ga4ghVisaPayload | null {
+  try {
+    const payload = jwtDecode<Ga4ghVisaPayload>(jwt);
+    if (!payload.ga4gh_visa_v1) {
+      return null;
+    }
+    return payload;
+  } catch {
+    return null;
+  }
+}
+
+/**
+ * Extracts `ControlledAccessGrants` visas from a GA4GH Passport (array of
+ * raw Visa JWTs). All other visa types are silently ignored.
+ *
+ * @param passportJwts - Raw Visa JWT strings from the `ga4gh_passport_v1` claim.
+ * @returns Structured `ControlledAccessGrant` objects for every valid
+ *   `ControlledAccessGrants` visa found in the passport.
+ */
+export function extractControlledAccessGrants(
+  passportJwts: string[]
+): ControlledAccessGrant[] {
+  return passportJwts
+    .map(decodeVisaPayload)
+    .filter(
+      (visa): visa is Ga4ghVisaPayload =>
+        visa !== null && visa.ga4gh_visa_v1.type === CONTROLLED_ACCESS_GRANTS
+    )
+    .map((visa) => ({
+      datasetId: visa.ga4gh_visa_v1.value,
+      source: visa.ga4gh_visa_v1.source,
+      by: visa.ga4gh_visa_v1.by,
+      asserted: visa.ga4gh_visa_v1.asserted,
+      exp: visa.exp,
+    }));
+}

--- a/src/app/api/ga4gh/visa.ts
+++ b/src/app/api/ga4gh/visa.ts
@@ -9,23 +9,24 @@ export type Ga4ghVisaV1 = {
   value: string;
   source: string;
   by: string;
-  asserted: number;
+  iat?: number;
+  exp?: number;
 };
 
 export type Ga4ghVisaPayload = {
   iss: string;
   sub: string;
-  iat: number;
-  exp: number;
+  iat?: number;
+  exp?: number;
   ga4gh_visa_v1: Ga4ghVisaV1;
 };
 
 export type ControlledAccessGrant = {
   datasetId: string;
+  iat?: number;
   source: string;
   by: string;
-  asserted: number;
-  exp: number;
+  exp?: number;
 };
 
 const CONTROLLED_ACCESS_GRANTS = "ControlledAccessGrants";
@@ -67,9 +68,9 @@ export function extractControlledAccessGrants(
     )
     .map((visa) => ({
       datasetId: visa.ga4gh_visa_v1.value,
+      iat: visa.ga4gh_visa_v1.iat ?? visa.iat,
       source: visa.ga4gh_visa_v1.source,
       by: visa.ga4gh_visa_v1.by,
-      asserted: visa.ga4gh_visa_v1.asserted,
-      exp: visa.exp,
+      exp: visa.ga4gh_visa_v1.exp ?? visa.exp,
     }));
 }

--- a/src/app/api/ga4gh/visa.ts
+++ b/src/app/api/ga4gh/visa.ts
@@ -2,6 +2,7 @@
 //
 // SPDX-License-Identifier: Apache-2.0
 
+import "server-only";
 import { jwtDecode } from "jwt-decode";
 
 export type Ga4ghVisaV1 = {

--- a/src/app/requests/entitlements/entitlementCardItems.ts
+++ b/src/app/requests/entitlements/entitlementCardItems.ts
@@ -13,7 +13,7 @@ import { SearchedDataset } from "@/app/api/discovery/open-api/schemas";
 
 export function createEntitlementCardItems(
   dataset: SearchedDataset,
-  start: string,
+  start?: string,
   end?: string
 ): CardItem[] {
   return [

--- a/src/config/serverConfig.ts
+++ b/src/config/serverConfig.ts
@@ -6,11 +6,13 @@ import { env } from "next-runtime-env";
 interface ServerConfig {
   discoveryUrl: string;
   daamUrl: string;
+  entitlementsV2Enabled: boolean;
 }
 
 const serverConfig: ServerConfig = {
   daamUrl: env("NEXT_PUBLIC_DAAM_URL") || "http://localhost:8080",
   discoveryUrl: env("NEXT_PUBLIC_DDS_URL") || "http://localhost:8080",
+  entitlementsV2Enabled: process.env.ENTITLEMENTS_V2_ENABLED === "true",
 };
 
 export default serverConfig;

--- a/src/utils/datasetEntitlements.ts
+++ b/src/utils/datasetEntitlements.ts
@@ -6,9 +6,11 @@ import {
   DatasetSearchQuery,
   SearchedDataset,
 } from "@/app/api/discovery/open-api/schemas";
-import { Entitlement } from "@/app/api/access-management/open-api/schemas";
 import { searchDatasetsApi } from "@/app/api/discovery";
-import { DatasetEntitlement } from "@/app/api/access-management/additional-types";
+import {
+  DatasetEntitlement,
+  Entitlement,
+} from "@/app/api/access-management/additional-types";
 import { QueryOperator } from "@/app/api/discovery/additional-types";
 
 export const mapToDatasetEntitlement = (


### PR DESCRIPTION
…(ART-27579)

- Add two-step passport fetch: Keycloak broker token exchange → LS-AAI userinfo
- Decode GA4GH Visa JWTs and extract ControlledAccessGrants visas (ART-27609)
- Map ControlledAccessGrants to structured Entitlement model
- Add unit tests for passport fetch, visa decoding, and entitlement mapping

## Summary by Sourcery

Introduce a GA4GH Passport/Visa-based entitlement retrieval path alongside the existing DAAM-based entitlements API.

New Features:
- Add a GA4GH Passport two-step retrieval flow via Keycloak broker and LS-AAI userinfo to obtain ga4gh_passport_v1 visas.
- Decode GA4GH Visa JWTs and extract ControlledAccessGrants visas into structured entitlements with ISO 8601 validity periods.
- Add a feature flag to switch the entitlements API between legacy DAAM-based retrieval and the new GA4GH-based flow.

Tests:
- Add unit tests covering GA4GH passport fetching, visa decoding, and ControlledAccessGrants-to-entitlement mapping.