### PR TITLE
ART-28209 fix for allele freq filters

### DIFF
--- a/.env.local.example
+++ b/.env.local.example
@@ -58,3 +58,8 @@ HELPDESK_ZAMMAD_API_TOKEN=<token-from-zammad-user-profile>
 HELPDESK_ZAMMAD_DEFAULT_GROUP=Users
 # Optional for internal/self-signed HTTPS certificates
 HELPDESK_ZAMMAD_TLS_INSECURE=true
+
+# Feature flag: set to 'true' to enable GA4GH Passport/Visa-based entitlements (V2 path)
+ENTITLEMENTS_V2_ENABLED=true
+KEYCLOAK_CLIENT_SCOPE=openid profile email elixir_id ga4gh_passport_v1
+LS_AAI_USERINFO_URL=https://login.aai.lifescience-ri.eu/oidc/userinfo

--- a/src/app/allele-frequency/GVariantsTable.tsx
+++ b/src/app/allele-frequency/GVariantsTable.tsx
@@ -71,14 +71,12 @@ export default function GVariantsTable({
     [datasetActions]
   );
 
-  const rowsForSummary = useMemo(
-    () => GVariantsTableUtils.getRowsForSummary(sortedResults),
-    [sortedResults]
-  );
-
   const summaryData = useMemo(
-    () => GVariantsTableUtils.buildSummaryData(rowsForSummary),
-    [rowsForSummary]
+    () =>
+      GVariantsTableUtils.buildSummaryData(
+        GVariantsTableUtils.getEffectiveTotals(groupedByBeacon)
+      ),
+    [groupedByBeacon]
   );
 
   const variantGroups = useMemo(
@@ -292,9 +290,9 @@ export default function GVariantsTable({
                                 NOT_AVAILABLE;
                               const totals =
                                 datasetGroup.totalVariant ??
-                                (datasetGroup.variants.length === 1
-                                  ? datasetGroup.variants[0]
-                                  : undefined);
+                                GVariantsTableUtils.aggregateVariants(
+                                  datasetGroup.variants
+                                );
                               const rowsToRender =
                                 datasetGroup.variants.length > 0
                                   ? datasetGroup.variants

--- a/src/utils/GVariantsTableUtils.ts
+++ b/src/utils/GVariantsTableUtils.ts
@@ -40,11 +40,6 @@ export class GVariantsTableUtils {
     return value?.trim() || GVariantsTableUtils.NOT_AVAILABLE;
   }
 
-  static isTotalPopulation(population?: string): boolean {
-    const p = population?.trim().toLowerCase();
-    return p === "total" || p === "m" || p === "f";
-  }
-
   static getBeaconCountryLabel(beaconId: string): string | undefined {
     const parts = beaconId
       .toUpperCase()
@@ -163,14 +158,6 @@ export class GVariantsTableUtils {
         sensitivity: "base",
         numeric: true,
       })
-    );
-  }
-
-  static getRowsForSummary(
-    sortedResults: GVariantsSearchResponse[]
-  ): GVariantsSearchResponse[] {
-    return sortedResults.filter(
-      (variant) => !GVariantsTableUtils.isTotalPopulation(variant.population)
     );
   }
 

--- a/src/utils/GVariantsTableUtils.ts
+++ b/src/utils/GVariantsTableUtils.ts
@@ -40,6 +40,11 @@ export class GVariantsTableUtils {
     return value?.trim() || GVariantsTableUtils.NOT_AVAILABLE;
   }
 
+  static isTotalPopulation(population?: string): boolean {
+    const p = population?.trim().toLowerCase();
+    return p === "total" || p === "m" || p === "f";
+  }
+
   static getBeaconCountryLabel(beaconId: string): string | undefined {
     const parts = beaconId
       .toUpperCase()
@@ -95,7 +100,8 @@ export class GVariantsTableUtils {
   static groupByBeacon(
     sortedResults: GVariantsSearchResponse[]
   ): Record<string, BeaconGroup> {
-    return sortedResults.reduce(
+    // First pass: assign literal "total" rows to totalVariant; everything else to variants.
+    const result = sortedResults.reduce(
       (acc, variant) => {
         const datasetId = GVariantsTableUtils.getDisplayText(variant.datasetId);
         const beaconId = GVariantsTableUtils.getDisplayText(variant.beacon);
@@ -112,10 +118,8 @@ export class GVariantsTableUtils {
           };
         }
 
-        const population = GVariantsTableUtils.getDisplayText(
-          variant.population
-        ).toLowerCase();
-        if (population === "total") {
+        const population = variant.population?.trim();
+        if (population?.toLowerCase() === "total") {
           acc[beaconId].datasets[datasetId].totalVariant ??= variant;
           return acc;
         }
@@ -125,6 +129,32 @@ export class GVariantsTableUtils {
       },
       {} as Record<string, BeaconGroup>
     );
+
+    // Second pass: for groups that have no literal "total", promote the first
+    // country-code row (e.g. "FR") or sex-aggregate row ("m"/"f") to totalVariant.
+    // This avoids double-counting when a global "total" is also present.
+    for (const beaconGroup of Object.values(result)) {
+      for (const datasetGroup of Object.values(beaconGroup.datasets)) {
+        if (datasetGroup.totalVariant) continue;
+        const idx = datasetGroup.variants.findIndex((v) => {
+          const p = v.population?.trim();
+          const pu = p?.toUpperCase();
+          return (
+            p === "m" ||
+            p === "f" ||
+            p === "M" ||
+            p === "F" ||
+            (!!pu && GVariantsTableUtils.COUNTRY_BY_CODE.has(pu))
+          );
+        });
+        if (idx !== -1) {
+          datasetGroup.totalVariant = datasetGroup.variants[idx];
+          datasetGroup.variants.splice(idx, 1);
+        }
+      }
+    }
+
+    return result;
   }
 
   static getSortedBeaconIds(groupedByBeacon: Record<string, BeaconGroup>) {
@@ -140,9 +170,21 @@ export class GVariantsTableUtils {
     sortedResults: GVariantsSearchResponse[]
   ): GVariantsSearchResponse[] {
     return sortedResults.filter(
-      (variant) =>
-        GVariantsTableUtils.getDisplayText(variant.population).toLowerCase() !==
-        "total"
+      (variant) => !GVariantsTableUtils.isTotalPopulation(variant.population)
+    );
+  }
+
+  static getEffectiveTotals(
+    groupedByBeacon: Record<string, BeaconGroup>
+  ): GVariantsSearchResponse[] {
+    return Object.values(groupedByBeacon).flatMap((beaconGroup) =>
+      Object.values(beaconGroup.datasets)
+        .map(
+          (datasetGroup) =>
+            datasetGroup.totalVariant ??
+            GVariantsTableUtils.aggregateVariants(datasetGroup.variants)
+        )
+        .filter((v): v is GVariantsSearchResponse => v !== undefined)
     );
   }
 
@@ -240,6 +282,43 @@ export class GVariantsTableUtils {
         hasAlleleCount && hasAlleleNumber && alleleNumber > 0
           ? alleleCount / alleleNumber
           : null,
+    };
+  }
+
+  static aggregateVariants(
+    variants: GVariantsSearchResponse[]
+  ): GVariantsSearchResponse | undefined {
+    if (variants.length === 0) return undefined;
+    if (variants.length === 1) return variants[0];
+
+    let alleleCount = 0;
+    let alleleNumber = 0;
+    let hasAlleleCount = false;
+    let hasAlleleNumber = false;
+
+    for (const v of variants) {
+      if (GVariantsTableUtils.isNumber(v.alleleCount)) {
+        alleleCount += v.alleleCount;
+        hasAlleleCount = true;
+      }
+      if (GVariantsTableUtils.isNumber(v.alleleNumber)) {
+        alleleNumber += v.alleleNumber;
+        hasAlleleNumber = true;
+      }
+    }
+
+    return {
+      ...variants[0],
+      population: "total",
+      alleleCount: hasAlleleCount ? alleleCount : undefined,
+      alleleNumber: hasAlleleNumber ? alleleNumber : undefined,
+      alleleFrequency:
+        hasAlleleCount && hasAlleleNumber && alleleNumber > 0
+          ? alleleCount / alleleNumber
+          : undefined,
+      alleleCountHomozygous: undefined,
+      alleleCountHeterozygous: undefined,
+      alleleCountHemizygous: undefined,
     };
   }
 

--- a/src/utils/__tests__/GVariantsTableUtils.test.ts
+++ b/src/utils/__tests__/GVariantsTableUtils.test.ts
@@ -281,26 +281,6 @@ describe("GVariantsTableUtils", () => {
     });
   });
 
-  describe("getRowsForSummary", () => {
-    test("excludes total rows from summary rows", () => {
-      const rows = GVariantsTableUtils.getRowsForSummary([
-        variant({ population: "total" }),
-        variant({ population: "FI_F" }),
-      ]);
-
-      expect(rows).toHaveLength(1);
-      expect(rows[0].population).toBe("FI_F");
-    });
-
-    test("returns an empty list when only totals exist", () => {
-      const rows = GVariantsTableUtils.getRowsForSummary([
-        variant({ population: "total" }),
-      ]);
-
-      expect(rows).toEqual([]);
-    });
-  });
-
   describe("buildVariantLabel", () => {
     test("builds full label using one-based display position", () => {
       expect(

--- a/src/utils/__tests__/GVariantsTableUtils.test.ts
+++ b/src/utils/__tests__/GVariantsTableUtils.test.ts
@@ -91,17 +91,107 @@ describe("GVariantsTableUtils", () => {
         grouped["Beacon B"].datasets["DS-3"].totalVariant?.population
       ).toBe("total");
     });
-    test("keeps non-total aggregate rows as expandable variants", () => {
+    test("promotes sex-total row (M/F) to totalVariant and keeps country breakdowns as expandable variants", () => {
       const grouped = GVariantsTableUtils.groupByBeacon([
-        variant({ beacon: "Beacon A", datasetId: "DS-1", population: "M" }),
-        variant({ beacon: "Beacon A", datasetId: "DS-1", population: "ES_M" }),
-        variant({ beacon: "Beacon A", datasetId: "DS-1", population: "FR_M" }),
+        variant({
+          beacon: "Beacon A",
+          datasetId: "DS-1",
+          population: "FI_M",
+          alleleCount: 120,
+        }),
+        variant({
+          beacon: "Beacon A",
+          datasetId: "DS-1",
+          population: "FR_M",
+          alleleCount: 150,
+        }),
+        variant({
+          beacon: "Beacon A",
+          datasetId: "DS-1",
+          population: "M",
+          alleleCount: 270,
+        }),
       ]);
 
-      expect(grouped["Beacon A"].datasets["DS-1"].totalVariant).toBeUndefined();
+      expect(
+        grouped["Beacon A"].datasets["DS-1"].totalVariant?.population
+      ).toBe("M");
+      expect(
+        grouped["Beacon A"].datasets["DS-1"].totalVariant?.alleleCount
+      ).toBe(270);
       expect(
         grouped["Beacon A"].datasets["DS-1"].variants.map((it) => it.population)
-      ).toEqual(["M", "ES_M", "FR_M"]);
+      ).toEqual(["FI_M", "FR_M"]);
+    });
+    test("treats country-code population as totalVariant to avoid double-counting with sex breakdowns", () => {
+      const grouped = GVariantsTableUtils.groupByBeacon([
+        variant({
+          beacon: "Beacon A",
+          datasetId: "DS-1",
+          population: "FR",
+          alleleCount: 300,
+        }),
+        variant({
+          beacon: "Beacon A",
+          datasetId: "DS-1",
+          population: "FR_M",
+          alleleCount: 150,
+        }),
+        variant({
+          beacon: "Beacon A",
+          datasetId: "DS-1",
+          population: "FR_F",
+          alleleCount: 150,
+        }),
+      ]);
+
+      expect(
+        grouped["Beacon A"].datasets["DS-1"].totalVariant?.population
+      ).toBe("FR");
+      expect(
+        grouped["Beacon A"].datasets["DS-1"].totalVariant?.alleleCount
+      ).toBe(300);
+      expect(
+        grouped["Beacon A"].datasets["DS-1"].variants.map((it) => it.population)
+      ).toEqual(["FR_M", "FR_F"]);
+    });
+    test("prefers literal 'total' over country-code rows when both are present", () => {
+      const grouped = GVariantsTableUtils.groupByBeacon([
+        variant({
+          beacon: "Beacon A",
+          datasetId: "DS-1",
+          population: "ES",
+          alleleCount: 80,
+        }),
+        variant({
+          beacon: "Beacon A",
+          datasetId: "DS-1",
+          population: "FI",
+          alleleCount: 120,
+        }),
+        variant({
+          beacon: "Beacon A",
+          datasetId: "DS-1",
+          population: "FR",
+          alleleCount: 200,
+        }),
+        variant({
+          beacon: "Beacon A",
+          datasetId: "DS-1",
+          population: "total",
+          alleleCount: 400,
+        }),
+      ]);
+
+      expect(
+        grouped["Beacon A"].datasets["DS-1"].totalVariant?.population
+      ).toBe("total");
+      expect(
+        grouped["Beacon A"].datasets["DS-1"].totalVariant?.alleleCount
+      ).toBe(400);
+      expect(
+        grouped["Beacon A"].datasets["DS-1"].variants.map((it) => it.population)
+      ).toEqual(["ES", "FI", "FR"]);
     });
   });
 
@@ -114,6 +204,80 @@ describe("GVariantsTableUtils", () => {
       });
 
       expect(ids).toEqual(["Beacon-1", "beacon-2", "beacon-10"]);
+    });
+  });
+
+  describe("getEffectiveTotals", () => {
+    test("returns totalVariant for groups that have one", () => {
+      const grouped = GVariantsTableUtils.groupByBeacon([
+        variant({
+          beacon: "Beacon A",
+          datasetId: "DS-1",
+          population: "FR",
+          alleleCount: 300,
+        }),
+        variant({
+          beacon: "Beacon A",
+          datasetId: "DS-1",
+          population: "FR_M",
+          alleleCount: 150,
+        }),
+        variant({
+          beacon: "Beacon A",
+          datasetId: "DS-1",
+          population: "FR_F",
+          alleleCount: 150,
+        }),
+      ]);
+
+      const totals = GVariantsTableUtils.getEffectiveTotals(grouped);
+      expect(totals).toHaveLength(1);
+      expect(totals[0].population).toBe("FR");
+      expect(totals[0].alleleCount).toBe(300);
+    });
+
+    test("aggregates variants when no totalVariant is available", () => {
+      const grouped = GVariantsTableUtils.groupByBeacon([
+        variant({
+          beacon: "Beacon A",
+          datasetId: "DS-1",
+          population: "FR_M",
+          alleleCount: 150,
+          alleleNumber: 1000,
+        }),
+        variant({
+          beacon: "Beacon A",
+          datasetId: "DS-1",
+          population: "FR_F",
+          alleleCount: 150,
+          alleleNumber: 1000,
+        }),
+      ]);
+
+      const totals = GVariantsTableUtils.getEffectiveTotals(grouped);
+      expect(totals).toHaveLength(1);
+      expect(totals[0].alleleCount).toBe(300);
+    });
+
+    test("returns one entry per beacon+dataset group across beacons", () => {
+      const grouped = GVariantsTableUtils.groupByBeacon([
+        variant({
+          beacon: "Beacon A",
+          datasetId: "DS-1",
+          population: "total",
+          alleleCount: 400,
+        }),
+        variant({
+          beacon: "Beacon B",
+          datasetId: "DS-1",
+          population: "FR",
+          alleleCount: 200,
+        }),
+      ]);
+
+      const totals = GVariantsTableUtils.getEffectiveTotals(grouped);
+      expect(totals).toHaveLength(2);
+      expect(totals.map((t) => t.alleleCount).sort()).toEqual([200, 400]);
     });
   });
 


### PR DESCRIPTION
## Summary by Sourcery

Improve handling of allele frequency totals to avoid double-counting and ensure consistent summary calculations across beacons and datasets.

New Features:
- Introduce logic to derive effective total rows per beacon+dataset group, preferring explicit totals or country/sex aggregates and falling back to computed aggregates when needed.

Enhancements:
- Update variant grouping to promote appropriate population rows (e.g. sex-aggregate or country-code) to totals when no literal total is present.
- Add aggregation utility to compute combined allele count, allele number, and frequency from multiple variant rows, and use it for dataset and summary totals.
- Adjust allele frequency table summary to be based on effective totals derived from grouped data instead of raw non-total rows.

Tests:
- Expand GVariantsTableUtils tests to cover total promotion rules, avoidance of double-counting with country/sex breakdowns, and the new effective totals aggregation behavior.