### PR TITLE
fix: hasStructuredData type to be able to harvest data dictionary 

### DIFF
--- a/src/app/api/discovery/harvester/__tests__/dcat-harvester-service.test.ts
+++ b/src/app/api/discovery/harvester/__tests__/dcat-harvester-service.test.ts
@@ -379,6 +379,30 @@ describe("DcatHarvesterService", () => {
     ]);
   });
 
+  test("derives hasStructuredData from dct:type STRUCTURED_DATA concept when no boolean literal is present", async () => {
+    const service = new DcatHarvesterService();
+    const rdf = `
+      <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+               xmlns:dcat="http://www.w3.org/ns/dcat#"
+               xmlns:dct="http://purl.org/dc/terms/"
+               xmlns:skos="http://www.w3.org/2004/02/skos/core#">
+        <dcat:Dataset rdf:about="https://example.org/datasets/1">
+          <dct:title>Dataset A</dct:title>
+          <dct:description>Description A</dct:description>
+          <dct:type>
+            <skos:Concept rdf:about="http://publications.europa.eu/resource/authority/dataset-type/TEST_DATA"/>
+          </dct:type>
+          <dct:type>
+            <skos:Concept rdf:about="http://publications.europa.eu/resource/authority/dataset-type/STRUCTURED_DATA"/>
+          </dct:type>
+        </dcat:Dataset>
+      </rdf:RDF>
+    `;
+
+    const datasets = await service.parseDatasetsFromRdf(rdf);
+    expect(datasets[0].hasStructuredData).toBe(true);
+  });
+
   test("parses distributions exposed under healthdcatap analytics", async () => {
     const service = new DcatHarvesterService();
     const rdf = `

--- a/src/app/api/discovery/harvester/dcat-dataset-mapper.ts
+++ b/src/app/api/discovery/harvester/dcat-dataset-mapper.ts
@@ -46,6 +46,8 @@ const HEALTHDCATAP_MIN_TYPICAL_AGE =
   "http://healthdataportal.eu/ns/health#minTypicalAge"; // NOSONAR
 const HEALTHDCATAP_HAS_STRUCTURED_DATA =
   "http://healthdataportal.eu/ns/health#hasStructuredData"; // NOSONAR
+const DATASET_TYPE_STRUCTURED_DATA =
+  "http://publications.europa.eu/resource/authority/dataset-type/STRUCTURED_DATA"; // NOSONAR
 const HEALTHDCATAP_POPULATION_COVERAGE =
   "http://healthdataportal.eu/ns/health#populationCoverage"; // NOSONAR
 const DCAT_SPATIAL_RESOLUTION_IN_METERS =
@@ -150,11 +152,12 @@ export const mapDataset = (
       graph,
       HEALTHDCATAP_MIN_TYPICAL_AGE
     ),
-    hasStructuredData: extractBooleanLiteral(
-      datasetSubject,
-      graph,
-      HEALTHDCATAP_HAS_STRUCTURED_DATA
-    ),
+    hasStructuredData:
+      extractBooleanLiteral(
+        datasetSubject,
+        graph,
+        HEALTHDCATAP_HAS_STRUCTURED_DATA
+      ) ?? hasStructuredDataTypeConcept(datasetSubject, graph),
     spatialCoverage: extractSpatialCoverage(datasetSubject, graph),
     populationCoverage: extractPopulationCoverage(datasetSubject, graph),
     spatialResolutionInMeters: extractSpatialResolutionInMeters(
@@ -313,6 +316,19 @@ const extractBooleanLiteral = (
   if (value === "true") return true;
   if (value === "false") return false;
   return undefined;
+};
+
+const hasStructuredDataTypeConcept = (
+  datasetSubject: RDF.Term,
+  graph: RdfGraph
+): boolean | undefined => {
+  const isStructuredData = graph
+    .getObjects(datasetSubject, DCT_TYPE)
+    .some(
+      (type) => graph.getNamedNodeValue(type) === DATASET_TYPE_STRUCTURED_DATA
+    );
+
+  return isStructuredData ? true : undefined;
 };
 
 const extractPopulationCoverage = (


### PR DESCRIPTION
<img width="1290" height="668" alt="image" src="https://github.com/user-attachments/assets/593b6056-9275-420e-8ab4-d1322898e903" />

This pr is about making hasStructuredData detect MDC's real signal (a dct:type pointing to STRUCTURED_DATA) instead of the nonexistent boolean literal it was looking for before

## Summary by Sourcery

Derive dataset hasStructuredData from both the healthdcatap boolean property and the DCAT dct:type STRUCTURED_DATA concept to correctly detect structured data dictionaries.

Bug Fixes:
- Fix hasStructuredData detection by falling back to the STRUCTURED_DATA dataset-type concept when the HealthDCATAP boolean literal is not present.

Tests:
- Add a harvester service test that verifies hasStructuredData is inferred from a dct:type STRUCTURED_DATA concept in the absence of an explicit boolean literal.