### PR TITLE
fix: search by keywords

### DIFF
--- a/src/app/api/discovery/local-store/opensearch/queries.ts
+++ b/src/app/api/discovery/local-store/opensearch/queries.ts
@@ -16,7 +16,13 @@ const fullTextSearchFields = [
   "versionNotes",
 ];
 
-const keywordSearchFields = ["id", "identifier", "catalogue", "version"];
+const keywordSearchFields = [
+  "id",
+  "identifier",
+  "catalogue",
+  "version",
+  "keywords",
+];
 
 const phrasePrefixFields = [
   "title^4",


### PR DESCRIPTION
## Summary by Sourcery

New Features:
- Allow keyword-based searches to match against the `keywords` field in the local opensearch discovery index.