### PR TITLE
ART-27612 add source and by labels to entitlement cards

### DIFF
--- a/src/app/api/access-management/additional-types.ts
+++ b/src/app/api/access-management/additional-types.ts
@@ -42,10 +42,14 @@ export type Entitlement = {
   datasetId: string;
   start?: string;
   end?: string;
+  source?: string;
+  by?: string;
 };
 
 export type DatasetEntitlement = {
   dataset: SearchedDataset;
   start?: string;
   end?: string;
+  source?: string;
+  by?: string;
 };

--- a/src/app/api/ga4gh/entitlements.ts
+++ b/src/app/api/ga4gh/entitlements.ts
@@ -23,6 +23,8 @@ export const retrieveEntitlementsV2 = async () => {
     datasetId: grant.datasetId,
     start: grant.iat ? new Date(grant.iat * 1000).toISOString() : undefined,
     end: grant.exp ? new Date(grant.exp * 1000).toISOString() : undefined,
+    source: grant.source,
+    by: grant.by,
   }));
 
   return { entitlements };

--- a/src/app/datasets/DatasetCard.tsx
+++ b/src/app/datasets/DatasetCard.tsx
@@ -30,14 +30,14 @@ type DatasetCardProps = {
   dataset: SearchedDataset;
   cardItems: CardItem[];
   displayBasketButton?: boolean;
-  entityLabel?: string;
+  sourceLabel?: string;
 };
 
 function DatasetCard({
   dataset,
   cardItems,
   displayBasketButton = true,
-  entityLabel: entityLabelProp,
+  sourceLabel: sourceLabelProp,
 }: Readonly<DatasetCardProps>) {
   const t = useTranslations("basket");
   const tDetail = useTranslations("datasets.detail");
@@ -185,7 +185,7 @@ function DatasetCard({
       isExternal={isExternal}
       externalLabel={externalLabel}
       entityLabel={entityLabel}
-      sourceLabel={entityLabelProp}
+      sourceLabel={sourceLabelProp}
     />
   );
 }

--- a/src/app/datasets/DatasetCard.tsx
+++ b/src/app/datasets/DatasetCard.tsx
@@ -30,12 +30,14 @@ type DatasetCardProps = {
   dataset: SearchedDataset;
   cardItems: CardItem[];
   displayBasketButton?: boolean;
+  entityLabel?: string;
 };
 
 function DatasetCard({
   dataset,
   cardItems,
   displayBasketButton = true,
+  entityLabel: entityLabelProp,
 }: Readonly<DatasetCardProps>) {
   const t = useTranslations("basket");
   const tDetail = useTranslations("datasets.detail");
@@ -183,6 +185,7 @@ function DatasetCard({
       isExternal={isExternal}
       externalLabel={externalLabel}
       entityLabel={entityLabel}
+      sourceLabel={entityLabelProp}
     />
   );
 }

--- a/src/app/requests/entitlements/EntitlementCard.tsx
+++ b/src/app/requests/entitlements/EntitlementCard.tsx
@@ -9,20 +9,20 @@ import { SearchedDataset } from "@/app/api/discovery/open-api/schemas";
 type EntitlementCardProps = {
   dataset: SearchedDataset;
   cardItems: CardItem[];
-  entityLabel?: string;
+  sourceLabel?: string;
 };
 
 function EntitlementCard({
   dataset,
   cardItems,
-  entityLabel,
+  sourceLabel,
 }: Readonly<EntitlementCardProps>) {
   return (
     <DatasetCard
       dataset={dataset}
       cardItems={cardItems}
       displayBasketButton={false}
-      entityLabel={entityLabel}
+      sourceLabel={sourceLabel}
     />
   );
 }

--- a/src/app/requests/entitlements/EntitlementCard.tsx
+++ b/src/app/requests/entitlements/EntitlementCard.tsx
@@ -9,19 +9,20 @@ import { SearchedDataset } from "@/app/api/discovery/open-api/schemas";
 type EntitlementCardProps = {
   dataset: SearchedDataset;
   cardItems: CardItem[];
-  start?: string;
-  end?: string;
+  entityLabel?: string;
 };
 
 function EntitlementCard({
   dataset,
   cardItems,
+  entityLabel,
 }: Readonly<EntitlementCardProps>) {
   return (
     <DatasetCard
       dataset={dataset}
       cardItems={cardItems}
       displayBasketButton={false}
+      entityLabel={entityLabel}
     />
   );
 }

--- a/src/app/requests/entitlements/EntitlementsList.tsx
+++ b/src/app/requests/entitlements/EntitlementsList.tsx
@@ -7,15 +7,17 @@ import ListItem from "@/components/List/ListItem";
 import EntitlementCard from "./EntitlementCard";
 import {
   createEntitlementCardItems,
-  formatEntitlementEntityLabel,
+  formatEntitlementSourceLabel,
 } from "./entitlementCardItems";
 import { DatasetEntitlement } from "@/app/api/access-management/additional-types";
+import { useTranslations } from "next-intl";
 
 type EntitlementsListProps = {
   entitlements: DatasetEntitlement[];
 };
 
 function EntitlementsList({ entitlements }: Readonly<EntitlementsListProps>) {
+  const t = useTranslations("requests.entitlements");
   return (
     <List>
       {entitlements.map(
@@ -32,9 +34,10 @@ function EntitlementsList({ entitlements }: Readonly<EntitlementsListProps>) {
                   entitlement.start,
                   entitlement.end
                 )}
-                entityLabel={formatEntitlementEntityLabel(
+                sourceLabel={formatEntitlementSourceLabel(
                   entitlement.source,
-                  entitlement.by
+                  entitlement.by,
+                  { grantedBy: t("grantedBy"), source: t("source") }
                 )}
               />
             </ListItem>

--- a/src/app/requests/entitlements/EntitlementsList.tsx
+++ b/src/app/requests/entitlements/EntitlementsList.tsx
@@ -5,7 +5,10 @@
 import List from "@/components/List";
 import ListItem from "@/components/List/ListItem";
 import EntitlementCard from "./EntitlementCard";
-import { createEntitlementCardItems } from "./entitlementCardItems";
+import {
+  createEntitlementCardItems,
+  formatEntitlementEntityLabel,
+} from "./entitlementCardItems";
 import { DatasetEntitlement } from "@/app/api/access-management/additional-types";
 
 type EntitlementsListProps = {
@@ -28,6 +31,10 @@ function EntitlementsList({ entitlements }: Readonly<EntitlementsListProps>) {
                   entitlement.dataset,
                   entitlement.start,
                   entitlement.end
+                )}
+                entityLabel={formatEntitlementEntityLabel(
+                  entitlement.source,
+                  entitlement.by
                 )}
               />
             </ListItem>

--- a/src/app/requests/entitlements/__tests__/entitlementCardItems.test.ts
+++ b/src/app/requests/entitlements/__tests__/entitlementCardItems.test.ts
@@ -2,7 +2,10 @@
 //
 // SPDX-License-Identifier: Apache-2.0
 
-import { createEntitlementCardItems } from "../entitlementCardItems";
+import {
+  createEntitlementCardItems,
+  formatEntitlementSourceLabel,
+} from "../entitlementCardItems";
 import { SearchedDataset } from "@/app/api/discovery/open-api/schemas";
 
 describe("entitlementCardItems", () => {
@@ -47,5 +50,46 @@ describe("entitlementCardItems", () => {
     expect(items[6].text).toBe("");
     expect(items[7].text).toBe("Start: 23 June 2024");
     expect(items[8].text).toBe("End: N/A");
+  });
+});
+
+describe("formatEntitlementSourceLabel", () => {
+  it("returns undefined when both source and by are undefined", () => {
+    expect(formatEntitlementSourceLabel(undefined, undefined)).toBeUndefined();
+  });
+
+  it("returns undefined when both source and by are empty strings", () => {
+    expect(formatEntitlementSourceLabel("", "")).toBeUndefined();
+  });
+
+  it("returns only the by part when source is absent", () => {
+    expect(formatEntitlementSourceLabel(undefined, "REMS")).toBe(
+      "Granted by: REMS"
+    );
+  });
+
+  it("returns only the source part when by is absent", () => {
+    expect(formatEntitlementSourceLabel("ckan", undefined)).toBe(
+      "Source: ckan"
+    );
+  });
+
+  it("returns combined label when both source and by are present", () => {
+    expect(formatEntitlementSourceLabel("ckan", "REMS")).toBe(
+      "Granted by: REMS | Source: ckan"
+    );
+  });
+
+  it("uses translated messages when provided", () => {
+    const messages = { grantedBy: "Accordé par", source: "Source" };
+    expect(formatEntitlementSourceLabel("ckan", "REMS", messages)).toBe(
+      "Accordé par: REMS | Source: ckan"
+    );
+  });
+
+  it("falls back to English when messages are not provided", () => {
+    expect(formatEntitlementSourceLabel("ckan", "REMS")).toBe(
+      "Granted by: REMS | Source: ckan"
+    );
   });
 });

--- a/src/app/requests/entitlements/entitlementCardItems.ts
+++ b/src/app/requests/entitlements/entitlementCardItems.ts
@@ -29,14 +29,22 @@ export function createEntitlementCardItems(
   ];
 }
 
-export function formatEntitlementEntityLabel(
+export type EntitlementLabelMessages = {
+  grantedBy: string;
+  source: string;
+};
+
+export function formatEntitlementSourceLabel(
   source?: string,
-  by?: string
+  by?: string,
+  messages?: EntitlementLabelMessages
 ): string | undefined {
   if (!source && !by) return undefined;
+  const grantedByLabel = messages?.grantedBy ?? "Granted by";
+  const sourceLabel = messages?.source ?? "Source";
   const parts = [
-    by ? `Granted by: ${by}` : null,
-    source ? `Source: ${source}` : null,
-  ].filter(Boolean);
+    by ? `${grantedByLabel}: ${by}` : null,
+    source ? `${sourceLabel}: ${source}` : null,
+  ].filter(Boolean) as string[];
   return parts.join(" | ");
 }

--- a/src/app/requests/entitlements/entitlementCardItems.ts
+++ b/src/app/requests/entitlements/entitlementCardItems.ts
@@ -28,3 +28,15 @@ export function createEntitlementCardItems(
     },
   ];
 }
+
+export function formatEntitlementEntityLabel(
+  source?: string,
+  by?: string
+): string | undefined {
+  if (!source && !by) return undefined;
+  const parts = [
+    by ? `Granted by: ${by}` : null,
+    source ? `Source: ${source}` : null,
+  ].filter(Boolean);
+  return parts.join(" | ");
+}

--- a/src/components/Card.tsx
+++ b/src/components/Card.tsx
@@ -6,6 +6,7 @@ import {
   IconDefinition,
   faCircleInfo,
   faLayerGroup,
+  faStamp,
 } from "@fortawesome/free-solid-svg-icons";
 import { FontAwesomeIcon } from "@fortawesome/react-fontawesome";
 import { Link } from "@/i18n/navigation";
@@ -30,6 +31,7 @@ type CardProps = {
   isExternal?: boolean;
   externalLabel?: string;
   entityLabel?: string;
+  sourceLabel?: string;
 };
 
 export default function Card({
@@ -44,6 +46,7 @@ export default function Card({
   isExternal: isExternalProp,
   externalLabel,
   entityLabel,
+  sourceLabel,
 }: CardProps) {
   const t = useTranslations();
   const isExternal = isExternalProp ?? !!externalUrl;
@@ -73,11 +76,21 @@ export default function Card({
             <div className="font-bold text-[20px] group-hover:text-info group-hover:underline">
               {title}
             </div>
-            {entityLabel && (
-              <span className="inline-flex items-center gap-1.5 text-xs font-semibold px-3 py-1 rounded-full bg-info/10 text-info border border-info/20 shrink-0">
-                <FontAwesomeIcon icon={faLayerGroup} className="w-3 h-3" />
-                {entityLabel}
-              </span>
+            {(entityLabel || sourceLabel) && (
+              <div className="inline-flex flex-wrap gap-1.5 shrink-0">
+                {entityLabel && (
+                  <span className="inline-flex items-center gap-1.5 text-xs font-semibold px-3 py-1 rounded-full bg-info/10 text-info border border-info/20">
+                    <FontAwesomeIcon icon={faLayerGroup} className="w-3 h-3" />
+                    {entityLabel}
+                  </span>
+                )}
+                {sourceLabel && (
+                  <span className="inline-flex items-center gap-1.5 text-xs font-semibold px-3 py-1 rounded-full bg-info/10 text-info border border-info/20">
+                    <FontAwesomeIcon icon={faStamp} className="w-3 h-3" />
+                    {sourceLabel}
+                  </span>
+                )}
+              </div>
             )}
           </div>
 

--- a/src/i18n/messages.json
+++ b/src/i18n/messages.json
@@ -979,6 +979,14 @@
     "en": "You don't have any entitlement yet.\nWait for your application(s) to be approved, or submit a new application.",
     "fr": "Vous n'avez encore aucune autorisation.\nAttendez l'approbation de votre ou vos demande(s), ou soumettez une nouvelle demande."
   },
+  "requests.entitlements.grantedBy": {
+    "en": "Granted by",
+    "fr": "Accordé par"
+  },
+  "requests.entitlements.source": {
+    "en": "Source",
+    "fr": "Source"
+  },
   "application.title": {
     "en": "Application {id}",
     "fr": "Demande {id}"

--- a/src/utils/__tests__/datasetEntitlements.test.ts
+++ b/src/utils/__tests__/datasetEntitlements.test.ts
@@ -35,17 +35,42 @@ describe("datasetEntitlements", () => {
         dataset: { identifier: "1", title: "Dataset 1" },
         start: "2021-01-01",
         end: "2021-12-31",
+        source: undefined,
+        by: undefined,
       },
       {
         dataset: { identifier: "2", title: "Dataset 2" },
         start: "2022-01-01",
         end: "2022-12-31",
+        source: undefined,
+        by: undefined,
       },
     ];
 
     const result = mapToDatasetEntitlement(datasets, entitlements);
 
     expect(result).toEqual(expected);
+  });
+
+  it("should map source and by fields from entitlements", () => {
+    const datasets: SearchedDataset[] = [
+      { identifier: "1", title: "Dataset 1" } as SearchedDataset,
+    ];
+
+    const entitlements: Entitlement[] = [
+      {
+        datasetId: "1",
+        start: "2021-01-01",
+        end: "2021-12-31",
+        source: "ckan",
+        by: "REMS",
+      } as Entitlement,
+    ];
+
+    const result = mapToDatasetEntitlement(datasets, entitlements);
+
+    expect(result[0].source).toBe("ckan");
+    expect(result[0].by).toBe("REMS");
   });
 
   it("should return an empty array if no match between datasets and entitlements", () => {

--- a/src/utils/datasetEntitlements.ts
+++ b/src/utils/datasetEntitlements.ts
@@ -27,6 +27,8 @@ export const mapToDatasetEntitlement = (
       ) as SearchedDataset,
       start: e.start,
       end: e.end,
+      source: e.source,
+      by: e.by,
     }));
 };
 


### PR DESCRIPTION
## Summary by Sourcery

Surface entitlement source and granter information on entitlement dataset cards and propagate the new fields through the entitlement data flow.

New Features:
- Add support for displaying an additional source label alongside the existing entity label on generic cards.
- Expose entitlement source and granter (by) fields on entitlement dataset cards via a formatted label.

Enhancements:
- Extend entitlement and dataset entitlement types and GA4GH entitlement mapping to include source and by metadata.
- Refine dataset card composition to pass separate entity and source labels into the shared Card component.
<img width="1314" height="452" alt="image" src="https://github.com/user-attachments/assets/aed87d92-c99b-40e1-8a4a-5f13d2364e8c" />
